### PR TITLE
fix(commands): Hide commands from palette that require nodes/info

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ### Bug fixes
 
 - To fix clicking submitted job hyperlink throws error [#2813](https://github.com/zowe/vscode-extension-for-zowe/issues/2813)
-- Omitted the following Zowe Explorer commands from the Command Palette that do not execute properly when run as a standalone command:
+- Omitted the following Zowe Explorer commands from the Command Palette that do not execute properly when run as a standalone command: [#2853](https://github.com/zowe/zowe-explorer-vscode/pull/2853)
   - `Zowe Explorer: Cancel job`
   - `Zowe Explorer: Filter jobs`
   - `Zowe Explorer: Filter PDS members`

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ### Bug fixes
 
 - To fix clicking submitted job hyperlink throws error [#2813](https://github.com/zowe/vscode-extension-for-zowe/issues/2813)
+- Omitted the following Zowe Explorer commands from the Command Palette that do not execute properly when run as a standalone command:
+  - `Zowe Explorer: Cancel job`
+  - `Zowe Explorer: Filter jobs`
+  - `Zowe Explorer: Filter PDS members`
+  - `Zowe Explorer: Sort jobs`
+  - `Zowe Explorer: Sort PDS members`
+  - `Zowe Explorer: Start Polling`
+  - `Zowe Explorer: Stop Polling`
 
 ## `2.15.3`
 

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1733,6 +1733,34 @@
         {
           "command": "zowe.uss.openWithEncoding",
           "when": "never"
+        },
+        {
+          "command": "zowe.jobs.cancelJob",
+          "when": "never"
+        },
+        {
+          "command": "zowe.jobs.filterJobs",
+          "when": "never"
+        },
+        {
+          "command": "zowe.ds.filterBy",
+          "when": "never"
+        },
+        {
+          "command": "zowe.jobs.sortBy",
+          "when": "never"
+        },
+        {
+          "command": "zowe.ds.sortBy",
+          "when": "never"
+        },
+        {
+          "command": "zowe.jobs.startPolling",
+          "when": "never"
+        },
+        {
+          "command": "zowe.jobs.stopPolling",
+          "when": "never"
         }
       ]
     },


### PR DESCRIPTION
## Proposed changes

Hides the following commands from the Command Palette as they do not function properly without a node or other arguments:

  - `Zowe Explorer: Cancel job`
  - `Zowe Explorer: Filter jobs`
  - `Zowe Explorer: Filter PDS members`
  - `Zowe Explorer: Sort jobs`
  - `Zowe Explorer: Sort PDS members`
  - `Zowe Explorer: Start Polling`
  - `Zowe Explorer: Stop Polling`

If we want to add support for running some of these commands in the Command Palette, I'll file an issue to track those. For now, it's best to hide these so users don't try to run them, as there isn't any error handling in place - so any errors will show in a modal dialog. Thanks to @awharn for spotting some of these during our offline discussion 🙂 

## Release Notes

Milestone: 2.16.0 (or 2.15.3 if we want to release another patch, whichever is preferred)

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
