### PR TITLE
fix(v2): add zedc to gitignore; update webviews package script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ temp
 coverage/
 dist/
 prebuilds/
+zedc/target/

--- a/packages/zowe-explorer/src/webviews/package.json
+++ b/packages/zowe-explorer/src/webviews/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "fresh-clone": "yarn clean && rimraf node_modules",
     "clean": "gulp clean",
-    "package": "echo \"webviews: nothing to package.\"",
+    "package": "node -e \"process.exit(+fs.existsSync(path.join(__dirname, 'dist')))\" && pnpm build || echo \"webviews: nothing to package.\"",
     "test": "echo \"webviews: nothing to test\"",
     "lint": "echo \"webviews: nothing to lint.\"",
     "lint:html": "echo \"webviews: nothing to lint.\"",

--- a/packages/zowe-explorer/src/webviews/package.json
+++ b/packages/zowe-explorer/src/webviews/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "fresh-clone": "yarn clean && rimraf node_modules",
     "clean": "gulp clean",
-    "package": "node -e \"process.exit(+fs.existsSync(path.join(__dirname, 'dist')))\" && pnpm build || echo \"webviews: nothing to package.\"",
+    "package": "node -e \"process.exit(+fs.existsSync(path.join(__dirname, 'dist')))\" && pnpm build || echo \"webviews: already packaged.\"",
     "test": "echo \"webviews: nothing to test\"",
     "lint": "echo \"webviews: nothing to lint.\"",
     "lint:html": "echo \"webviews: nothing to lint.\"",

--- a/packages/zowe-explorer/src/webviews/package.json
+++ b/packages/zowe-explorer/src/webviews/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "fresh-clone": "yarn clean && rimraf node_modules",
     "clean": "gulp clean",
-    "package": "node -e \"process.exit(+fs.existsSync(path.join(__dirname, 'dist')))\" && pnpm build || echo \"webviews: already packaged.\"",
+    "package": "node -e \"fs.accessSync(path.join(__dirname, 'dist'))\" && echo \"webviews: already packaged.\" || pnpm build",
     "test": "echo \"webviews: nothing to test\"",
     "lint": "echo \"webviews: nothing to lint.\"",
     "lint:html": "echo \"webviews: nothing to lint.\"",


### PR DESCRIPTION
## Proposed changes

- Adds the `zedc/target` folder to `.gitignore` so that changing between v2 and v3 branches does not affect working tree
- Updates the webviews `package` script to check for the existence of the `dist` folder
  - If it does not exist, it will run `pnpm build`
  - Otherwise it will print the message `"webviews: already packaged."`

## Release Notes

Milestone: 

Changelog: None

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] A GIF or screenshot is included in the PR for visual changes

**Deployment**

- [x] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [x] These changes may need ported to the appropriate branches (list here): **`next`**
  - The port will be a part of the `rnd/tables` branch