### PR TITLE
Fix regression with clearing profile object caches on refresh

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 ### Bug fixes
 
 - Updated `@zowe/cli` dependency to fix issue where "Log out of authentication service" doesn't show in Manage Profile menu. [#2633](https://github.com/zowe/zowe-explorer-vscode/issues/2633)
+- Fixed regression of issue where the `ProfilesCache` class would retain old service profiles, even if they were removed from the team config. [#2910](https://github.com/zowe/zowe-explorer-vscode/issues/2910)
 
 ## `2.15.4`
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -302,14 +302,16 @@ describe("ProfilesCache", () => {
         it("should remove old types from profilesByType and defaultProfileByType maps when reloading profiles", async () => {
             const profCache = new ProfilesCache({ ...fakeLogger, error: mockLogError } as unknown as zowe.imperative.Logger);
             jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([]));
-            (profCache as any).profilesByType.set("test-type", { name: "someProf" as any });
-            (profCache as any).defaultProfileByType.set("test-type", { name: "someProf" as any });
+            (profCache as any).profilesByType.set("base", { name: "someProf" as any });
+            (profCache as any).defaultProfileByType.set("base", { name: "someProf" as any });
             const promise = profCache.refresh();
             expect((profCache as any).profilesByType.size).toBe(1);
             expect((profCache as any).defaultProfileByType.size).toBe(1);
             await promise;
             expect((profCache as any).profilesByType.size).toBe(0);
             expect((profCache as any).defaultProfileByType.size).toBe(0);
+            expect((profCache as any).allProfiles.length).toBe(0);
+            expect((profCache as any).allTypes).toEqual(["base"]);
             expect(mockLogError).not.toHaveBeenCalled();
         });
     });

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -175,7 +175,7 @@ export class ProfilesCache {
      *
      * @returns {IProfileLoaded[]}
      */
-    public getProfiles(type = "zosmf"): zowe.imperative.IProfileLoaded[] {
+    public getProfiles(type = "zosmf"): zowe.imperative.IProfileLoaded[] | undefined {
         return this.profilesByType.get(type);
     }
 
@@ -222,7 +222,7 @@ export class ProfilesCache {
             }
             this.allProfiles = allProfiles;
             this.allTypes = allTypes;
-            for (const oldType of [...this.profilesByType.keys()].filter((type) => !allTypes.includes(type))) {
+            for (const oldType of [...this.profilesByType.keys()].filter((type) => !allProfiles.some((prof) => prof.type === type))) {
                 this.profilesByType.delete(oldType);
                 this.defaultProfileByType.delete(oldType);
             }


### PR DESCRIPTION
## Proposed changes

Fixes #2910

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone:

Changelog: Fixed regression of issue where the `ProfilesCache` class would retain old service profiles, even if they were removed from the team config

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [ ] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [ ] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
