### PR TITLE
fix: Fire `onProfilesUpdate` event when secure credentials are updated

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
-- Fixed an issue where the `onProfilesUpdate` event did not fire after secure credentials were updated.
+- Fixed an issue where the `onProfilesUpdate` event did not fire after secure credentials were updated. [#2822](https://github.com/zowe/zowe-explorer-vscode/issues/2822)
 
 ## `2.16.1`
 

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
+- Fixed an issue where the `onProfilesUpdate` event did not fire after secure credentials were updated.
+
 ## `2.16.1`
 
 ## `2.16.0`


### PR DESCRIPTION
## Proposed changes

Previously, we ran the `zowe.extRefresh` command to signal a refresh of Zowe Explorer and its extenders when credentials are updated for a profile. While this worked to synchronize credentials in most cases, extender event callbacks for `onProfilesUpdate` were never fired for this scenario.

This updates the logic so that we fire the `onProfilesUpdateEmitter` event when the following conditions are met:
* Secure credentials are enabled in Zowe Explorer
* The credentials were successfully updated on the profile

### How to test
* Subscribe to the `onProfilesUpdate` event in a Zowe Explorer extender with a test callback, e.g.,
  ```ts
  ZoweVsCodeExtension.getZoweExplorerApi().onProfilesUpdate?.(
      (eventType: any) =>
          vscode.window.showInformationMessage(`onProfilesUpdate fired, type: ${eventType}` as string)
  );
  ```
  * _thanks @zFernand0 for cleaning up the example callback 😋_

* Right-click on a profile in the tree view **with pre-existing, secured credentials** and select "Manage Profile" -> "Update Credentials"
* After the credential update is successful, notice that the callback added by the extension is now fired

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog -->
<!-- If there is a linked issue, it should have the same milestone as this PR -->

Milestone: v2.16.2

Changelog:

- Fixed an issue where the `onProfilesUpdate` event was not fired after secure credentials were updated.

## Types of changes

What types of changes does your code introduce to Zowe Explorer?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Updates to Documentation or Tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer_

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] PR title follows [Conventional Commits Guidelines](https://www.conventionalcommits.org/en/v1.0.0-beta.2/)
- [x] PR Description is included
- [ ] gif or screenshot is included if visual changes are made
- [x] `yarn workspace vscode-extension-for-zowe vscode:prepublish` has been executed
- [x] All checks have passed (DCO, Jenkins and Code Coverage)
- [x] I have added unit test and it is passing
- [ ] I have added integration test and it is passing
- [x] There is coverage for the code that I have added
- [x] I have tested it manually and there are no regressions found