### PR TITLE
fix(ProfilesCache): Clear object caches before refresh

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.16.0-SNAPSHOT",
+  "version": "2.15.2",
   "command": {
     "version": {
       "forcePublish": true,

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
+- Fixed an issue where the `ProfilesCache` class would retain old service profiles, even if they were removed from the team config. [#2395](https://github.com/zowe/zowe-explorer-vscode/issues/2395)
+
 ## `2.15.1`
 
 ### New features and enhancements

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -299,13 +299,15 @@ describe("ProfilesCache", () => {
             expect(mockLogError).toHaveBeenCalledWith(fakeError);
         });
 
-        it("should clear the profilesByType map before reloading profiles", async () => {
+        it("should clear the profilesByType and defaultProfileByType maps before reloading profiles", async () => {
             const profCache = new ProfilesCache({ ...fakeLogger, error: mockLogError } as unknown as zowe.imperative.Logger);
             const profInfoMock = jest.spyOn(profCache, "getProfileInfo").mockRejectedValueOnce("some error");
             const errorMock = jest.spyOn((profCache as any).log, "error").mockImplementation();
             (profCache as any).profilesByType["test-type"] = { name: "someProf" as any };
+            (profCache as any).defaultProfileByType["test-type"] = { name: "someProf" as any };
             await profCache.refresh();
             expect((profCache as any).profilesByType.size).toBe(0);
+            expect((profCache as any).defaultProfileByType.size).toBe(0);
             expect(errorMock).toHaveBeenCalledWith("some error");
             profInfoMock.mockRestore();
             errorMock.mockRestore();

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -298,6 +298,18 @@ describe("ProfilesCache", () => {
             expect(profCache.getAllTypes().length).toEqual(0);
             expect(mockLogError).toHaveBeenCalledWith(fakeError);
         });
+
+        it("should clear the profilesByType map before reloading profiles", async () => {
+            const profCache = new ProfilesCache({ ...fakeLogger, error: mockLogError } as unknown as zowe.imperative.Logger);
+            const profInfoMock = jest.spyOn(profCache, "getProfileInfo").mockRejectedValueOnce("some error");
+            const errorMock = jest.spyOn((profCache as any).log, "error").mockImplementation();
+            (profCache as any).profilesByType["test-type"] = { name: "someProf" as any };
+            await profCache.refresh();
+            expect((profCache as any).profilesByType.size).toBe(0);
+            expect(errorMock).toHaveBeenCalledWith("some error");
+            profInfoMock.mockRestore();
+            errorMock.mockRestore();
+        });
     });
 
     describe("validateAndParseUrl", () => {

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -195,6 +195,7 @@ export class ProfilesCache {
         this.allProfiles = [];
         this.allTypes = [];
         this.profilesByType.clear();
+        this.defaultProfileByType.clear();
         let mProfileInfo: zowe.imperative.ProfileInfo;
         try {
             mProfileInfo = await this.getProfileInfo();

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -194,6 +194,7 @@ export class ProfilesCache {
     public async refresh(apiRegister?: ZoweExplorerApi.IApiRegisterClient): Promise<void> {
         this.allProfiles = [];
         this.allTypes = [];
+        this.profilesByType.clear();
         let mProfileInfo: zowe.imperative.ProfileInfo;
         try {
             mProfileInfo = await this.getProfileInfo();


### PR DESCRIPTION
## Proposed changes

Resolves #2395 

## Release Notes

Milestone: 2.15.2

Changelog:

- Fixed an issue where the `ProfilesCache` class would retain old service profiles, even if they were removed from the team config.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found