### PR TITLE
fix(ftp): use 'sha256' instead of 'sha1'

### DIFF
--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to the "zowe-explorer-ftp-extension" extension will be docum
 
 ### New features and enhancements
 
+### Bug fixes
+
 - Changed the hashing algorithm for e-tag generation from `sha1` to `sha256`. [#2890](https://github.com/zowe/zowe-explorer-vscode/pull/2890)
   - _Reason:_ Hash collisions can occur when using the `sha1` algorithm, so it was replaced to avoid collisions.
-
-### Bug fixes
 
 ## `2.15.4`
 

--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the "zowe-explorer-ftp-extension" extension will be docum
 
 ### New features and enhancements
 
+- Changed the hashing algorithm for e-tag generation from `sha1` to `sha256`. [#2890](https://github.com/zowe/zowe-explorer-vscode/pull/2890)
+  - _Reason:_ Hash collisions can occur when using the `sha1` algorithm, so it was replaced to avoid collisions.
+
 ### Bug fixes
 
 ## `2.15.4`

--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -6,8 +6,7 @@ All notable changes to the "zowe-explorer-ftp-extension" extension will be docum
 
 ### Bug fixes
 
-- Changed the hashing algorithm for e-tag generation from `sha1` to `sha256`. [#2890](https://github.com/zowe/zowe-explorer-vscode/pull/2890)
-  - _Reason:_ Hash collisions can occur when using the `sha1` algorithm, so it was replaced to avoid collisions.
+- Changed the hashing algorithm for e-tag generation from `sha1` to `sha256` to avoid collisions. [#2890](https://github.com/zowe/zowe-explorer-vscode/pull/2890)
 
 ## `2.15.4`
 

--- a/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Mvs/ZoweExplorerFtpMvsApi.unit.test.ts
+++ b/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Mvs/ZoweExplorerFtpMvsApi.unit.test.ts
@@ -91,7 +91,7 @@ describe("FtpMvsApi", () => {
         };
         const result = await MvsApi.getContents(mockParams.dataSetName, mockParams.options);
 
-        expect(result.apiResponse.etag).toHaveLength(40);
+        expect(result.apiResponse.etag).toHaveLength(64);
         expect(DataSetUtils.downloadDataSet).toBeCalledTimes(1);
         expect(MvsApi.releaseConnection).toBeCalled();
 

--- a/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Uss/ZoweExplorerFtpUssApi.unit.test.ts
+++ b/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Uss/ZoweExplorerFtpUssApi.unit.test.ts
@@ -75,7 +75,7 @@ describe("FtpUssApi", () => {
         };
         const result = await UssApi.getContents(mockParams.ussFilePath, mockParams.options);
 
-        expect(result.apiResponse.etag).toHaveLength(40);
+        expect(result.apiResponse.etag).toHaveLength(64);
         expect(UssUtils.downloadFile).toBeCalledTimes(1);
         expect(UssApi.releaseConnection).toBeCalled();
 

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpMvsApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpMvsApi.ts
@@ -385,7 +385,7 @@ export class FtpMvsApi extends AbstractFtpApi implements ZoweExplorerApi.IMvs {
 
     private hashFile(filename: string): Promise<string> {
         return new Promise((resolve) => {
-            const hash = crypto.createHash("sha1");
+            const hash = crypto.createHash("sha256");
             const input = fs.createReadStream(filename);
             input.on("readable", () => {
                 const data = input.read();

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpUssApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpUssApi.ts
@@ -291,7 +291,7 @@ export class FtpUssApi extends AbstractFtpApi implements ZoweExplorerApi.IUss {
 
     private hashFile(filename: string): Promise<string> {
         return new Promise((resolve) => {
-            const hash = crypto.createHash("sha1");
+            const hash = crypto.createHash("sha256");
             const input = fs.createReadStream(filename);
             input.on("readable", () => {
                 const data = input.read();


### PR DESCRIPTION
## Proposed changes

This updates the FTP extension to use `sha256` instead of `sha1` for hashing file contents (generating fake e-tags).

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: 

Changelog:

- Changed the hashing algorithm for e-tag generation from `sha1` to `sha256`. [#2890](https://github.com/zowe/zowe-explorer-vscode/pull/2890)
  - _Reason:_ Hash collisions can occur when using the `sha1` algorithm, so it was replaced to avoid collisions.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
