### PR TITLE
Fix errorHandling function failing for circular refs

### DIFF
--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -15,6 +15,7 @@ import * as vscode from "vscode";
 import * as globals from "../globals";
 import * as path from "path";
 import * as fs from "fs";
+import * as util from "util";
 import { getSecurityModules, IZoweTreeNode, ZoweTreeNode, getZoweDir, getFullPath, Gui } from "@zowe/zowe-explorer-api";
 import { Profiles } from "../Profiles";
 import * as nls from "vscode-nls";
@@ -36,8 +37,9 @@ const localize: nls.LocalizeFunc = nls.loadMessageBundle();
  * @param {moreInfo} - additional/customized error messages
  *************************************************************************************************************/
 export async function errorHandling(errorDetails: Error | string, label?: string, moreInfo?: string): Promise<void> {
+    // Use util.inspect instead of JSON.stringify to handle circular references
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    ZoweLogger.error(`${errorDetails.toString()}\n` + JSON.stringify({ errorDetails, label, moreInfo }));
+    ZoweLogger.error(`${errorDetails.toString()}\n` + util.inspect({ errorDetails, label, moreInfo }, { depth: null }));
 
     if (errorDetails instanceof imperative.ImperativeError && errorDetails.mDetails !== undefined) {
         const httpErrorCode = errorDetails.mDetails.errorCode as unknown as number;


### PR DESCRIPTION
## Proposed changes

Fixes `errorHandling` function throwing when the error object passed in contains circular refs. This could make debugging the original error confusing, because a JSON parse error was thrown and the original error message was not shown to the user.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone:

Changelog: N/A

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
