### PR TITLE
Fix command not assigned to new member nodes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.16.0-SNAPSHOT",
+  "version": "2.15.4",
   "command": {
     "version": {
       "forcePublish": true,

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where new PDS member node cannot be re-opened unless you pull from mainframe. [#2857](https://github.com/zowe/zowe-explorer-vscode/issues/2857)
+
 ## `2.15.3`
 
 ### Bug fixes

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -183,7 +183,10 @@ describe("Dataset Actions Unit Tests - Function createMember", () => {
 
         await dsActions.createMember(parent, blockMocks.testDatasetTree);
 
-        expect(parent.children.find((node) => node.label === "TESTMEMBER")).toBeDefined();
+        const newNode = parent.children.find((node) => node.label === "TESTMEMBER");
+        expect(newNode).toBeDefined();
+        expect(newNode?.contextValue).toBe(globals.DS_MEMBER_CONTEXT);
+        expect(newNode?.command.command).toBe("zowe.ds.ZoweNode.openPS");
         expect(mySpy).toBeCalledWith({
             placeHolder: "Name of Member",
             validateInput: expect.any(Function),

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -427,6 +427,7 @@ export async function createMember(parent: api.IZoweDatasetTreeNode, datasetProv
             parentNode: parent,
             profile: parent.getProfile(),
         });
+        newNode.command = { command: "zowe.ds.ZoweNode.openPS", title: "", arguments: [newNode] };
         await newNode.openDs(false, true, datasetProvider);
 
         parent.children.push(newNode);


### PR DESCRIPTION
## Proposed changes

Fixes #2857

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 2.15.4

Changelog: Fixed issue where new PDS member node cannot be re-opened unless you pull from mainframe

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
