### PR TITLE
Fix issue Right-click-delete deletes the wrong program

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ### Bug fixes
 
 - To add the ability to open a Favorited Job Search under Favorites [#2630](https://github.com/zowe/zowe-explorer-vscode/pull/2930)
+- Fix issue Right-click-delete option deleting the currently open/selected file and not the file which is right-clicked when members having same name [#2941](https://github.com/zowe/zowe-explorer-vscode/issues/2941)
 
 ## `2.16.1`
 

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -495,14 +495,6 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
             profile: globalMocks.imperativeProfile,
             contextOverride: globals.DS_MEMBER_CONTEXT,
         });
-        const testMemberNode1 = new ZoweDatasetNode({
-            label: "MEMB",
-            collapsibleState: vscode.TreeItemCollapsibleState.None,
-            parentNode: testDatasetNode,
-            session: globalMocks.session,
-            profile: globalMocks.imperativeProfile,
-            contextOverride: globals.DS_MEMBER_CONTEXT,
-        });
         const testFavoritedNode = new ZoweDatasetNode({
             label: "HLQ.TEST.FAV",
             collapsibleState: vscode.TreeItemCollapsibleState.None,

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -495,6 +495,14 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
             profile: globalMocks.imperativeProfile,
             contextOverride: globals.DS_MEMBER_CONTEXT,
         });
+        const testMemberNode1 = new ZoweDatasetNode({
+            label: "MEMB",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            parentNode: testDatasetNode,
+            session: globalMocks.session,
+            profile: globalMocks.imperativeProfile,
+            contextOverride: globals.DS_MEMBER_CONTEXT,
+        });
         const testFavoritedNode = new ZoweDatasetNode({
             label: "HLQ.TEST.FAV",
             collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -708,6 +716,21 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         await dsActions.deleteDatasetPrompt(blockMocks.testDatasetTree);
 
         expect(mocked(vscode.window.withProgress).mock.calls.length).toBe(0);
+    });
+
+    it("test when selected node is sent", async () => {
+        const globalMocks = createGlobalMocks();
+        const blockMocks = createBlockMocks(globalMocks);
+
+        const selectedNodes = [blockMocks.testMemberNode];
+        const treeView = createTreeView(selectedNodes);
+        blockMocks.testDatasetTree.getTreeView.mockReturnValueOnce(treeView);
+        globalMocks.mockShowWarningMessage.mockResolvedValueOnce("Delete");
+
+        await dsActions.deleteDatasetPrompt(blockMocks.testDatasetTree, blockMocks.testMemberNode);
+        expect(mocked(Gui.showMessage)).toBeCalledWith(
+            `The following 1 item(s) were deleted: ${blockMocks.testMemberNode.getParent().getLabel()}(${blockMocks.testMemberNode.getLabel()})`
+        );
     });
 });
 

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -254,12 +254,14 @@ export async function deleteDatasetPrompt(datasetProvider: api.IZoweTree<api.IZo
     let includedSelection = false;
     if (node) {
         for (const item of selectedNodes) {
-            if (node.getLabel().toString() === item.getLabel().toString()) {
+            if (
+                node.getLabel().toString() === item.getLabel().toString() &&
+                node.getParent().getLabel().toString() === item.getParent().getLabel().toString()
+            ) {
                 includedSelection = true;
             }
         }
     }
-
     // Check that child and parent aren't both in array, removing children whose parents are in
     // array to avoid errors from host when deleting none=existent children.
     const childArray: api.IZoweDatasetTreeNode[] = [];
@@ -273,7 +275,6 @@ export async function deleteDatasetPrompt(datasetProvider: api.IZoweTree<api.IZo
         }
     }
     selectedNodes = selectedNodes.filter((val) => !childArray.includes(val));
-
     if (includedSelection || !node) {
         // Filter out sessions and information messages
         nodes = selectedNodes.filter(


### PR DESCRIPTION
## Proposed changes

1. Solves: https://github.com/zowe/zowe-explorer-vscode/issues/2941
    Fix the issue of right-click-Delete option which is deleting the currently open/selected file and not the file which is right-clicked when the names of members are same.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone:

Changelog:

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [ ] All checks have passed (DCO, Jenkins and Code Coverage)
- [ ] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [ ] There is coverage for the code that I have added
- [ ] I have tested it manually and there are no regressions found
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any PR dependencies have been merged and published (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
