### PR TITLE
fix(ds): resolve TypeError when expanding favorited PDS

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed issue where expanding a favorited PDS resulted in an error message. [#2873](https://github.com/zowe/zowe-explorer-vscode/issues/2873)
+
 ## `2.15.3`
 
 ### Bug fixes

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -99,7 +99,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             this.iconPath = icon.path;
         }
 
-        if (this.getParent() == null) {
+        if (this.getParent() == null || this.getParent().label === localize("Favorites", "Favorites")) {
             // set default sort options for session nodes
             this.sort = {
                 method: DatasetSortOpts.Name,

--- a/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/dataset/ZoweDatasetNode.ts
@@ -99,7 +99,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             this.iconPath = icon.path;
         }
 
-        if (this.getParent() == null || this.getParent().label === localize("Favorites", "Favorites")) {
+        if (this.getParent() == null || contextually.isFavorite(this.getParent())) {
             // set default sort options for session nodes
             this.sort = {
                 method: DatasetSortOpts.Name,


### PR DESCRIPTION
## Proposed changes

Resolves the issue where expanding a PDS member results in a TypeError. The logic for `getSessionNode` was updated for 2.15.3 and now returns the proper node for favorited items. However, due to this change, the sorting logic needs an adjustment to define the `sort` property for sessions under the Favorites folder. 

## Release Notes

Milestone: 2.15.4

Changelog:

- Fixed issue where expanding a favorited PDS resulted in an error message.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
