### PR TITLE
Warn users about files reopened from previous session

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### New features and enhancements
 
-- Added optional method `getDsDocumentFilePath` to `IZoweDatasetTreeNode` interface.
+- Added optional method `getDsDocumentFilePath` to `IZoweDatasetTreeNode` interface to make it easier for extenders to get the local file path of a data set node. [#2760](https://github.com/zowe/vscode-extension-for-zowe/pull/2760)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -10,15 +10,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
-## `2.15.0`
-
-### New features and enhancements
-
-### Bug fixes
-
 ## `2.15.1`
-
-### New features and enhancements
 
 ### Bug fixes
 

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### New features and enhancements
 
+- Added optional method `getDsDocumentFilePath` to `IZoweDatasetTreeNode` interface.
+
+### Bug fixes
+
+## `2.15.0`
+
+### New features and enhancements
+
 ### Bug fixes
 
 ## `2.15.1`

--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -213,6 +213,11 @@ export interface IZoweDatasetTreeNode extends IZoweTreeNode {
      */
     openDs?(download: boolean, previewFile: boolean, datasetFileProvider: IZoweTree<IZoweDatasetTreeNode>): Promise<void>;
     /**
+     * Returns the local file path for the ZoweDatasetNode
+     *
+     */
+    getDsDocumentFilePath?(): string;
+    /**
      * Sets the codepage value for the file
      *
      * @param {string}

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where files left open in prior VS Code session cannot be uploaded to mainframe after window is reloaded. [#2758](https://github.com/zowe/vscode-extension-for-zowe/issues/2758)
+
 ## `2.15.1`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/__mocks__/vscode.ts
+++ b/packages/zowe-explorer/__mocks__/vscode.ts
@@ -736,3 +736,12 @@ export const version = "1.53.2";
 export namespace languages {
     export function createDiagnosticCollection(name: string): any {}
 }
+
+export class Diagnostic {}
+
+export enum DiagnosticSeverity {
+    Error = 0,
+    Warning = 1,
+    Information = 2,
+    Hint = 3,
+}

--- a/packages/zowe-explorer/__mocks__/vscode.ts
+++ b/packages/zowe-explorer/__mocks__/vscode.ts
@@ -636,6 +636,8 @@ export namespace workspace {
      */
     export let rootPath: string | undefined;
 
+    export let textDocuments: string[] = [];
+
     /**
      * A workspace folder is one of potentially many roots opened by the editor. All workspace folders
      * are equal which means there is no notion of an active or master workspace folder.
@@ -730,3 +732,7 @@ export namespace env {
 }
 
 export const version = "1.53.2";
+
+export namespace languages {
+    export function createDiagnosticCollection(name: string): any {}
+}

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
@@ -55,6 +55,7 @@ import { TreeProviders } from "../../../src/shared/TreeProviders";
 import { join } from "path";
 import { mocked } from "../../../__mocks__/mockUtils";
 import * as sharedUtils from "../../../src/shared/utils";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 jest.mock("fs");
 jest.mock("util");
@@ -168,6 +169,8 @@ function createGlobalMocks() {
     Object.defineProperty(ZoweLogger, "warn", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "info", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "trace", { value: jest.fn(), configurable: true });
+    jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
+    jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
 
     return globalMocks;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
@@ -171,6 +171,7 @@ function createGlobalMocks() {
     Object.defineProperty(ZoweLogger, "trace", { value: jest.fn(), configurable: true });
     jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
     jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
+    jest.spyOn(LocalFileManagement, "removeRecoveredFile").mockImplementation();
 
     return globalMocks;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/DatasetTree.unit.test.ts
@@ -3329,11 +3329,11 @@ describe("Dataset Tree Unit Tests - Sorting and Filtering operations", () => {
     });
 
     describe("onDidCloseTextDocument", () => {
-        it("sets the entry in openFiles record to null if Data Set URI is valid", () => {
+        it("sets the entry in openFiles record to null if Data Set URI is valid", async () => {
             const doc = { uri: { fsPath: join(globals.DS_DIR, "lpar", "SOME.PS") } } as vscode.TextDocument;
 
             jest.spyOn(TreeProviders, "ds", "get").mockReturnValue(tree);
-            DatasetTree.onDidCloseTextDocument(doc);
+            await DatasetTree.onDidCloseTextDocument(doc);
             expect(tree.openFiles[doc.uri.fsPath]).toBeNull();
         });
     });

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/ZoweDatasetNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/ZoweDatasetNode.unit.test.ts
@@ -28,6 +28,7 @@ import * as fs from "fs";
 import * as sharedUtils from "../../../src/shared/utils";
 import { Profiles } from "../../../src/Profiles";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 // Missing the definition of path module, because I need the original logic for tests
 jest.mock("fs");
@@ -59,6 +60,7 @@ function createGlobalMocks() {
         configurable: true,
     });
     Object.defineProperty(vscode.workspace, "openTextDocument", { value: jest.fn(), configurable: true });
+    jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
 
     return newMocks;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -42,6 +42,7 @@ import * as utils from "../../../src/utils/ProfilesUtils";
 import { getNodeLabels } from "../../../src/dataset/utils";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 import { mocked } from "../../../__mocks__/mockUtils";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 // Missing the definition of path module, because I need the original logic for tests
 jest.mock("fs");
@@ -127,6 +128,7 @@ function createGlobalMocks() {
     Object.defineProperty(ZoweLogger, "info", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "warn", { value: jest.fn(), configurable: true });
     mocked(Profiles.getInstance).mockReturnValue(newMocks.profileInstance);
+    jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
 
     return newMocks;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -1030,6 +1030,7 @@ describe("Dataset Actions Unit Tests - Function saveFile", () => {
         const testDatasetTree = createDatasetTree(datasetSessionNode, treeView, datasetFavoritesNode);
         const mvsApi = createMvsApi(imperativeProfile);
         bindMvsApi(mvsApi);
+        const uploadContentSpy = jest.spyOn(sharedUtils, "uploadContent");
 
         return {
             session,
@@ -1042,8 +1043,11 @@ describe("Dataset Actions Unit Tests - Function saveFile", () => {
             mvsApi,
             profileInstance,
             testDatasetTree,
+            uploadContentSpy,
         };
     }
+
+    afterEach(() => jest.clearAllMocks());
 
     afterAll(() => jest.restoreAllMocks());
 
@@ -1199,6 +1203,7 @@ describe("Dataset Actions Unit Tests - Function saveFile", () => {
 
         expect(dataSetSpy).toBeCalledWith("HLQ.TEST.AFILE", { responseTimeout: blockMocks.imperativeProfile.profile?.responseTimeout });
         expect(mocked(Gui.errorMessage)).toBeCalledWith("Data set failed to save. Data set may have been deleted or renamed on mainframe.");
+        expect(blockMocks.uploadContentSpy).not.toHaveBeenCalled();
     });
     it("Checking common dataset saving", async () => {
         globals.defineGlobals("");
@@ -1244,6 +1249,7 @@ describe("Dataset Actions Unit Tests - Function saveFile", () => {
         expect(mocked(sharedUtils.concatChildNodes)).toBeCalled();
         expect(mockSetEtag).toHaveBeenCalledWith("123");
         expect(mocked(globalMocks.statusBarMsgSpy)).toBeCalledWith("success", globals.STATUS_BAR_TIMEOUT_MS);
+        expect(blockMocks.uploadContentSpy).toHaveBeenCalledTimes(1);
     });
     it("Checking common dataset failed saving attempt", async () => {
         globals.defineGlobals("");
@@ -1333,14 +1339,13 @@ describe("Dataset Actions Unit Tests - Function saveFile", () => {
         });
         mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
         blockMocks.profileInstance.loadNamedProfile.mockReturnValue(blockMocks.imperativeProfile);
-        const mockSetEtag = jest.spyOn(node, "setEtag").mockImplementation(() => null);
         const testDocument = createTextDocument("HLQ.TEST.AFILE", blockMocks.datasetSessionNode);
         (testDocument as any).fileName = path.join(globals.DS_DIR, blockMocks.imperativeProfile.name, testDocument.fileName);
 
         await dsActions.saveFile(testDocument, blockMocks.testDatasetTree);
 
         expect(mocked(sharedUtils.concatChildNodes)).toBeCalled();
-        expect(mocked(globalMocks.statusBarMsgSpy)).toBeCalledWith("success", globals.STATUS_BAR_TIMEOUT_MS);
+        expect(globalMocks.statusBarMsgSpy).toBeCalledWith("success", globals.STATUS_BAR_TIMEOUT_MS);
     });
     it("Checking favorite PDS Member saving", async () => {
         globals.defineGlobals("");
@@ -1443,25 +1448,31 @@ describe("Dataset Actions Unit Tests - Function saveFile", () => {
         expect(mocked(zowe.List.dataSet)).not.toBeCalled();
         expect(mocked(zowe.Upload.pathToDataSet)).not.toBeCalled();
     });
-    it("Checking PDS member saving attempt", async () => {
+    fit("Checking PDS member saving attempt", async () => {
         globals.defineGlobals("");
-        createGlobalMocks();
+        const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks();
-        const node = new ZoweDatasetNode({
-            label: "HLQ.TEST.AFILE(mem)",
-            collapsibleState: vscode.TreeItemCollapsibleState.None,
+        const dsNode = new ZoweDatasetNode({
+            label: "HLQ.TEST.AFILE",
+            collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
             parentNode: blockMocks.datasetSessionNode,
             profile: blockMocks.imperativeProfile,
         });
-        blockMocks.datasetSessionNode.children.push(node);
+        const memberNode = new ZoweDatasetNode({
+            label: "MEMBER",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            parentNode: dsNode,
+            contextOverride: globals.DS_MEMBER_CONTEXT,
+        });
+        blockMocks.datasetSessionNode.children.push(memberNode);
 
-        mocked(sharedUtils.concatChildNodes).mockReturnValueOnce([node]);
+        mocked(sharedUtils.concatChildNodes).mockReturnValueOnce([memberNode]);
         blockMocks.testDatasetTree.getChildren.mockReturnValueOnce([blockMocks.datasetSessionNode]);
         mocked(zowe.List.dataSet).mockResolvedValue({
             success: true,
             commandResponse: "",
             apiResponse: {
-                items: [{ dsname: "HLQ.TEST.AFILE" }, { dsname: "HLQ.TEST.AFILE(mem)" }],
+                items: [{ dsname: "HLQ.TEST.AFILE" }, { dsname: "HLQ.TEST.AFILE(MEMBER)" }],
             },
         });
         mocked(zowe.Upload.pathToDataSet).mockResolvedValueOnce({
@@ -1478,13 +1489,13 @@ describe("Dataset Actions Unit Tests - Function saveFile", () => {
         });
         blockMocks.profileInstance.loadNamedProfile.mockReturnValueOnce(blockMocks.imperativeProfile);
         mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
-        const testDocument = createTextDocument("HLQ.TEST.AFILE(mem)", blockMocks.datasetSessionNode);
+        const testDocument = createTextDocument("HLQ.TEST.AFILE(MEMBER)", blockMocks.datasetSessionNode);
         (testDocument as any).fileName = path.join(globals.DS_DIR, testDocument.fileName);
 
         await dsActions.saveFile(testDocument, blockMocks.testDatasetTree);
 
         expect(mocked(sharedUtils.concatChildNodes)).toBeCalled();
-        expect(mocked(Gui.setStatusBarMessage)).toBeCalledWith("success", globals.STATUS_BAR_TIMEOUT_MS);
+        expect(globalMocks.statusBarMsgSpy).toBeCalledWith("success", globals.STATUS_BAR_TIMEOUT_MS);
     });
 });
 

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
@@ -37,6 +37,7 @@ import { Poller } from "@zowe/zowe-explorer-api/src/utils";
 import { SettingsConfig } from "../../../src/utils/SettingsConfig";
 import { mocked } from "../../../__mocks__/mockUtils";
 import { TreeProviders } from "../../../src/shared/TreeProviders";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 jest.mock("vscode");
 const showMock = jest.fn();
@@ -237,6 +238,7 @@ async function createGlobalMocks() {
         value: globalMocks.mockRefresh,
         configurable: true,
     });
+    jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
 
     return globalMocks;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/ZosJobsProvider.unit.test.ts
@@ -37,7 +37,6 @@ import { Poller } from "@zowe/zowe-explorer-api/src/utils";
 import { SettingsConfig } from "../../../src/utils/SettingsConfig";
 import { mocked } from "../../../__mocks__/mockUtils";
 import { TreeProviders } from "../../../src/shared/TreeProviders";
-import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 jest.mock("vscode");
 const showMock = jest.fn();
@@ -238,7 +237,6 @@ async function createGlobalMocks() {
         value: globalMocks.mockRefresh,
         configurable: true,
     });
-    jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
 
     return globalMocks;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
@@ -45,6 +45,7 @@ import { ZosJobsProvider } from "../../../src/job/ZosJobsProvider";
 import { ProfileManagement } from "../../../src/utils/ProfileManagement";
 import { TreeProviders } from "../../../src/shared/TreeProviders";
 import { mocked } from "../../../__mocks__/mockUtils";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 const activeTextEditorDocument = jest.fn();
 
@@ -132,6 +133,7 @@ function createGlobalMocks() {
         value: jest.fn().mockReturnValue([newMocks.imperativeProfile.name]),
         configurable: true,
     });
+    jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
     function settingJobObjects(job: zowe.IJob, setjobname: string, setjobid: string, setjobreturncode: string): zowe.IJob {
         job.jobname = setjobname;
         job.jobid = setjobid;

--- a/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/job/actions.unit.test.ts
@@ -45,7 +45,6 @@ import { ZosJobsProvider } from "../../../src/job/ZosJobsProvider";
 import { ProfileManagement } from "../../../src/utils/ProfileManagement";
 import { TreeProviders } from "../../../src/shared/TreeProviders";
 import { mocked } from "../../../__mocks__/mockUtils";
-import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 const activeTextEditorDocument = jest.fn();
 
@@ -133,7 +132,6 @@ function createGlobalMocks() {
         value: jest.fn().mockReturnValue([newMocks.imperativeProfile.name]),
         configurable: true,
     });
-    jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
     function settingJobObjects(job: zowe.IJob, setjobname: string, setjobid: string, setjobreturncode: string): zowe.IJob {
         job.jobname = setjobname;
         job.jobid = setjobid;

--- a/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
@@ -337,6 +337,10 @@ describe("Test force upload", () => {
         return newVariables;
     }
 
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
     it("should successfully call upload for a USS file if user clicks 'Yes'", async () => {
         const blockMocks = await createBlockMocks();
         blockMocks.showInformationMessage.mockResolvedValueOnce("Yes");
@@ -688,13 +692,17 @@ describe("Shared utils unit tests - function updateOpenFiles", () => {
     const someTree = { openFiles: {} };
 
     it("sets a file entry to null in the openFiles record", () => {
+        const deleteFileInfoSpy = jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
         sharedUtils.updateOpenFiles(someTree as any, "/a/doc/path", null);
         expect(someTree.openFiles["/a/doc/path"]).toBeNull();
+        expect(deleteFileInfoSpy).toHaveBeenCalledTimes(1);
     });
 
     it("sets a file entry to a valid node in the openFiles record", () => {
+        const storeFileInfoSpy = jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
         sharedUtils.updateOpenFiles(someTree as any, "/a/doc/path", { label: "testLabel" } as IZoweTreeNode);
         expect(someTree.openFiles["/a/doc/path"].label).toBe("testLabel");
+        expect(storeFileInfoSpy).toHaveBeenCalledTimes(1);
     });
 
     it("does nothing if openFiles is not defined", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
@@ -692,28 +692,28 @@ describe("Shared utils unit tests - function updateOpenFiles", () => {
     const someTree = { openFiles: {} };
 
     beforeAll(() => {
-        globals.defineGlobals("/");
+        globals.defineGlobals("~");
     });
 
     it("sets a file entry to null in the openFiles record", () => {
         const deleteFileInfoSpy = jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
-        sharedUtils.updateOpenFiles(someTree as any, "/temp/_D_/dsname", null);
-        expect(someTree.openFiles["/temp/_D_/dsname"]).toBeNull();
+        sharedUtils.updateOpenFiles(someTree as any, "~/temp/_D_/dsname", null);
+        expect(someTree.openFiles["~/temp/_D_/dsname"]).toBeNull();
         expect(deleteFileInfoSpy).toHaveBeenCalledTimes(1);
     });
 
     it("sets a file entry to a valid node in the openFiles record", () => {
         const storeFileInfoSpy = jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
-        sharedUtils.updateOpenFiles(someTree as any, "/temp/_D_/dsname", { label: "testDsLabel" } as IZoweTreeNode);
-        sharedUtils.updateOpenFiles(someTree as any, "/temp/_U_/fspath", { label: "testUssLabel" } as IZoweTreeNode);
-        expect(someTree.openFiles["/temp/_D_/dsname"].label).toBe("testDsLabel");
-        expect(someTree.openFiles["/temp/_U_/fspath"].label).toBe("testUssLabel");
+        sharedUtils.updateOpenFiles(someTree as any, "~/temp/_D_/dsname", { label: "testDsLabel" } as IZoweTreeNode);
+        sharedUtils.updateOpenFiles(someTree as any, "~/temp/_U_/fspath", { label: "testUssLabel" } as IZoweTreeNode);
+        expect(someTree.openFiles["~/temp/_D_/dsname"].label).toBe("testDsLabel");
+        expect(someTree.openFiles["~/temp/_U_/fspath"].label).toBe("testUssLabel");
         expect(storeFileInfoSpy).toHaveBeenCalledTimes(2);
     });
 
     it("does nothing if openFiles is not defined", () => {
         someTree.openFiles = undefined as any;
-        sharedUtils.updateOpenFiles(someTree as any, "/temp/_D_/dsname", null);
+        sharedUtils.updateOpenFiles(someTree as any, "~/temp/_D_/dsname", null);
         expect(someTree.openFiles).toBeUndefined();
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
@@ -31,7 +31,7 @@ import { Profiles } from "../../../src/Profiles";
 import * as utils from "../../../src/utils/ProfilesUtils";
 import { Gui, IZoweTreeNode, ProfilesCache, ZosEncoding } from "@zowe/zowe-explorer-api";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
-import { ZoweLocalStorage } from "../../../src/utils/ZoweLocalStorage";
+import { LocalStorageKey, ZoweLocalStorage } from "../../../src/utils/ZoweLocalStorage";
 import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 async function createGlobalMocks() {
@@ -691,23 +691,29 @@ describe("Shared utils unit tests - function sortTreeItems", () => {
 describe("Shared utils unit tests - function updateOpenFiles", () => {
     const someTree = { openFiles: {} };
 
+    beforeAll(() => {
+        globals.defineGlobals("/");
+    });
+
     it("sets a file entry to null in the openFiles record", () => {
         const deleteFileInfoSpy = jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
-        sharedUtils.updateOpenFiles(someTree as any, "/a/doc/path", null);
-        expect(someTree.openFiles["/a/doc/path"]).toBeNull();
+        sharedUtils.updateOpenFiles(someTree as any, "/temp/_D_/dsname", null);
+        expect(someTree.openFiles["/temp/_D_/dsname"]).toBeNull();
         expect(deleteFileInfoSpy).toHaveBeenCalledTimes(1);
     });
 
     it("sets a file entry to a valid node in the openFiles record", () => {
         const storeFileInfoSpy = jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
-        sharedUtils.updateOpenFiles(someTree as any, "/a/doc/path", { label: "testLabel" } as IZoweTreeNode);
-        expect(someTree.openFiles["/a/doc/path"].label).toBe("testLabel");
-        expect(storeFileInfoSpy).toHaveBeenCalledTimes(1);
+        sharedUtils.updateOpenFiles(someTree as any, "/temp/_D_/dsname", { label: "testDsLabel" } as IZoweTreeNode);
+        sharedUtils.updateOpenFiles(someTree as any, "/temp/_U_/fspath", { label: "testUssLabel" } as IZoweTreeNode);
+        expect(someTree.openFiles["/temp/_D_/dsname"].label).toBe("testDsLabel");
+        expect(someTree.openFiles["/temp/_U_/fspath"].label).toBe("testUssLabel");
+        expect(storeFileInfoSpy).toHaveBeenCalledTimes(2);
     });
 
     it("does nothing if openFiles is not defined", () => {
         someTree.openFiles = undefined as any;
-        sharedUtils.updateOpenFiles(someTree as any, "/a/doc/path", null);
+        sharedUtils.updateOpenFiles(someTree as any, "/temp/_D_/dsname", null);
         expect(someTree.openFiles).toBeUndefined();
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
@@ -32,6 +32,7 @@ import * as utils from "../../../src/utils/ProfilesUtils";
 import { Gui, IZoweTreeNode, ProfilesCache, ZosEncoding } from "@zowe/zowe-explorer-api";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 import { ZoweLocalStorage } from "../../../src/utils/ZoweLocalStorage";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 async function createGlobalMocks() {
     const newMocks = {
@@ -330,6 +331,8 @@ describe("Test force upload", () => {
             configurable: true,
         });
         Object.defineProperty(vscode, "ProgressLocation", { value: newVariables.ProgressLocation, configurable: true });
+        jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
+        jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
 
         return newVariables;
     }

--- a/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/shared/utils.unit.test.ts
@@ -690,6 +690,8 @@ describe("Shared utils unit tests - function sortTreeItems", () => {
 
 describe("Shared utils unit tests - function updateOpenFiles", () => {
     const someTree = { openFiles: {} };
+    const testDsPath = path.join("~", "temp", "_D_", "dsname");
+    const testUssPath = path.join("~", "temp", "_U_", "fspath");
 
     beforeAll(() => {
         globals.defineGlobals("~");
@@ -697,23 +699,23 @@ describe("Shared utils unit tests - function updateOpenFiles", () => {
 
     it("sets a file entry to null in the openFiles record", () => {
         const deleteFileInfoSpy = jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
-        sharedUtils.updateOpenFiles(someTree as any, "~/temp/_D_/dsname", null);
-        expect(someTree.openFiles["~/temp/_D_/dsname"]).toBeNull();
+        sharedUtils.updateOpenFiles(someTree as any, testDsPath, null);
+        expect(someTree.openFiles[testDsPath]).toBeNull();
         expect(deleteFileInfoSpy).toHaveBeenCalledTimes(1);
     });
 
     it("sets a file entry to a valid node in the openFiles record", () => {
         const storeFileInfoSpy = jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
-        sharedUtils.updateOpenFiles(someTree as any, "~/temp/_D_/dsname", { label: "testDsLabel" } as IZoweTreeNode);
-        sharedUtils.updateOpenFiles(someTree as any, "~/temp/_U_/fspath", { label: "testUssLabel" } as IZoweTreeNode);
-        expect(someTree.openFiles["~/temp/_D_/dsname"].label).toBe("testDsLabel");
-        expect(someTree.openFiles["~/temp/_U_/fspath"].label).toBe("testUssLabel");
+        sharedUtils.updateOpenFiles(someTree as any, testDsPath, { label: "testDsLabel" } as IZoweTreeNode);
+        sharedUtils.updateOpenFiles(someTree as any, testUssPath, { label: "testUssLabel" } as IZoweTreeNode);
+        expect(someTree.openFiles[testDsPath].label).toBe("testDsLabel");
+        expect(someTree.openFiles[testUssPath].label).toBe("testUssLabel");
         expect(storeFileInfoSpy).toHaveBeenCalledTimes(2);
     });
 
     it("does nothing if openFiles is not defined", () => {
         someTree.openFiles = undefined as any;
-        sharedUtils.updateOpenFiles(someTree as any, "~/temp/_D_/dsname", null);
+        sharedUtils.updateOpenFiles(someTree as any, testDsPath, null);
         expect(someTree.openFiles).toBeUndefined();
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
@@ -195,6 +195,7 @@ async function createGlobalMocks() {
     } as any);
     jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
     jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
+    jest.spyOn(LocalFileManagement, "removeRecoveredFile").mockImplementation();
 
     return globalMocks;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
@@ -1650,6 +1650,10 @@ describe("USSTree Unit Tests - Function editSession", () => {
         it("sets the entry in openFiles record to null if USS URI is valid", async () => {
             const globalMocks = await createGlobalMocks();
             const tree = globalMocks.testTree as unknown as any;
+            Object.defineProperty(vscode.workspace, "textDocuments", {
+                value: [],
+                configurable: true,
+            });
             Object.defineProperty(globals, "USS_DIR", {
                 value: join("some", "fspath", "_U_"),
             });

--- a/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
@@ -37,6 +37,7 @@ import { TreeProviders } from "../../../src/shared/TreeProviders";
 import { join } from "path";
 import * as sharedUtils from "../../../src/shared/utils";
 import { mocked } from "../../../__mocks__/mockUtils";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 async function createGlobalMocks() {
     const globalMocks = {
@@ -192,6 +193,8 @@ async function createGlobalMocks() {
         uss: { addSingleSession: jest.fn(), mSessionNodes: [...globalMocks.testTree.mSessionNodes], refresh: jest.fn() } as any,
         jobs: { addSingleSession: jest.fn(), mSessionNodes: [...globalMocks.testTree.mSessionNodes], refresh: jest.fn() } as any,
     } as any);
+    jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
+    jest.spyOn(LocalFileManagement, "deleteFileInfo").mockImplementation();
 
     return globalMocks;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/USSTree.unit.test.ts
@@ -1656,7 +1656,7 @@ describe("USSTree Unit Tests - Function editSession", () => {
             const doc = { uri: { fsPath: join(globals.USS_DIR, "lpar", "someFile.txt") } } as vscode.TextDocument;
 
             jest.spyOn(TreeProviders, "uss", "get").mockReturnValue(tree);
-            USSTree.onDidCloseTextDocument(doc);
+            await USSTree.onDidCloseTextDocument(doc);
             expect(tree.openFiles[doc.uri.fsPath]).toBeNull();
         });
     });

--- a/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
@@ -33,6 +33,7 @@ import * as globals from "../../../src/globals";
 import * as ussUtils from "../../../src/uss/utils";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 import { TreeProviders } from "../../../src/shared/TreeProviders";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 jest.mock("fs");
 jest.mock("path");
@@ -179,6 +180,8 @@ async function createGlobalMocks() {
     Object.defineProperty(ZoweLogger, "warn", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "info", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "trace", { value: jest.fn(), configurable: true });
+    jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
+
     return globalMocks;
 }
 

--- a/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
@@ -77,7 +77,7 @@ async function createGlobalMocks() {
         response: createFileResponse({ etag: "123" }),
         ussApi: null,
         mockShowWarningMessage: jest.fn(),
-        fileExistsCaseSensitveSync: jest.fn(),
+        fileExistsCaseSensitiveSync: jest.fn(),
         readText: jest.fn(),
         fileToUSSFile: jest.fn(),
         basePath: jest.fn(),
@@ -169,8 +169,8 @@ async function createGlobalMocks() {
     Object.defineProperty(globals, "LOG", { value: jest.fn(), configurable: true });
     Object.defineProperty(globals.LOG, "error", { value: jest.fn(), configurable: true });
     Object.defineProperty(globals.LOG, "warn", { value: jest.fn(), configurable: true });
-    Object.defineProperty(ussUtils, "fileExistsCaseSensitveSync", {
-        value: globalMocks.fileExistsCaseSensitveSync,
+    Object.defineProperty(ussUtils, "fileExistsCaseSensitiveSync", {
+        value: globalMocks.fileExistsCaseSensitiveSync,
         configurable: true,
     });
     Object.defineProperty(vscode.env.clipboard, "readText", { value: globalMocks.readText, configurable: true });
@@ -1141,7 +1141,7 @@ describe("ZoweUSSNode Unit Tests - Function node.openUSS()", () => {
 
         globalMocks.existsSync.mockReturnValue("exists");
         globalMocks.mockShowTextDocument.mockRejectedValueOnce(Error("testError"));
-        globalMocks.fileExistsCaseSensitveSync.mockReturnValue(true);
+        globalMocks.fileExistsCaseSensitiveSync.mockReturnValue(true);
 
         try {
             await child.openUSS(false, true, blockMocks.testUSSTree);

--- a/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
@@ -40,6 +40,7 @@ import * as refreshActions from "../../../src/shared/refresh";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 import { AttributeView } from "../../../src/uss/AttributeView";
 import { mocked } from "../../../__mocks__/mockUtils";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 function createGlobalMocks() {
     const globalMocks = {
@@ -164,6 +165,7 @@ function createGlobalMocks() {
     Object.defineProperty(ZoweLogger, "warn", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "info", { value: jest.fn(), configurable: true });
     Object.defineProperty(ZoweLogger, "trace", { value: jest.fn(), configurable: true });
+    jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
 
     return globalMocks;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/uss/utils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/utils.unit.test.ts
@@ -14,6 +14,7 @@ import { ZoweExplorerApiRegister } from "../../../src/ZoweExplorerApiRegister";
 import { ZoweUSSNode } from "../../../src/uss/ZoweUSSNode";
 import * as utils from "../../../src/uss/utils";
 import { createIProfile } from "../../../__mocks__/mockCreators/shared";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 
 describe("USS utils unit tests - function autoDetectEncoding", () => {
     const getTagMock = jest.fn();
@@ -23,6 +24,7 @@ describe("USS utils unit tests - function autoDetectEncoding", () => {
         mockUssApi = jest.spyOn(ZoweExplorerApiRegister, "getUssApi").mockReturnValue({
             getTag: getTagMock.mockClear(),
         } as any);
+        jest.spyOn(LocalFileManagement, "storeFileInfo").mockImplementation();
     });
 
     afterAll(() => {

--- a/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
@@ -17,7 +17,6 @@ import { ZoweDatasetNode } from "../../../src/dataset/ZoweDatasetNode";
 import { TreeProviders } from "../../../src/shared/TreeProviders";
 import { IZoweTreeNode } from "@zowe/zowe-explorer-api";
 import { ZoweUSSNode } from "../../../src/uss/ZoweUSSNode";
-import * as sharedUtils from "../../../src/shared/utils";
 
 describe("LocalFileManagement Unit Tests", () => {
     function createBlockMocks() {
@@ -106,7 +105,6 @@ describe("LocalFileManagement Unit Tests", () => {
 
     it("should store file info for dataset node", () => {
         const blockMocks = createBlockMocks();
-        jest.spyOn(sharedUtils, "getDocumentFilePath").mockReturnValue("file:///abc.txt");
         const dsNode = new ZoweDatasetNode({
             label: "member",
             collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -114,7 +112,7 @@ describe("LocalFileManagement Unit Tests", () => {
         });
         dsNode.setEncoding({ kind: "text" });
         dsNode.setEtag("fakeEtag");
-        jest.spyOn(sharedUtils, "getDocumentFilePath").mockReturnValue("file:///abc.txt");
+        jest.spyOn(dsNode, "getDsDocumentFilePath").mockReturnValue("file:///abc.txt");
         LocalFileManagement.storeFileInfo(dsNode);
         expect(blockMocks.storageUpdate).toHaveBeenLastCalledWith("zowe.fileInfoCache", {
             "file:///abc.txt": {

--- a/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
@@ -29,6 +29,7 @@ describe("LocalFileManagement Unit Tests", () => {
 
         Object.defineProperty(LocalFileManagement, "recoveryDiagnostics", {
             value: {
+                has: jest.fn().mockReturnValue(true),
                 set: newMocks.diagnosticsSet,
                 delete: newMocks.diagnosticsDelete,
             },

--- a/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
@@ -11,7 +11,7 @@
 
 import * as vscode from "vscode";
 import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
-import { ZoweLocalStorage } from "../../../src/utils/ZoweLocalStorage";
+import { LocalStorageKey, ZoweLocalStorage } from "../../../src/utils/ZoweLocalStorage";
 import { IZoweTreeOpts } from "../../../src/shared/IZoweTreeOpts";
 import { ZoweDatasetNode } from "../../../src/dataset/ZoweDatasetNode";
 import { TreeProviders } from "../../../src/shared/TreeProviders";
@@ -114,7 +114,7 @@ describe("LocalFileManagement Unit Tests", () => {
         dsNode.setEtag("fakeEtag");
         jest.spyOn(dsNode, "getDsDocumentFilePath").mockReturnValue("file:///abc.txt");
         LocalFileManagement.storeFileInfo(dsNode);
-        expect(blockMocks.storageUpdate).toHaveBeenLastCalledWith("zowe.fileInfoCache", {
+        expect(blockMocks.storageUpdate).toHaveBeenLastCalledWith(LocalStorageKey.FILE_INFO_CACHE, {
             "file:///abc.txt": {
                 binary: false,
                 encoding: null,
@@ -134,7 +134,7 @@ describe("LocalFileManagement Unit Tests", () => {
         ussNode.setEtag("fakeEtag");
         jest.spyOn(ussNode, "getUSSDocumentFilePath").mockReturnValue("file:///abc.txt");
         LocalFileManagement.storeFileInfo(ussNode);
-        expect(blockMocks.storageUpdate).toHaveBeenLastCalledWith("zowe.fileInfoCache", {
+        expect(blockMocks.storageUpdate).toHaveBeenLastCalledWith(LocalStorageKey.FILE_INFO_CACHE, {
             "file:///abc.txt": {
                 binary: true,
                 encoding: undefined,

--- a/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
@@ -1,0 +1,165 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import * as vscode from "vscode";
+import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
+import { ZoweLocalStorage } from "../../../src/utils/ZoweLocalStorage";
+import { IZoweTreeOpts } from "../../../src/shared/IZoweTreeOpts";
+import { ZoweDatasetNode } from "../../../src/dataset/ZoweDatasetNode";
+import { TreeProviders } from "../../../src/shared/TreeProviders";
+import { IZoweTreeNode } from "@zowe/zowe-explorer-api";
+import { ZoweUSSNode } from "../../../src/uss/ZoweUSSNode";
+import * as sharedUtils from "../../../src/shared/utils";
+
+describe("LocalFileManagement Unit Tests", () => {
+    function createBlockMocks() {
+        const newMocks = {
+            diagnosticsSet: jest.fn(),
+            diagnosticsDelete: jest.fn(),
+            storageGet: jest.fn(),
+            storageUpdate: jest.fn(),
+        };
+
+        Object.defineProperty(LocalFileManagement, "recoveryDiagnostics", {
+            value: {
+                set: newMocks.diagnosticsSet,
+                delete: newMocks.diagnosticsDelete,
+            },
+            configurable: true,
+        });
+        const mockGlobalState = { get: newMocks.storageGet, update: newMocks.storageUpdate, keys: () => [] } as vscode.Memento;
+        ZoweLocalStorage.initializeZoweLocalStorage(mockGlobalState);
+
+        return newMocks;
+    }
+
+    it("should add and remove diagnostic for recovered file", () => {
+        const blockMocks = createBlockMocks();
+        const fakeDocument: vscode.TextDocument = {
+            lineAt: jest.fn().mockReturnValue({ range: { start: 0, end: 100 } }),
+            uri: vscode.Uri.parse("file:///abc.txt"),
+        } as any;
+        const treeOpts: IZoweTreeOpts = {
+            label: fakeDocument.uri.fsPath,
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            profile: { name: "lpar1_zosmf" } as any,
+        };
+        LocalFileManagement.addRecoveredFile(fakeDocument, treeOpts);
+        expect(blockMocks.diagnosticsSet).toHaveBeenCalledTimes(1);
+        expect(LocalFileManagement.recoveredFileCount).toBe(1);
+        LocalFileManagement.removeRecoveredFile(fakeDocument);
+        expect(blockMocks.diagnosticsDelete).toHaveBeenCalledTimes(1);
+        expect(LocalFileManagement.recoveredFileCount).toBe(0);
+    });
+
+    it("should load file info for dataset node", () => {
+        const blockMocks = createBlockMocks();
+        const dsNode = new ZoweDatasetNode({
+            label: "member",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            profile: { name: "lpar1_zosmf" } as any,
+        });
+        const openFiles: Record<string, IZoweTreeNode> = {};
+        blockMocks.storageGet.mockReturnValueOnce({
+            "file:///abc.txt": {
+                binary: false,
+                encoding: "IBM-1047",
+                etag: "fakeEtag",
+            },
+        });
+        jest.spyOn(TreeProviders, "ds", "get").mockReturnValue({ openFiles } as any);
+        LocalFileManagement.loadFileInfo(dsNode, "file:///abc.txt");
+        expect(dsNode.encoding).toBe("IBM-1047");
+        expect(dsNode.getEtag()).toBe("fakeEtag");
+        expect(openFiles["file:///abc.txt"]).toEqual(dsNode);
+    });
+
+    it("should load file info for USS node", () => {
+        const blockMocks = createBlockMocks();
+        const ussNode = new ZoweUSSNode({
+            label: "abc.txt",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            profile: { name: "lpar1_zosmf" } as any,
+        });
+        const openFiles: Record<string, IZoweTreeNode> = {};
+        blockMocks.storageGet.mockReturnValueOnce({
+            "file:///abc.txt": {
+                binary: true,
+                encoding: undefined,
+                etag: "fakeEtag",
+            },
+        });
+        jest.spyOn(TreeProviders, "uss", "get").mockReturnValue({ openFiles } as any);
+        LocalFileManagement.loadFileInfo(ussNode, "file:///abc.txt");
+        expect(ussNode.binary).toBe(true);
+        expect(ussNode.getEtag()).toBe("fakeEtag");
+        expect(openFiles["file:///abc.txt"]).toEqual(ussNode);
+    });
+
+    it("should store file info for dataset node", () => {
+        const blockMocks = createBlockMocks();
+        jest.spyOn(sharedUtils, "getDocumentFilePath").mockReturnValue("file:///abc.txt");
+        const dsNode = new ZoweDatasetNode({
+            label: "member",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            profile: { name: "lpar1_zosmf" } as any,
+        });
+        dsNode.setEncoding({ kind: "text" });
+        dsNode.setEtag("fakeEtag");
+        LocalFileManagement.storeFileInfo(dsNode, "file:///abc.txt");
+        expect(blockMocks.storageUpdate).toHaveBeenLastCalledWith("zowe.fileInfoCache", {
+            "file:///abc.txt": {
+                binary: false,
+                encoding: null,
+                etag: "fakeEtag",
+            },
+        });
+    });
+
+    it("should store file info for USS node", () => {
+        const blockMocks = createBlockMocks();
+        jest.spyOn(sharedUtils, "getDocumentFilePath").mockReturnValue("file:///abc.txt");
+        const ussNode = new ZoweUSSNode({
+            label: "abc.txt",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            profile: { name: "lpar1_zosmf" } as any,
+        });
+        ussNode.setEncoding({ kind: "binary" });
+        ussNode.setEtag("fakeEtag");
+        LocalFileManagement.storeFileInfo(ussNode);
+        expect(blockMocks.storageUpdate).toHaveBeenLastCalledWith("zowe.fileInfoCache", {
+            "file:///abc.txt": {
+                binary: true,
+                encoding: undefined,
+                etag: "fakeEtag",
+            },
+        });
+    });
+
+    it("should delete file info associated with filename", () => {
+        const blockMocks = createBlockMocks();
+        blockMocks.storageGet.mockReturnValueOnce({
+            "file:///abc.txt": {
+                binary: false,
+                encoding: "IBM-1047",
+                etag: "fakeEtag",
+            },
+            "file:///def.txt": {
+                binary: true,
+                encoding: undefined,
+                etag: "fakeEtag",
+            },
+        });
+        LocalFileManagement.deleteFileInfo("file:///abc.txt");
+        expect(blockMocks.storageUpdate).toHaveBeenCalledTimes(1);
+        expect(Object.keys(blockMocks.storageUpdate.mock.calls[0][1])).toEqual(["file:///def.txt"]);
+    });
+});

--- a/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/LocalFileManagement.unit.test.ts
@@ -114,7 +114,8 @@ describe("LocalFileManagement Unit Tests", () => {
         });
         dsNode.setEncoding({ kind: "text" });
         dsNode.setEtag("fakeEtag");
-        LocalFileManagement.storeFileInfo(dsNode, "file:///abc.txt");
+        jest.spyOn(sharedUtils, "getDocumentFilePath").mockReturnValue("file:///abc.txt");
+        LocalFileManagement.storeFileInfo(dsNode);
         expect(blockMocks.storageUpdate).toHaveBeenLastCalledWith("zowe.fileInfoCache", {
             "file:///abc.txt": {
                 binary: false,
@@ -126,7 +127,6 @@ describe("LocalFileManagement Unit Tests", () => {
 
     it("should store file info for USS node", () => {
         const blockMocks = createBlockMocks();
-        jest.spyOn(sharedUtils, "getDocumentFilePath").mockReturnValue("file:///abc.txt");
         const ussNode = new ZoweUSSNode({
             label: "abc.txt",
             collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -134,6 +134,7 @@ describe("LocalFileManagement Unit Tests", () => {
         });
         ussNode.setEncoding({ kind: "binary" });
         ussNode.setEtag("fakeEtag");
+        jest.spyOn(ussNode, "getUSSDocumentFilePath").mockReturnValue("file:///abc.txt");
         LocalFileManagement.storeFileInfo(ussNode);
         expect(blockMocks.storageUpdate).toHaveBeenLastCalledWith("zowe.fileInfoCache", {
             "file:///abc.txt": {

--- a/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
@@ -21,7 +21,6 @@ import { SettingsConfig } from "../../../src/utils/SettingsConfig";
 import { Gui } from "@zowe/zowe-explorer-api";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
-import { Profiles } from "../../../src/Profiles";
 
 jest.mock("fs");
 jest.mock("fs", () => ({

--- a/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
@@ -159,7 +159,7 @@ describe("TempFolder Unit Tests", () => {
             LocalFileManagement.recoveredFileCount++;
         });
         const dsDocument = {
-            fileName: path.join(globals.DS_DIR, "lpar1_zosmf", "IBMUSER.TEST.PS(member).txt"),
+            fileName: path.join(globals.DS_DIR, "lpar1_zosmf", "IBMUSER.TEST.PS(member)"),
         };
         const ussDocument = {
             fileName: path.join(globals.USS_DIR, "lpar1_zosmf", "u/ibmuser/test.txt"),
@@ -176,9 +176,10 @@ describe("TempFolder Unit Tests", () => {
             profile: { name: "lpar1_zosmf", type: "zosmf" },
         });
         expect(blockMocks.addRecoveredFile).toHaveBeenNthCalledWith(2, ussDocument, {
-            label: "/u/ibmuser/test.txt",
+            label: "test.txt",
             collapsibleState: vscode.TreeItemCollapsibleState.None,
             profile: { name: "lpar1_zosmf", type: "zosmf" },
+            parentPath: "/u/ibmuser",
         });
         expect(blockMocks.loadFileInfo).toHaveBeenCalledTimes(2);
         expect(warningMessageSpy).toHaveBeenCalledTimes(1);

--- a/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
@@ -67,9 +67,6 @@ describe("TempFolder Unit Tests", () => {
         Object.defineProperty(ZoweLogger, "trace", { value: jest.fn(), configurable: true });
         Object.defineProperty(ZoweLogger, "info", { value: jest.fn(), configurable: true });
         jest.spyOn(ProfileUtils, "errorHandling").mockImplementationOnce(jest.fn());
-        jest.spyOn(Profiles, "getInstance").mockReturnValue({
-            loadNamedProfile: jest.fn((name: string) => ({ name, type: "zosmf" })),
-        } as any);
         return newMocks;
     }
 
@@ -173,12 +170,12 @@ describe("TempFolder Unit Tests", () => {
         expect(blockMocks.addRecoveredFile).toHaveBeenNthCalledWith(1, dsDocument, {
             label: "IBMUSER.TEST.PS(member)",
             collapsibleState: vscode.TreeItemCollapsibleState.None,
-            profile: { name: "lpar1_zosmf", type: "zosmf" },
+            profile: { name: "lpar1_zosmf" },
         });
         expect(blockMocks.addRecoveredFile).toHaveBeenNthCalledWith(2, ussDocument, {
             label: "test.txt",
             collapsibleState: vscode.TreeItemCollapsibleState.None,
-            profile: { name: "lpar1_zosmf", type: "zosmf" },
+            profile: { name: "lpar1_zosmf" },
             parentPath: "/u/ibmuser",
         });
         expect(blockMocks.loadFileInfo).toHaveBeenCalledTimes(2);

--- a/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
@@ -159,6 +159,9 @@ describe("TempFolder Unit Tests", () => {
 
     it("findRecoveredFiles should recover data sets and USS files that were left open", () => {
         const blockMocks = createBlockMocks();
+        blockMocks.addRecoveredFile.mockImplementation(() => {
+            LocalFileManagement.recoveredFileCount++;
+        });
         const dsDocument = {
             fileName: path.join(testDsDir, "lpar1_zosmf", "IBMUSER.TEST.PS(member).txt"),
         };
@@ -169,6 +172,7 @@ describe("TempFolder Unit Tests", () => {
             value: [dsDocument, ussDocument],
             configurable: true,
         });
+        const warningMessageSpy = jest.spyOn(Gui, "warningMessage").mockImplementation();
         TempFolder.findRecoveredFiles();
         expect(blockMocks.addRecoveredFile).toHaveBeenNthCalledWith(1, dsDocument, {
             label: "IBMUSER.TEST.PS(member)",
@@ -181,6 +185,7 @@ describe("TempFolder Unit Tests", () => {
             profile: { name: "lpar1_zosmf", type: "zosmf" },
         });
         expect(blockMocks.loadFileInfo).toHaveBeenCalledTimes(2);
+        expect(warningMessageSpy).toHaveBeenCalledTimes(1);
     });
 
     it("findRecoveredFiles should do nothing when no files were left open", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/TempFolder.unit.test.ts
@@ -38,9 +38,6 @@ jest.mock("fs-extra", () => ({
 }));
 
 describe("TempFolder Unit Tests", () => {
-    const testDsDir = "/tmp/ds";
-    const testUssDir = "/tmp/uss";
-
     afterEach(() => {
         jest.clearAllMocks();
         jest.restoreAllMocks();
@@ -64,8 +61,6 @@ describe("TempFolder Unit Tests", () => {
             configurable: true,
         });
         Object.defineProperty(Gui, "showMessage", { value: jest.fn() });
-        Object.defineProperty(globals, "DS_DIR", { value: testDsDir, configurable: true });
-        Object.defineProperty(globals, "USS_DIR", { value: testUssDir, configurable: true });
         Object.defineProperty(globals, "LOG", { value: jest.fn(), configurable: true });
         Object.defineProperty(globals.LOG, "error", { value: jest.fn(), configurable: true });
         Object.defineProperty(ZoweLogger, "error", { value: jest.fn(), configurable: true });
@@ -159,14 +154,15 @@ describe("TempFolder Unit Tests", () => {
 
     it("findRecoveredFiles should recover data sets and USS files that were left open", () => {
         const blockMocks = createBlockMocks();
+        globals.defineGlobals(__dirname);
         blockMocks.addRecoveredFile.mockImplementation(() => {
             LocalFileManagement.recoveredFileCount++;
         });
         const dsDocument = {
-            fileName: path.join(testDsDir, "lpar1_zosmf", "IBMUSER.TEST.PS(member).txt"),
+            fileName: path.join(globals.DS_DIR, "lpar1_zosmf", "IBMUSER.TEST.PS(member).txt"),
         };
         const ussDocument = {
-            fileName: path.join(testUssDir, "lpar1_zosmf", "u/ibmuser/test.txt"),
+            fileName: path.join(globals.USS_DIR, "lpar1_zosmf", "u/ibmuser/test.txt"),
         };
         Object.defineProperty(vscode.workspace, "textDocuments", {
             value: [dsDocument, ussDocument],

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ZoweLocalStorage.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ZoweLocalStorage.unit.test.ts
@@ -10,7 +10,7 @@
  */
 
 import * as vscode from "vscode";
-import { ZoweLocalStorage } from "../../../src/utils/ZoweLocalStorage";
+import { LocalStorageKey, ZoweLocalStorage } from "../../../src/utils/ZoweLocalStorage";
 
 describe("ZoweLocalStorage Unit Tests", () => {
     it("should initialize successfully", () => {
@@ -27,7 +27,7 @@ describe("ZoweLocalStorage Unit Tests", () => {
             keys: () => [],
         };
         ZoweLocalStorage.initializeZoweLocalStorage(mockGlobalState);
-        ZoweLocalStorage.setValue("fruit", "banana");
-        expect(ZoweLocalStorage.getValue("fruit")).toEqual("banana");
+        ZoweLocalStorage.setValue("fruit" as LocalStorageKey, "banana");
+        expect(ZoweLocalStorage.getValue("fruit" as LocalStorageKey)).toEqual("banana");
     });
 });

--- a/packages/zowe-explorer/i18n/sample/src/utils/LocalFileManagement.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/utils/LocalFileManagement.i18n.json
@@ -1,3 +1,3 @@
 {
-  "addRecoveredFile.diagnosticMessage": "File is out of sync with {0}: {1}"
+  "addRecoveredFile.diagnosticMessage": "File content is out of sync with {0}: {1}"
 }

--- a/packages/zowe-explorer/i18n/sample/src/utils/LocalFileManagement.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/utils/LocalFileManagement.i18n.json
@@ -1,0 +1,3 @@
+{
+  "addRecoveredFile.diagnosticMessage": "File is out of sync with {0}: {1}"
+}

--- a/packages/zowe-explorer/i18n/sample/src/utils/TempFolder.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/utils/TempFolder.i18n.json
@@ -1,4 +1,5 @@
 {
   "moveTempFolder.error": "Error encountered when creating temporary folder!",
-  "deactivate.error": "Unable to delete temporary folder. "
+  "deactivate.error": "Unable to delete temporary folder. ",
+  "findRecoveredFiles.message": "One or more files remained open in your last VS Code session. To prevent losing your updates, check the Problems view to see the list of files and re-save them to upload edits to the mainframe."
 }

--- a/packages/zowe-explorer/i18n/sample/src/utils/TempFolder.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/utils/TempFolder.i18n.json
@@ -1,5 +1,5 @@
 {
   "moveTempFolder.error": "Error encountered when creating temporary folder!",
   "deactivate.error": "Unable to delete temporary folder. ",
-  "findRecoveredFiles.message": "One or more files remained open in your last VS Code session. To prevent losing your updates, check the Problems view to see the list of files and re-save them to upload edits to the mainframe."
+  "findRecoveredFiles.message": "One or more files remained open in your last VS Code session. To avoid losing your updates, check the Problems view to see the list of files and re-save them to upload the changes to the mainframe."
 }

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -45,6 +45,7 @@ import { SettingsConfig } from "../utils/SettingsConfig";
 import { ZoweLogger } from "../utils/LoggerUtils";
 import { TreeViewUtils } from "../utils/TreeViewUtils";
 import { TreeProviders } from "../shared/TreeProviders";
+import { LocalFileManagement } from "../utils/LocalFileManagement";
 
 // Set up localization
 nls.config({
@@ -1516,6 +1517,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
     public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): void {
         if (doc.uri.fsPath.includes(globals.DS_DIR)) {
             updateOpenFiles(TreeProviders.ds, doc.uri.fsPath, null);
+            LocalFileManagement.removeRecoveredFile(doc);
         }
     }
 

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -1518,8 +1518,11 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
     public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): Promise<void> {
         if (doc.uri.fsPath.includes(globals.DS_DIR)) {
             return ZoweSaveQueue.all().then(() => {
-                updateOpenFiles(TreeProviders.ds, doc.uri.fsPath, null);
-                LocalFileManagement.removeRecoveredFile(doc);
+                if (!doc.isDirty) {
+                    // Remove document from cache only if there are no pending unsaved changes
+                    updateOpenFiles(TreeProviders.ds, doc.uri.fsPath, null);
+                    LocalFileManagement.removeRecoveredFile(doc);
+                }
             });
         }
     }

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -46,6 +46,7 @@ import { ZoweLogger } from "../utils/LoggerUtils";
 import { TreeViewUtils } from "../utils/TreeViewUtils";
 import { TreeProviders } from "../shared/TreeProviders";
 import { LocalFileManagement } from "../utils/LocalFileManagement";
+import { ZoweSaveQueue } from "../abstract/ZoweSaveQueue";
 
 // Set up localization
 nls.config({
@@ -1514,10 +1515,12 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
      * @param this (resolves ESlint warning about unbound methods)
      * @param doc A doc URI that was closed
      */
-    public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): void {
+    public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): Promise<void> {
         if (doc.uri.fsPath.includes(globals.DS_DIR)) {
-            updateOpenFiles(TreeProviders.ds, doc.uri.fsPath, null);
-            LocalFileManagement.removeRecoveredFile(doc);
+            return ZoweSaveQueue.all().then(() => {
+                updateOpenFiles(TreeProviders.ds, doc.uri.fsPath, null);
+                LocalFileManagement.removeRecoveredFile(doc);
+            });
         }
     }
 

--- a/packages/zowe-explorer/src/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/dataset/DatasetTree.ts
@@ -1518,7 +1518,7 @@ export class DatasetTree extends ZoweTreeProvider implements IZoweTree<IZoweData
     public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): Promise<void> {
         if (doc.uri.fsPath.includes(globals.DS_DIR)) {
             return ZoweSaveQueue.all().then(() => {
-                if (!doc.isDirty) {
+                if (!vscode.workspace.textDocuments.find(({ uri }) => uri.fsPath === doc.uri.fsPath)?.isDirty) {
                     // Remove document from cache only if there are no pending unsaved changes
                     updateOpenFiles(TreeProviders.ds, doc.uri.fsPath, null);
                     LocalFileManagement.removeRecoveredFile(doc);

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -633,4 +633,16 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
         this.iconPath = iconPath;
         vscode.commands.executeCommand("zowe.ds.refreshDataset", this);
     }
+
+    /**
+     * Returns the local file path for the ZoweDatasetNode
+     *
+     */
+    public getDsDocumentFilePath(): string {
+        ZoweLogger.trace("ZoweDatasetNode.getDsDocumentFilePath called.");
+        if (contextually.isDsMember(this)) {
+            return getDocumentFilePath(`${this.getParent().label as string}(${this.label as string})`, this);
+        }
+        return getDocumentFilePath(this.label as string, this);
+    }
 }

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -543,10 +543,10 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                 }
 
                 const documentFilePath = getDocumentFilePath(label, this);
-                const reopenedFile = LocalFileManagement.findReopenedFile(documentFilePath);
-                if (reopenedFile != null) {
-                    await compareFileContent(reopenedFile, this, label);
-                    LocalFileManagement.removeReopenedFile(reopenedFile);
+                const recoveredFile = LocalFileManagement.findRecoveredFile(documentFilePath);
+                if (recoveredFile != null) {
+                    await compareFileContent(recoveredFile, this, label);
+                    LocalFileManagement.removeRecoveredFile(recoveredFile);
                     return;
                 }
 

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -451,7 +451,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
     public setEtag(etagValue): void {
         ZoweLogger.trace("ZoweDatasetNode.setEtag called.");
         this.etag = etagValue;
-        LocalFileManagement.updateFileInfo(this);
+        LocalFileManagement.storeFileInfo(this);
     }
 
     private async getDatasets(): Promise<zowe.IZosFilesResponse[]> {
@@ -620,7 +620,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             this.setIcon(icon.path);
         }
 
-        LocalFileManagement.updateFileInfo(this);
+        LocalFileManagement.storeFileInfo(this);
         this.dirty = true;
     }
 

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -1582,11 +1582,10 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
                 return false;
             }
         }) ?? datasetProvider.openFiles?.[doc.uri.fsPath];
-    const cachedFileInfo = LocalFileManagement.getFileInfo(doc.uri.fsPath);
 
     // define upload options
     const uploadOptions: IUploadOptions = {
-        etag: node?.getEtag() ?? cachedFileInfo?.etag,
+        etag: node?.getEtag(),
         returnEtag: true,
     };
 

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -1567,7 +1567,9 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
             return;
         }
     } catch (err) {
+        await markDocumentUnsaved(doc);
         await errorHandling(err, sesName);
+        return;
     }
     // Get specific node based on label and parent tree (session / favorites)
     const nodes = concatChildNodes(sesNode ? [sesNode] : datasetProvider.mSessionNodes);

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -40,6 +40,7 @@ import { ProfileManagement } from "../utils/ProfileManagement";
 // Set up localization
 import * as nls from "vscode-nls";
 import { resolveFileConflict } from "../shared/actions";
+import { LocalFileManagement } from "../utils/LocalFileManagement";
 
 nls.config({
     messageFormat: nls.MessageFormat.bundle,
@@ -1527,6 +1528,16 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
         const sessionError = localize("saveFile.session.error", "Could not locate session when saving data set.");
         ZoweLogger.error(sessionError);
         await api.Gui.errorMessage(sessionError);
+        return;
+    } else if (LocalFileManagement.findRecoveredFile(doc.fileName) != null) {
+        const syncError = localize(
+            "saveFile.sync.error",
+            "Cannot save {0} because it is out of sync with {1}. To synchronize this data set, re-open it in the Zowe Explorer tree.",
+            path.basename(doc.fileName),
+            profile.name
+        );
+        ZoweLogger.error(syncError);
+        await api.Gui.errorMessage(syncError);
         return;
     }
 

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -17,7 +17,7 @@ import { ZoweExplorerExtender } from "./ZoweExplorerExtender";
 import { Profiles } from "./Profiles";
 import { ProfilesUtils } from "./utils/ProfilesUtils";
 import { initializeSpoolProvider } from "./SpoolProvider";
-import { cleanTempDir, hideTempFolder } from "./utils/TempFolder";
+import { cleanTempDir, hideTempFolder, findReopenedFiles } from "./utils/TempFolder";
 import { SettingsConfig } from "./utils/SettingsConfig";
 import { registerCommonCommands, registerCredentialManager, registerRefreshCommand, watchConfigProfile } from "./shared/init";
 import { ZoweLogger } from "./utils/LoggerUtils";
@@ -63,7 +63,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
     ZoweExplorerExtender.createInstance(providers.ds, providers.uss, providers.job);
     await SettingsConfig.standardizeSettings();
     await watchConfigProfile(context, providers);
-    globals.setActivated(true);
+    await globals.setActivated(true);
+    findReopenedFiles();
     return ZoweExplorerApiRegister.getInstance();
 }
 /**

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -17,7 +17,7 @@ import { ZoweExplorerExtender } from "./ZoweExplorerExtender";
 import { Profiles } from "./Profiles";
 import { ProfilesUtils } from "./utils/ProfilesUtils";
 import { initializeSpoolProvider } from "./SpoolProvider";
-import { cleanTempDir, hideTempFolder, findReopenedFiles } from "./utils/TempFolder";
+import { cleanTempDir, hideTempFolder, findRecoveredFiles } from "./utils/TempFolder";
 import { SettingsConfig } from "./utils/SettingsConfig";
 import { registerCommonCommands, registerCredentialManager, registerRefreshCommand, watchConfigProfile } from "./shared/init";
 import { ZoweLogger } from "./utils/LoggerUtils";
@@ -64,7 +64,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
     await SettingsConfig.standardizeSettings();
     await watchConfigProfile(context, providers);
     await globals.setActivated(true);
-    findReopenedFiles();
+    findRecoveredFiles();
     return ZoweExplorerApiRegister.getInstance();
 }
 /**

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -63,7 +63,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
     ZoweExplorerExtender.createInstance(providers.ds, providers.uss, providers.job);
     await SettingsConfig.standardizeSettings();
     await watchConfigProfile(context, providers);
-    await globals.setActivated(true);
+    globals.setActivated(true);
     findRecoveredFiles();
     return ZoweExplorerApiRegister.getInstance();
 }

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -37,6 +37,7 @@ import { errorHandling } from "../utils/ProfilesUtils";
 import { LocalStorageKey, ZoweLocalStorage } from "../utils/ZoweLocalStorage";
 import { LocalFileManagement } from "../utils/LocalFileManagement";
 import { TreeProviders } from "./TreeProviders";
+import { ZoweSaveQueue } from "../abstract/ZoweSaveQueue";
 
 // Set up localization
 nls.config({
@@ -435,6 +436,14 @@ export function updateOpenFiles<T extends IZoweTreeNode>(treeProvider: IZoweTree
             LocalFileManagement.deleteFileInfo(docPath);
         }
     }
+}
+
+/**
+ * Check for pending unsaved changes on a document that has just been closed.
+ */
+export async function isClosedFileDirty(doc: vscode.TextDocument): Promise<boolean> {
+    await ZoweSaveQueue.all();
+    return vscode.workspace.textDocuments.find(({ uri }) => uri.fsPath === doc.uri.fsPath)?.isDirty;
 }
 
 function getCachedEncoding(node: IZoweTreeNode): string | undefined {

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -230,8 +230,8 @@ export async function uploadContent(
     const uploadOptions: IUploadOptions = {
         etag: etagToUpload,
         returnEtag: true,
-        binary: node?.binary,
-        encoding: node?.encoding !== undefined ? node.encoding : profile.profile?.encoding,
+        binary: node.binary,
+        encoding: node.encoding !== undefined ? node.encoding : profile.profile?.encoding,
         responseTimeout: profile.profile?.responseTimeout,
     };
     if (isZoweDatasetTreeNode(node)) {
@@ -380,17 +380,17 @@ export async function compareFileContent(
     if (isTypeUssTreeNode(node)) {
         downloadResponse = await ZoweExplorerApiRegister.getUssApi(prof).getContents(node.fullPath, {
             file: node.getUSSDocumentFilePath(),
-            binary: node?.binary,
+            binary: node.binary,
             returnEtag: true,
-            encoding: node?.encoding !== undefined ? node.encoding : prof.profile?.encoding,
+            encoding: node.encoding !== undefined ? node.encoding : prof.profile?.encoding,
             responseTimeout: prof.profile?.responseTimeout,
         });
     } else {
         downloadResponse = await ZoweExplorerApiRegister.getMvsApi(prof).getContents(label, {
             file: doc.fileName,
-            binary: node?.binary,
+            binary: node.binary,
             returnEtag: true,
-            encoding: node?.encoding !== undefined ? node.encoding : prof.profile?.encoding,
+            encoding: node.encoding !== undefined ? node.encoding : prof.profile?.encoding,
             responseTimeout: prof.profile?.responseTimeout,
         });
     }

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -234,7 +234,7 @@ export async function uploadContent(
         encoding: node?.encoding !== undefined ? node.encoding : profile.profile?.encoding,
         responseTimeout: profile.profile?.responseTimeout,
     };
-    if (doc.uri.fsPath.toUpperCase().includes(globals.DS_DIR.toUpperCase())) {
+    if (isZoweDatasetTreeNode(node)) {
         return ZoweExplorerApiRegister.getMvsApi(profile).putContents(doc.fileName, remotePath, uploadOptions);
     } else {
         // if new api method exists, use it
@@ -266,7 +266,7 @@ export function willForceUpload(
 ): Thenable<void> {
     // setup to handle both cases (dataset & USS)
     let title: string;
-    if (doc.uri.fsPath.toUpperCase().includes(globals.DS_DIR.toUpperCase())) {
+    if (isZoweDatasetTreeNode(node)) {
         title = localize("saveFile.response.save.title", "Saving data set...");
     } else {
         title = localize("saveUSSFile.response.title", "Saving file...");
@@ -377,17 +377,17 @@ export async function compareFileContent(
     const prof = node ? node.getProfile() : profile;
     let downloadResponse;
 
-    if (doc.uri.fsPath.toUpperCase().includes(globals.DS_DIR.toUpperCase())) {
-        downloadResponse = await ZoweExplorerApiRegister.getMvsApi(prof).getContents(label, {
-            file: doc.fileName,
+    if (isTypeUssTreeNode(node)) {
+        downloadResponse = await ZoweExplorerApiRegister.getUssApi(prof).getContents(node.fullPath, {
+            file: node.getUSSDocumentFilePath(),
             binary: node?.binary,
             returnEtag: true,
             encoding: node?.encoding !== undefined ? node.encoding : prof.profile?.encoding,
             responseTimeout: prof.profile?.responseTimeout,
         });
     } else {
-        downloadResponse = await ZoweExplorerApiRegister.getUssApi(prof).getContents(node.fullPath, {
-            file: (node as IZoweUSSTreeNode).getUSSDocumentFilePath(),
+        downloadResponse = await ZoweExplorerApiRegister.getMvsApi(prof).getContents(label, {
+            file: doc.fileName,
             binary: node?.binary,
             returnEtag: true,
             encoding: node?.encoding !== undefined ? node.encoding : prof.profile?.encoding,

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -230,7 +230,7 @@ export async function uploadContent(
 ): Promise<IZosFilesResponse> {
     const uploadOptions: IUploadOptions = {
         etag: etagToUpload,
-        returnEtag: true,
+        returnEtag: returnEtag ?? true,
         binary: node.binary,
         encoding: node.encoding !== undefined ? node.encoding : profile.profile?.encoding,
         responseTimeout: profile.profile?.responseTimeout,

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -34,7 +34,7 @@ import { ZoweLogger } from "../utils/LoggerUtils";
 import { isTypeUssTreeNode } from "./context";
 import { markDocumentUnsaved } from "../utils/workspace";
 import { errorHandling } from "../utils/ProfilesUtils";
-import { ZoweLocalStorage } from "../utils/ZoweLocalStorage";
+import { LocalStorageKey, ZoweLocalStorage } from "../utils/ZoweLocalStorage";
 import { LocalFileManagement } from "../utils/LocalFileManagement";
 import { TreeProviders } from "./TreeProviders";
 
@@ -428,10 +428,12 @@ export function updateOpenFiles<T extends IZoweTreeNode>(treeProvider: IZoweTree
     if (treeProvider.openFiles) {
         treeProvider.openFiles[docPath] = value;
     }
-    if (value != null) {
-        LocalFileManagement.storeFileInfo(value, docPath);
-    } else {
-        LocalFileManagement.deleteFileInfo(docPath);
+    if (docPath.includes(globals.DS_DIR) || docPath.includes(globals.USS_DIR)) {
+        if (value != null) {
+            LocalFileManagement.storeFileInfo(value, docPath);
+        } else {
+            LocalFileManagement.deleteFileInfo(docPath);
+        }
     }
 }
 
@@ -481,7 +483,7 @@ export async function promptForEncoding(node: IZoweDatasetTreeNode | IZoweUSSTre
     } else if (node.encoding === null || currentEncoding === "text") {
         currentEncoding = ebcdicItem.label;
     }
-    const encodingHistory = ZoweLocalStorage.getValue<string[]>("zowe.encodingHistory") ?? [];
+    const encodingHistory = ZoweLocalStorage.getValue<string[]>(LocalStorageKey.ENCODING_HISTORY) ?? [];
     if (encodingHistory.length > 0) {
         for (const encoding of encodingHistory) {
             items.push({ label: encoding });
@@ -514,7 +516,7 @@ export async function promptForEncoding(node: IZoweDatasetTreeNode | IZoweUSSTre
             if (response != null) {
                 encoding = { kind: "other", codepage: response };
                 encodingHistory.push(encoding.codepage);
-                ZoweLocalStorage.setValue("zowe.encodingHistory", encodingHistory.slice(0, globals.MAX_FILE_HISTORY));
+                ZoweLocalStorage.setValue(LocalStorageKey.ENCODING_HISTORY, encodingHistory.slice(0, globals.MAX_FILE_HISTORY));
             }
             break;
         default:

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -36,6 +36,7 @@ import { markDocumentUnsaved } from "../utils/workspace";
 import { errorHandling } from "../utils/ProfilesUtils";
 import { ZoweLocalStorage } from "../utils/ZoweLocalStorage";
 import { LocalFileManagement } from "../utils/LocalFileManagement";
+import { TreeProviders } from "./TreeProviders";
 
 // Set up localization
 nls.config({
@@ -134,7 +135,7 @@ export function getAppName(isTheia: boolean): "Theia" | "VS Code" {
  * @param {IZoweTreeNode} node
  */
 export function getDocumentFilePath(label: string, node: IZoweTreeNode): string {
-    const dsDir = globals.DS_DIR;
+    const dsDir = globals.DS_DIR || "";
     const profName = node.getProfileName();
     const suffix = appendSuffix(label);
     return path.join(dsDir, profName || "", suffix);
@@ -375,6 +376,7 @@ export async function compareFileContent(
 ): Promise<void> {
     await markDocumentUnsaved(doc);
     const prof = node ? node.getProfile() : profile;
+    node = node ?? TreeProviders.ds.openFiles?.[doc.uri.fsPath] ?? TreeProviders.uss.openFiles?.[doc.uri.fsPath];
     let downloadResponse;
 
     if (isTypeUssTreeNode(node)) {

--- a/packages/zowe-explorer/src/shared/utils.ts
+++ b/packages/zowe-explorer/src/shared/utils.ts
@@ -427,7 +427,7 @@ export function updateOpenFiles<T extends IZoweTreeNode>(treeProvider: IZoweTree
         treeProvider.openFiles[docPath] = value;
     }
     if (value != null) {
-        LocalFileManagement.updateFileInfo(value, docPath);
+        LocalFileManagement.storeFileInfo(value, docPath);
     } else {
         LocalFileManagement.deleteFileInfo(docPath);
     }

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -27,6 +27,7 @@ import * as nls from "vscode-nls";
 import { ZoweLogger } from "../utils/LoggerUtils";
 import { TreeViewUtils } from "../utils/TreeViewUtils";
 import { TreeProviders } from "../shared/TreeProviders";
+import { LocalFileManagement } from "../utils/LocalFileManagement";
 
 // Set up localization
 nls.config({
@@ -950,6 +951,7 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
     public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): void {
         if (doc.uri.fsPath.includes(globals.USS_DIR)) {
             updateOpenFiles(TreeProviders.uss, doc.uri.fsPath, null);
+            LocalFileManagement.removeRecoveredFile(doc);
         }
     }
 

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -952,8 +952,11 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
     public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): Promise<void> {
         if (doc.uri.fsPath.includes(globals.USS_DIR)) {
             return ZoweSaveQueue.all().then(() => {
-                updateOpenFiles(TreeProviders.uss, doc.uri.fsPath, null);
-                LocalFileManagement.removeRecoveredFile(doc);
+                if (!doc.isDirty) {
+                    // Remove document from cache only if there are no pending unsaved changes
+                    updateOpenFiles(TreeProviders.uss, doc.uri.fsPath, null);
+                    LocalFileManagement.removeRecoveredFile(doc);
+                }
             });
         }
     }

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -28,6 +28,7 @@ import { ZoweLogger } from "../utils/LoggerUtils";
 import { TreeViewUtils } from "../utils/TreeViewUtils";
 import { TreeProviders } from "../shared/TreeProviders";
 import { LocalFileManagement } from "../utils/LocalFileManagement";
+import { ZoweSaveQueue } from "../abstract/ZoweSaveQueue";
 
 // Set up localization
 nls.config({
@@ -948,10 +949,12 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
      * @param this (resolves ESlint warning about unbound methods)
      * @param doc A doc URI that was closed
      */
-    public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): void {
+    public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): Promise<void> {
         if (doc.uri.fsPath.includes(globals.USS_DIR)) {
-            updateOpenFiles(TreeProviders.uss, doc.uri.fsPath, null);
-            LocalFileManagement.removeRecoveredFile(doc);
+            return ZoweSaveQueue.all().then(() => {
+                updateOpenFiles(TreeProviders.uss, doc.uri.fsPath, null);
+                LocalFileManagement.removeRecoveredFile(doc);
+            });
         }
     }
 

--- a/packages/zowe-explorer/src/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/uss/USSTree.ts
@@ -952,7 +952,7 @@ export class USSTree extends ZoweTreeProvider implements IZoweTree<IZoweUSSTreeN
     public static onDidCloseTextDocument(this: void, doc: vscode.TextDocument): Promise<void> {
         if (doc.uri.fsPath.includes(globals.USS_DIR)) {
             return ZoweSaveQueue.all().then(() => {
-                if (!doc.isDirty) {
+                if (!vscode.workspace.textDocuments.find(({ uri }) => uri.fsPath === doc.uri.fsPath)?.isDirty) {
                     // Remove document from cache only if there are no pending unsaved changes
                     updateOpenFiles(TreeProviders.uss, doc.uri.fsPath, null);
                     LocalFileManagement.removeRecoveredFile(doc);

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -28,7 +28,7 @@ import { Profiles } from "../Profiles";
 import { ZoweExplorerApiRegister } from "../ZoweExplorerApiRegister";
 import { errorHandling, syncSessionNode } from "../utils/ProfilesUtils";
 import { getIconByNode } from "../generators/icons/index";
-import { autoDetectEncoding, fileExistsCaseSensitveSync, injectAdditionalDataToTooltip } from "../uss/utils";
+import { autoDetectEncoding, fileExistsCaseSensitiveSync, injectAdditionalDataToTooltip } from "../uss/utils";
 import * as contextually from "../shared/context";
 import { closeOpenedTextFile } from "../utils/workspace";
 import * as nls from "vscode-nls";
@@ -510,7 +510,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
                 const documentFilePath = this.getUSSDocumentFilePath();
                 // check if some other file is already created with the same name avoid opening file warn user
                 const fileExists = fs.existsSync(documentFilePath);
-                if (fileExists && !fileExistsCaseSensitveSync(documentFilePath)) {
+                if (fileExists && !fileExistsCaseSensitiveSync(documentFilePath)) {
                     Gui.showMessage(
                         localize(
                             "openUSS.name.exists",

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -34,7 +34,7 @@ import { closeOpenedTextFile } from "../utils/workspace";
 import * as nls from "vscode-nls";
 import { UssFileTree, UssFileType, UssFileUtils } from "./FileStructure";
 import { ZoweLogger } from "../utils/LoggerUtils";
-import { compareFileContent, updateOpenFiles } from "../shared/utils";
+import { updateOpenFiles } from "../shared/utils";
 import { IZoweUssTreeOpts } from "../shared/IZoweTreeOpts";
 import { TreeProviders } from "../shared/TreeProviders";
 import { LocalFileManagement } from "../utils/LocalFileManagement";
@@ -299,6 +299,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
             this.setIcon(icon.path);
         }
 
+        LocalFileManagement.updateFileInfo(this);
         this.tooltip = injectAdditionalDataToTooltip(this, this.fullPath);
         this.dirty = true;
     }
@@ -442,6 +443,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
     public setEtag(etagValue): void {
         ZoweLogger.trace("ZoweUSSNode.setEtag called.");
         this.etag = etagValue;
+        LocalFileManagement.updateFileInfo(this);
     }
 
     /**
@@ -506,13 +508,6 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
                 }
 
                 const documentFilePath = this.getUSSDocumentFilePath();
-                const recoveredFile = LocalFileManagement.findRecoveredFile(documentFilePath);
-                if (recoveredFile != null) {
-                    await compareFileContent(recoveredFile, this, documentFilePath);
-                    LocalFileManagement.removeRecoveredFile(recoveredFile);
-                    return;
-                }
-
                 // check if some other file is already created with the same name avoid opening file warn user
                 const fileExists = fs.existsSync(documentFilePath);
                 if (fileExists && !fileExistsCaseSensitveSync(documentFilePath)) {

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -506,10 +506,10 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
                 }
 
                 const documentFilePath = this.getUSSDocumentFilePath();
-                const reopenedFile = LocalFileManagement.findReopenedFile(documentFilePath);
-                if (reopenedFile != null) {
-                    await compareFileContent(reopenedFile, this, documentFilePath);
-                    LocalFileManagement.removeReopenedFile(reopenedFile);
+                const recoveredFile = LocalFileManagement.findRecoveredFile(documentFilePath);
+                if (recoveredFile != null) {
+                    await compareFileContent(recoveredFile, this, documentFilePath);
+                    LocalFileManagement.removeRecoveredFile(recoveredFile);
                     return;
                 }
 

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -34,9 +34,10 @@ import { closeOpenedTextFile } from "../utils/workspace";
 import * as nls from "vscode-nls";
 import { UssFileTree, UssFileType, UssFileUtils } from "./FileStructure";
 import { ZoweLogger } from "../utils/LoggerUtils";
-import { updateOpenFiles } from "../shared/utils";
+import { compareFileContent, updateOpenFiles } from "../shared/utils";
 import { IZoweUssTreeOpts } from "../shared/IZoweTreeOpts";
 import { TreeProviders } from "../shared/TreeProviders";
+import { LocalFileManagement } from "../utils/LocalFileManagement";
 
 // Set up localization
 nls.config({
@@ -505,6 +506,13 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
                 }
 
                 const documentFilePath = this.getUSSDocumentFilePath();
+                const reopenedFile = LocalFileManagement.findReopenedFile(documentFilePath);
+                if (reopenedFile != null) {
+                    await compareFileContent(reopenedFile, this, documentFilePath);
+                    LocalFileManagement.removeReopenedFile(reopenedFile);
+                    return;
+                }
+
                 // check if some other file is already created with the same name avoid opening file warn user
                 const fileExists = fs.existsSync(documentFilePath);
                 if (fileExists && !fileExistsCaseSensitveSync(documentFilePath)) {

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -299,7 +299,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
             this.setIcon(icon.path);
         }
 
-        LocalFileManagement.updateFileInfo(this);
+        LocalFileManagement.storeFileInfo(this);
         this.tooltip = injectAdditionalDataToTooltip(this, this.fullPath);
         this.dirty = true;
     }
@@ -443,7 +443,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
     public setEtag(etagValue): void {
         ZoweLogger.trace("ZoweUSSNode.setEtag called.");
         this.etag = etagValue;
-        LocalFileManagement.updateFileInfo(this);
+        LocalFileManagement.storeFileInfo(this);
     }
 
     /**

--- a/packages/zowe-explorer/src/uss/actions.ts
+++ b/packages/zowe-explorer/src/uss/actions.ts
@@ -30,6 +30,7 @@ import { UssFileTree, UssFileType } from "./FileStructure";
 import { ZoweLogger } from "../utils/LoggerUtils";
 import { AttributeView } from "./AttributeView";
 import { resolveFileConflict } from "../shared/actions";
+import { LocalFileManagement } from "../utils/LocalFileManagement";
 
 // Set up localization
 nls.config({
@@ -280,6 +281,16 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: IZo
         const sessionError = localize("saveUSSFile.session.error", "Could not locate session when saving USS file.");
         ZoweLogger.error(sessionError);
         await Gui.errorMessage(sessionError);
+        return;
+    } else if (LocalFileManagement.findRecoveredFile(doc.fileName) != null) {
+        const syncError = localize(
+            "saveUSSFile.sync.error",
+            "Cannot save {0} because it is out of sync with {1}. To synchronize this USS file, re-open it in the Zowe Explorer tree.",
+            path.basename(doc.fileName),
+            profile.name
+        );
+        ZoweLogger.error(syncError);
+        await Gui.errorMessage(syncError);
         return;
     }
 

--- a/packages/zowe-explorer/src/uss/actions.ts
+++ b/packages/zowe-explorer/src/uss/actions.ts
@@ -309,10 +309,9 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: IZo
                 return false;
             }
         }) ?? ussFileProvider.openFiles?.[doc.uri.fsPath];
-    const cachedFileInfo = LocalFileManagement.getFileInfo(doc.uri.fsPath);
 
     // define upload options
-    const etagToUpload = node?.getEtag() ?? cachedFileInfo?.etag;
+    const etagToUpload = node?.getEtag();
     const returnEtag = etagToUpload != null;
 
     const prof = node?.getProfile() ?? profile;

--- a/packages/zowe-explorer/src/uss/actions.ts
+++ b/packages/zowe-explorer/src/uss/actions.ts
@@ -25,7 +25,7 @@ import { markDocumentUnsaved, setFileSaved } from "../utils/workspace";
 import * as nls from "vscode-nls";
 import { refreshAll } from "../shared/refresh";
 import { IUploadOptions } from "@zowe/zos-files-for-zowe-sdk";
-import { autoDetectEncoding, fileExistsCaseSensitveSync } from "./utils";
+import { autoDetectEncoding, fileExistsCaseSensitiveSync } from "./utils";
 import { UssFileTree, UssFileType } from "./FileStructure";
 import { ZoweLogger } from "../utils/LoggerUtils";
 import { AttributeView } from "./AttributeView";
@@ -83,7 +83,7 @@ export async function createUSSNode(
             ussFileProvider.getTreeView().reveal(newNode, { select: true, focus: true });
             const localPath = `${node.getUSSDocumentFilePath()}/${name}`;
             const fileExists = fs.existsSync(localPath);
-            if (fileExists && !fileExistsCaseSensitveSync(localPath)) {
+            if (fileExists && !fileExistsCaseSensitiveSync(localPath)) {
                 Gui.showMessage(
                     localize(
                         "createUSSNode.name.exists",

--- a/packages/zowe-explorer/src/uss/utils.ts
+++ b/packages/zowe-explorer/src/uss/utils.ts
@@ -52,8 +52,8 @@ export function injectAdditionalDataToTooltip(node: ZoweUSSNode, tooltip: string
  * @param filepath
  * @returns {boolean}
  */
-export function fileExistsCaseSensitveSync(filepath: string): boolean {
-    ZoweLogger.trace("uss.utils.fileExistsCaseSensitveSync called.");
+export function fileExistsCaseSensitiveSync(filepath: string): boolean {
+    ZoweLogger.trace("uss.utils.fileExistsCaseSensitiveSync called.");
     const dir = path.dirname(filepath);
     if (dir === path.dirname(dir)) {
         return true;
@@ -62,7 +62,7 @@ export function fileExistsCaseSensitveSync(filepath: string): boolean {
     if (filenames.indexOf(path.basename(filepath)) === -1) {
         return false;
     }
-    return fileExistsCaseSensitveSync(dir);
+    return fileExistsCaseSensitiveSync(dir);
 }
 
 /**

--- a/packages/zowe-explorer/src/uss/utils.ts
+++ b/packages/zowe-explorer/src/uss/utils.ts
@@ -75,7 +75,7 @@ export function disposeClipboardContents(): void {
 }
 
 export async function autoDetectEncoding(node: IZoweUSSTreeNode, profile?: imperative.IProfileLoaded): Promise<void> {
-    if (node.binary || node.encoding !== undefined) {
+    if (node == null || node.binary || node.encoding !== undefined) {
         return;
     }
     const ussApi = ZoweExplorerApiRegister.getUssApi(profile ?? node.getProfile());

--- a/packages/zowe-explorer/src/utils/LocalFileManagement.ts
+++ b/packages/zowe-explorer/src/utils/LocalFileManagement.ts
@@ -1,0 +1,48 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import * as vscode from "vscode";
+import * as nls from "vscode-nls";
+
+// Set up localization
+nls.config({
+    messageFormat: nls.MessageFormat.bundle,
+    bundleFormat: nls.BundleFormat.standalone,
+})();
+const localize: nls.LocalizeFunc = nls.loadMessageBundle();
+
+export class LocalFileManagement {
+    private static reopenedFiles: vscode.TextDocument[] = [];
+    private static recoveryDiagnostics: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection("zowe-explorer");
+
+    public static addReopenedFile(document: vscode.TextDocument, fileInfo: { profile: string; filename: string }): void {
+        this.reopenedFiles.push(document);
+        const firstLine = document.lineAt(0);
+        const lastLine = document.lineAt(document.lineCount - 1);
+        const textRange = new vscode.Range(firstLine.range.start, lastLine.range.end);
+        this.recoveryDiagnostics.set(document.uri, [
+            new vscode.Diagnostic(
+                textRange,
+                localize("addReopenedFile.diagnosticMessage", "File is out of sync with mainframe: [{0}] {1}", fileInfo.profile, fileInfo.filename),
+                vscode.DiagnosticSeverity.Error
+            ),
+        ]);
+    }
+
+    public static findReopenedFile(filePath: string): vscode.TextDocument | undefined {
+        return this.reopenedFiles.find((document) => document.fileName == filePath);
+    }
+
+    public static removeReopenedFile(document: vscode.TextDocument): void {
+        this.reopenedFiles = this.reopenedFiles.filter((doc) => doc != document);
+        this.recoveryDiagnostics.delete(document.uri);
+    }
+}

--- a/packages/zowe-explorer/src/utils/LocalFileManagement.ts
+++ b/packages/zowe-explorer/src/utils/LocalFileManagement.ts
@@ -12,7 +12,7 @@
 import { IZoweDatasetTreeNode, IZoweUSSTreeNode } from "@zowe/zowe-explorer-api";
 import * as vscode from "vscode";
 import * as nls from "vscode-nls";
-import { ZoweLocalStorage } from "./ZoweLocalStorage";
+import { LocalStorageKey, ZoweLocalStorage } from "./ZoweLocalStorage";
 import { isZoweDatasetTreeNode, updateOpenFiles } from "../shared/utils";
 import { IZoweDatasetTreeOpts, IZoweUssTreeOpts } from "../shared/IZoweTreeOpts";
 import { TreeProviders } from "../shared/TreeProviders";
@@ -55,7 +55,7 @@ export class LocalFileManagement {
     }
 
     public static loadFileInfo(node: IZoweDatasetTreeNode | IZoweUSSTreeNode, filename: string): void {
-        const fileInfo = ZoweLocalStorage.getValue<Record<string, IFileInfo>>("zowe.fileInfoCache") ?? {};
+        const fileInfo = ZoweLocalStorage.getValue<Record<string, IFileInfo>>(LocalStorageKey.FILE_INFO_CACHE) ?? {};
         if (fileInfo[filename] != null) {
             for (const [k, v] of Object.entries(fileInfo[filename])) {
                 node[k] = v;
@@ -65,7 +65,7 @@ export class LocalFileManagement {
     }
 
     public static storeFileInfo(node: IZoweDatasetTreeNode | IZoweUSSTreeNode, filename?: string): void {
-        const fileInfo = ZoweLocalStorage.getValue<Record<string, IFileInfo>>("zowe.fileInfoCache") ?? {};
+        const fileInfo = ZoweLocalStorage.getValue<Record<string, IFileInfo>>(LocalStorageKey.FILE_INFO_CACHE) ?? {};
         if (filename == null) {
             filename = isZoweDatasetTreeNode(node) ? node.getDsDocumentFilePath() : node.getUSSDocumentFilePath();
         }
@@ -74,12 +74,12 @@ export class LocalFileManagement {
             encoding: node.encoding,
             etag: node.getEtag(),
         };
-        ZoweLocalStorage.setValue("zowe.fileInfoCache", fileInfo);
+        ZoweLocalStorage.setValue(LocalStorageKey.FILE_INFO_CACHE, fileInfo);
     }
 
     public static deleteFileInfo(filename: string): void {
-        const fileInfo = ZoweLocalStorage.getValue<Record<string, IFileInfo>>("zowe.fileInfoCache") ?? {};
+        const fileInfo = ZoweLocalStorage.getValue<Record<string, IFileInfo>>(LocalStorageKey.FILE_INFO_CACHE) ?? {};
         delete fileInfo[filename];
-        ZoweLocalStorage.setValue("zowe.fileInfoCache", fileInfo);
+        ZoweLocalStorage.setValue(LocalStorageKey.FILE_INFO_CACHE, fileInfo);
     }
 }

--- a/packages/zowe-explorer/src/utils/LocalFileManagement.ts
+++ b/packages/zowe-explorer/src/utils/LocalFileManagement.ts
@@ -42,7 +42,7 @@ export class LocalFileManagement {
         this.recoveryDiagnostics.set(document.uri, [
             new vscode.Diagnostic(
                 textRange,
-                localize("addRecoveredFile.diagnosticMessage", "File is out of sync with {0}: {1}", treeOpts.profile.name, fullPath),
+                localize("addRecoveredFile.diagnosticMessage", "File content is out of sync with {0}: {1}", treeOpts.profile.name, fullPath),
                 vscode.DiagnosticSeverity.Error
             ),
         ]);

--- a/packages/zowe-explorer/src/utils/LocalFileManagement.ts
+++ b/packages/zowe-explorer/src/utils/LocalFileManagement.ts
@@ -50,8 +50,10 @@ export class LocalFileManagement {
     }
 
     public static removeRecoveredFile(document: vscode.TextDocument): void {
-        this.recoveryDiagnostics.delete(document.uri);
-        this.recoveredFileCount--;
+        if (this.recoveryDiagnostics.has(document.uri)) {
+            this.recoveryDiagnostics.delete(document.uri);
+            this.recoveredFileCount--;
+        }
     }
 
     public static loadFileInfo(node: IZoweDatasetTreeNode | IZoweUSSTreeNode, filename: string): void {
@@ -79,7 +81,9 @@ export class LocalFileManagement {
 
     public static deleteFileInfo(filename: string): void {
         const fileInfo = ZoweLocalStorage.getValue<Record<string, IFileInfo>>(LocalStorageKey.FILE_INFO_CACHE) ?? {};
-        delete fileInfo[filename];
-        ZoweLocalStorage.setValue(LocalStorageKey.FILE_INFO_CACHE, fileInfo);
+        if (filename in fileInfo) {
+            delete fileInfo[filename];
+            ZoweLocalStorage.setValue(LocalStorageKey.FILE_INFO_CACHE, fileInfo);
+        }
     }
 }

--- a/packages/zowe-explorer/src/utils/LocalFileManagement.ts
+++ b/packages/zowe-explorer/src/utils/LocalFileManagement.ts
@@ -13,7 +13,7 @@ import { IZoweDatasetTreeNode, IZoweUSSTreeNode } from "@zowe/zowe-explorer-api"
 import * as vscode from "vscode";
 import * as nls from "vscode-nls";
 import { ZoweLocalStorage } from "./ZoweLocalStorage";
-import { getDocumentFilePath, isZoweDatasetTreeNode, updateOpenFiles } from "../shared/utils";
+import { isZoweDatasetTreeNode, updateOpenFiles } from "../shared/utils";
 import { IZoweDatasetTreeOpts, IZoweUssTreeOpts } from "../shared/IZoweTreeOpts";
 import { TreeProviders } from "../shared/TreeProviders";
 
@@ -67,7 +67,7 @@ export class LocalFileManagement {
     public static storeFileInfo(node: IZoweDatasetTreeNode | IZoweUSSTreeNode, filename?: string): void {
         const fileInfo = ZoweLocalStorage.getValue<Record<string, IFileInfo>>("zowe.fileInfoCache") ?? {};
         if (filename == null) {
-            filename = isZoweDatasetTreeNode(node) ? getDocumentFilePath(node.label as string, node) : node.getUSSDocumentFilePath();
+            filename = isZoweDatasetTreeNode(node) ? node.getDsDocumentFilePath() : node.getUSSDocumentFilePath();
         }
         fileInfo[filename] = {
             binary: node.binary,

--- a/packages/zowe-explorer/src/utils/LocalFileManagement.ts
+++ b/packages/zowe-explorer/src/utils/LocalFileManagement.ts
@@ -20,29 +20,29 @@ nls.config({
 const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 export class LocalFileManagement {
-    private static reopenedFiles: vscode.TextDocument[] = [];
+    private static recoveredFiles: vscode.TextDocument[] = [];
     private static recoveryDiagnostics: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection("zowe-explorer");
 
-    public static addReopenedFile(document: vscode.TextDocument, fileInfo: { profile: string; filename: string }): void {
-        this.reopenedFiles.push(document);
+    public static addRecoveredFile(document: vscode.TextDocument, fileInfo: { profile: string; filename: string }): void {
+        this.recoveredFiles.push(document);
         const firstLine = document.lineAt(0);
         const lastLine = document.lineAt(document.lineCount - 1);
         const textRange = new vscode.Range(firstLine.range.start, lastLine.range.end);
         this.recoveryDiagnostics.set(document.uri, [
             new vscode.Diagnostic(
                 textRange,
-                localize("addReopenedFile.diagnosticMessage", "File is out of sync with mainframe: [{0}] {1}", fileInfo.profile, fileInfo.filename),
+                localize("addRecoveredFile.diagnosticMessage", "File is out of sync with {0}: {1}", fileInfo.profile, fileInfo.filename),
                 vscode.DiagnosticSeverity.Error
             ),
         ]);
     }
 
-    public static findReopenedFile(filePath: string): vscode.TextDocument | undefined {
-        return this.reopenedFiles.find((document) => document.fileName == filePath);
+    public static findRecoveredFile(filePath: string): vscode.TextDocument | undefined {
+        return this.recoveredFiles.find((document) => document.fileName == filePath);
     }
 
-    public static removeReopenedFile(document: vscode.TextDocument): void {
-        this.reopenedFiles = this.reopenedFiles.filter((doc) => doc != document);
+    public static removeRecoveredFile(document: vscode.TextDocument): void {
+        this.recoveredFiles = this.recoveredFiles.filter((doc) => doc != document);
         this.recoveryDiagnostics.delete(document.uri);
     }
 }

--- a/packages/zowe-explorer/src/utils/TempFolder.ts
+++ b/packages/zowe-explorer/src/utils/TempFolder.ts
@@ -138,7 +138,7 @@ export async function hideTempFolder(zoweDir: string): Promise<void> {
 
 export function findRecoveredFiles(): void {
     ZoweLogger.trace("TempFolder.findRecoveredFiles called.");
-    const recoveredFiles: { profile: string; filename: string }[] = [];
+    let recoveredFileCount = 0;
     for (const document of vscode.workspace.textDocuments) {
         let fileInfo: { profile: string; filename: string } = null;
         if (document.fileName.toUpperCase().indexOf(globals.DS_DIR.toUpperCase()) >= 0) {
@@ -155,20 +155,16 @@ export function findRecoveredFiles(): void {
             };
         }
         if (fileInfo != null) {
-            recoveredFiles.push(fileInfo);
+            recoveredFileCount++;
             LocalFileManagement.addRecoveredFile(document, fileInfo);
         }
     }
-    if (recoveredFiles.length > 0) {
-        Gui.showMessage(
+    if (recoveredFileCount > 0) {
+        Gui.warningMessage(
             localize(
                 "findRecoveredFiles.message",
-                "One or more files remained open in your last VS Code session:\n\n{0}\n\nTo prevent losing your updates, re-open these files in the Zowe Explorer tree to sync them with the mainframe.",
-                recoveredFiles.map(({ profile, filename }) => `[${profile}] ${filename}`).join("\n")
-            ),
-            {
-                vsCodeOpts: { modal: true },
-            }
+                "One or more files remained open in your last VS Code session. To prevent losing your updates, check the Problems view to see the list of files and re-save them to upload edits to the mainframe."
+            )
         );
     }
 }

--- a/packages/zowe-explorer/src/utils/TempFolder.ts
+++ b/packages/zowe-explorer/src/utils/TempFolder.ts
@@ -138,28 +138,22 @@ export async function hideTempFolder(zoweDir: string): Promise<void> {
 
 export function findRecoveredFiles(): void {
     ZoweLogger.trace("TempFolder.findRecoveredFiles called.");
-    let recoveredFileCount = 0;
     for (const document of vscode.workspace.textDocuments) {
-        let fileInfo: { profile: string; filename: string } = null;
         if (document.fileName.toUpperCase().indexOf(globals.DS_DIR.toUpperCase()) >= 0) {
             const pathSegments = document.fileName.slice(globals.DS_DIR.length + 1).split(path.sep);
-            fileInfo = {
+            LocalFileManagement.addRecoveredDs(document, {
                 profile: pathSegments.shift(),
-                filename: path.basename(pathSegments[0], path.extname(pathSegments[0])),
-            };
+                label: path.basename(pathSegments[0], path.extname(pathSegments[0])),
+            });
         } else if (document.fileName.toUpperCase().indexOf(globals.USS_DIR.toUpperCase()) >= 0) {
             const pathSegments = document.fileName.slice(globals.USS_DIR.length + 1).split(path.sep);
-            fileInfo = {
+            LocalFileManagement.addRecoveredUss(document, {
                 profile: pathSegments.shift(),
-                filename: path.posix.join(...pathSegments),
-            };
-        }
-        if (fileInfo != null) {
-            recoveredFileCount++;
-            LocalFileManagement.addRecoveredFile(document, fileInfo);
+                label: path.posix.join(...pathSegments),
+            });
         }
     }
-    if (recoveredFileCount > 0) {
+    if (LocalFileManagement.recoveredFileCount > 0) {
         Gui.warningMessage(
             localize(
                 "findRecoveredFiles.message",

--- a/packages/zowe-explorer/src/utils/TempFolder.ts
+++ b/packages/zowe-explorer/src/utils/TempFolder.ts
@@ -151,16 +151,16 @@ export function findRecoveredFiles(): void {
                 profile: Profiles.getInstance().loadNamedProfile(pathSegments[0]),
             };
             LocalFileManagement.addRecoveredFile(document, treeOpts);
-            LocalFileManagement.loadFileInfo(new ZoweDatasetNode(treeOpts), document.uri.fsPath);
+            LocalFileManagement.loadFileInfo(new ZoweDatasetNode(treeOpts), document.fileName);
         } else if (document.fileName.toUpperCase().indexOf(globals.USS_DIR.toUpperCase()) >= 0) {
             const pathSegments = document.fileName.slice(globals.USS_DIR.length + 1).split(path.sep);
             const treeOpts: IZoweTreeOpts = {
-                label: path.posix.join(...pathSegments.slice(1)),
+                label: "/" + path.posix.join(...pathSegments.slice(1)),
                 collapsibleState: vscode.TreeItemCollapsibleState.None,
                 profile: Profiles.getInstance().loadNamedProfile(pathSegments[0]),
             };
             LocalFileManagement.addRecoveredFile(document, treeOpts);
-            LocalFileManagement.loadFileInfo(new ZoweUSSNode(treeOpts), document.uri.fsPath);
+            LocalFileManagement.loadFileInfo(new ZoweUSSNode(treeOpts), document.fileName);
         }
     }
     if (LocalFileManagement.recoveredFileCount > 0) {

--- a/packages/zowe-explorer/src/utils/TempFolder.ts
+++ b/packages/zowe-explorer/src/utils/TempFolder.ts
@@ -22,8 +22,9 @@ import * as vscode from "vscode";
 import { LocalFileManagement } from "./LocalFileManagement";
 import { ZoweDatasetNode } from "../dataset/ZoweDatasetNode";
 import { ZoweUSSNode } from "../uss/ZoweUSSNode";
-import { IZoweTreeOpts } from "../shared/IZoweTreeOpts";
+import { IZoweDatasetTreeOpts, IZoweUssTreeOpts } from "../shared/IZoweTreeOpts";
 import { Profiles } from "../Profiles";
+import { checkForAddedSuffix } from "../shared/utils";
 
 // Set up localization
 nls.config({
@@ -145,8 +146,8 @@ export function findRecoveredFiles(): void {
     for (const document of vscode.workspace.textDocuments) {
         if (document.fileName.toUpperCase().indexOf(globals.DS_DIR.toUpperCase()) >= 0) {
             const pathSegments = document.fileName.slice(globals.DS_DIR.length + 1).split(path.sep);
-            const treeOpts: IZoweTreeOpts = {
-                label: path.basename(pathSegments[1], path.extname(pathSegments[1])),
+            const treeOpts: IZoweDatasetTreeOpts = {
+                label: checkForAddedSuffix(pathSegments[1]) ? path.parse(pathSegments[1]).name : pathSegments[1],
                 collapsibleState: vscode.TreeItemCollapsibleState.None,
                 profile: Profiles.getInstance().loadNamedProfile(pathSegments[0]),
             };
@@ -154,10 +155,11 @@ export function findRecoveredFiles(): void {
             LocalFileManagement.loadFileInfo(new ZoweDatasetNode(treeOpts), document.fileName);
         } else if (document.fileName.toUpperCase().indexOf(globals.USS_DIR.toUpperCase()) >= 0) {
             const pathSegments = document.fileName.slice(globals.USS_DIR.length + 1).split(path.sep);
-            const treeOpts: IZoweTreeOpts = {
-                label: "/" + path.posix.join(...pathSegments.slice(1)),
+            const treeOpts: IZoweUssTreeOpts = {
+                label: pathSegments[pathSegments.length - 1],
                 collapsibleState: vscode.TreeItemCollapsibleState.None,
                 profile: Profiles.getInstance().loadNamedProfile(pathSegments[0]),
+                parentPath: "/" + path.posix.join(...pathSegments.slice(1, -1)),
             };
             LocalFileManagement.addRecoveredFile(document, treeOpts);
             LocalFileManagement.loadFileInfo(new ZoweUSSNode(treeOpts), document.fileName);

--- a/packages/zowe-explorer/src/utils/TempFolder.ts
+++ b/packages/zowe-explorer/src/utils/TempFolder.ts
@@ -169,7 +169,7 @@ export function findRecoveredFiles(): void {
         Gui.warningMessage(
             localize(
                 "findRecoveredFiles.message",
-                "One or more files remained open in your last VS Code session. To prevent losing your updates, check the Problems view to see the list of files and re-save them to upload edits to the mainframe."
+                "One or more files remained open in your last VS Code session. To avoid losing your updates, check the Problems view to see the list of files and re-save them to upload the changes to the mainframe."
             )
         );
     }

--- a/packages/zowe-explorer/src/utils/TempFolder.ts
+++ b/packages/zowe-explorer/src/utils/TempFolder.ts
@@ -136,9 +136,9 @@ export async function hideTempFolder(zoweDir: string): Promise<void> {
     }
 }
 
-export function findReopenedFiles(): void {
-    ZoweLogger.trace("TempFolder.findReopenedFiles called.");
-    const reopenedFiles: { profile: string; filename: string }[] = [];
+export function findRecoveredFiles(): void {
+    ZoweLogger.trace("TempFolder.findRecoveredFiles called.");
+    const recoveredFiles: { profile: string; filename: string }[] = [];
     for (const document of vscode.workspace.textDocuments) {
         let fileInfo: { profile: string; filename: string } = null;
         if (document.fileName.toUpperCase().indexOf(globals.DS_DIR.toUpperCase()) >= 0) {
@@ -155,16 +155,16 @@ export function findReopenedFiles(): void {
             };
         }
         if (fileInfo != null) {
-            reopenedFiles.push(fileInfo);
-            LocalFileManagement.addReopenedFile(document, fileInfo);
+            recoveredFiles.push(fileInfo);
+            LocalFileManagement.addRecoveredFile(document, fileInfo);
         }
     }
-    if (reopenedFiles.length > 0) {
+    if (recoveredFiles.length > 0) {
         Gui.showMessage(
             localize(
-                "findReopenedFiles.message",
-                "One or more files remained open in your last VS Code session:\n\n{0}\n\nTo prevent losing your updates, navigate to these files in the Zowe Explorer tree to sync them with the mainframe.",
-                reopenedFiles.map(({ profile, filename }) => `[${profile}] ${filename}`).join("\n")
+                "findRecoveredFiles.message",
+                "One or more files remained open in your last VS Code session:\n\n{0}\n\nTo prevent losing your updates, re-open these files in the Zowe Explorer tree to sync them with the mainframe.",
+                recoveredFiles.map(({ profile, filename }) => `[${profile}] ${filename}`).join("\n")
             ),
             {
                 vsCodeOpts: { modal: true },

--- a/packages/zowe-explorer/src/utils/TempFolder.ts
+++ b/packages/zowe-explorer/src/utils/TempFolder.ts
@@ -25,6 +25,7 @@ import { ZoweUSSNode } from "../uss/ZoweUSSNode";
 import { IZoweDatasetTreeOpts, IZoweUssTreeOpts } from "../shared/IZoweTreeOpts";
 import { Profiles } from "../Profiles";
 import { checkForAddedSuffix } from "../shared/utils";
+import { LocalStorageKey, ZoweLocalStorage } from "./ZoweLocalStorage";
 
 // Set up localization
 nls.config({
@@ -121,6 +122,7 @@ export function cleanTempDir(): Promise<void> {
     }
     try {
         cleanDir(globals.ZOWETEMPFOLDER);
+        ZoweLocalStorage.setValue(LocalStorageKey.FILE_INFO_CACHE, undefined);
     } catch (err) {
         ZoweLogger.error(err);
         if (err instanceof Error) {

--- a/packages/zowe-explorer/src/utils/ZoweLocalStorage.ts
+++ b/packages/zowe-explorer/src/utils/ZoweLocalStorage.ts
@@ -12,18 +12,23 @@
 import * as vscode from "vscode";
 import { ZoweLogger } from "./LoggerUtils";
 
+export enum LocalStorageKey {
+    ENCODING_HISTORY = "zowe.encodingHistory",
+    FILE_INFO_CACHE = "zowe.fileInfoCache",
+}
+
 export class ZoweLocalStorage {
     private static storage: vscode.Memento;
     public static initializeZoweLocalStorage(state: vscode.Memento): void {
         ZoweLocalStorage.storage = state;
     }
 
-    public static getValue<T>(key: string): T {
+    public static getValue<T>(key: LocalStorageKey): T {
         ZoweLogger.trace("ZoweLocalStorage.getValue called.");
         return ZoweLocalStorage.storage.get<T>(key);
     }
 
-    public static setValue<T>(key: string, value: T): void {
+    public static setValue<T>(key: LocalStorageKey, value: T): void {
         ZoweLogger.trace("ZoweLocalStorage.setValue called.");
         ZoweLocalStorage.storage.update(key, value);
     }


### PR DESCRIPTION
## Proposed changes

Resolves #2758 by improving user experience for data set or USS files left open in the last VS Code session. This can happen when the VS Code window is reloaded or restarted after terminating abnormally.

* Stores the node properties `binary`, `encoding`, and `etag` in local storage so they will persist after reload
* Recreates old nodes at launch time using properties in local storage so that old edits can still be uploaded
* Shows warning message and inline diagnostic for any "recovered" data sets or USS files that are detected

<img width="954" alt="image" src="https://github.com/zowe/vscode-extension-for-zowe/assets/22344007/22e87d7c-3bca-4bcf-86c5-9a63e6afc436">

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.15.2

Changelog: Fixed issue where files left open in prior VS Code session cannot be uploaded to mainframe after window is reloaded.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/vscode-extension-for-zowe/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [x] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
