### PR TITLE
port(v3/ftp): Use `sha256` instead of `sha1`

### DIFF
--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "zowe-explorer-ftp-extension" extension will be docum
 
 ### Bug fixes
 
+- Changed the hashing algorithm for e-tag generation from `sha1` to `sha256` to avoid collisions. [#2890](https://github.com/zowe/zowe-explorer-vscode/pull/2890)
+
 ## `3.0.0-next.202404242037`
 
 ### New features and enhancements

--- a/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Mvs/ZoweExplorerFtpMvsApi.unit.test.ts
+++ b/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Mvs/ZoweExplorerFtpMvsApi.unit.test.ts
@@ -91,7 +91,7 @@ describe("FtpMvsApi", () => {
         };
         const result = await MvsApi.getContents(mockParams.dataSetName, mockParams.options);
 
-        expect(result.apiResponse.etag).toHaveLength(40);
+        expect(result.apiResponse.etag).toHaveLength(64);
         expect(DataSetUtils.downloadDataSet).toHaveBeenCalledTimes(1);
         expect(MvsApi.releaseConnection).toHaveBeenCalled();
 

--- a/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Uss/ZoweExplorerFtpUssApi.unit.test.ts
+++ b/packages/zowe-explorer-ftp-extension/__tests__/__unit__/Uss/ZoweExplorerFtpUssApi.unit.test.ts
@@ -76,7 +76,7 @@ describe("FtpUssApi", () => {
         };
         const result = await UssApi.getContents(mockParams.ussFilePath, mockParams.options);
 
-        expect(result.apiResponse.etag).toHaveLength(40);
+        expect(result.apiResponse.etag).toHaveLength(64);
         expect(UssUtils.downloadFile).toHaveBeenCalledTimes(1);
         expect(UssApi.releaseConnection).toHaveBeenCalled();
 

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerAbstractFtpApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerAbstractFtpApi.ts
@@ -51,7 +51,7 @@ export abstract class AbstractFtpApi implements MainframeInteraction.ICommon {
     }
 
     protected hashBuffer(buffer: Buffer): string {
-        const hash = crypto.createHash("sha1");
+        const hash = crypto.createHash("sha256");
         hash.update(buffer);
         return hash.digest("hex");
     }

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpMvsApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpMvsApi.ts
@@ -384,7 +384,7 @@ export class FtpMvsApi extends AbstractFtpApi implements MainframeInteraction.IM
 
     private hashFile(filename: string): Promise<string> {
         return new Promise((resolve) => {
-            const hash = crypto.createHash("sha1");
+            const hash = crypto.createHash("sha256");
             const input = fs.createReadStream(filename);
             input.on("readable", () => {
                 const data = input.read();

--- a/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpUssApi.ts
+++ b/packages/zowe-explorer-ftp-extension/src/ZoweExplorerFtpUssApi.ts
@@ -299,7 +299,7 @@ export class FtpUssApi extends AbstractFtpApi implements MainframeInteraction.IU
 
     private hashFile(filename: string): Promise<string> {
         return new Promise((resolve) => {
-            const hash = crypto.createHash("sha1");
+            const hash = crypto.createHash("sha256");
             const input = fs.createReadStream(filename);
             input.on("readable", () => {
                 const data = input.read();


### PR DESCRIPTION
## Proposed changes

This is a port of the SHA256 change for the next branch.

## Release Notes

Milestone: 

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found
