### PR TITLE
fix(v2): `onProfilesUpdate` does not always fire for extenders

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed issue where creating a new team configuration file could cause Zowe Explorer to crash, resulting in all sessions disappearing from trees. [#2906](https://github.com/zowe/zowe-explorer-vscode/issues/2906)
 - Fixed data set not opening when the token has expired. [#3001](https://github.com/zowe/zowe-explorer-vscode/issues/3001)
 - Fixed JSON errors being ignored when `zowe.config.json` files change on disk and are reloaded. [#3066](https://github.com/zowe/zowe-explorer-vscode/issues/3066) [#3074](https://github.com/zowe/zowe-explorer-vscode/issues/3074)
+- Resolved an issue where extender event callbacks were not always fired when the team configuration file was created, updated or deleted. [#3078](https://github.com/zowe/zowe-explorer-vscode/issues/3078)
 
 ## `2.17.0`
 

--- a/packages/zowe-explorer/src/shared/init.ts
+++ b/packages/zowe-explorer/src/shared/init.ts
@@ -243,14 +243,14 @@ export function watchConfigProfile(context: vscode.ExtensionContext): void {
     context.subscriptions.push(...watchers);
 
     watchers.forEach((watcher) => {
-        watcher.onDidCreate(async () => {
+        watcher.onDidCreate(() => {
             ZoweLogger.info(localize("watchConfigProfile.create", "Team config file created, refreshing Zowe Explorer."));
-            await refreshActions.refreshAll();
+            void refreshActions.refreshAll();
             ZoweExplorerApiRegister.getInstance().onProfilesUpdateEmitter.fire(EventTypes.CREATE);
         });
-        watcher.onDidDelete(async () => {
+        watcher.onDidDelete(() => {
             ZoweLogger.info(localize("watchConfigProfile.delete", "Team config file deleted, refreshing Zowe Explorer."));
-            await refreshActions.refreshAll();
+            void refreshActions.refreshAll();
             ZoweExplorerApiRegister.getInstance().onProfilesUpdateEmitter.fire(EventTypes.DELETE);
         });
         watcher.onDidChange(async (uri: vscode.Uri) => {
@@ -260,7 +260,7 @@ export function watchConfigProfile(context: vscode.ExtensionContext): void {
                 return;
             }
             globals.setSavedProfileContents(newProfileContents);
-            await refreshActions.refreshAll();
+            void refreshActions.refreshAll();
             ZoweExplorerApiRegister.getInstance().onProfilesUpdateEmitter.fire(EventTypes.UPDATE);
         });
     });


### PR DESCRIPTION
## Proposed changes

Fixes an issue where the event callback for the Team Config file watcher stopped abruptly before firing the emitter for extenders. 

## Release Notes

Milestone: 2.18.0

Changelog: 

- Resolved an issue where extender event callbacks were not always fired when the team configuration file was created, updated or changed. [#3078](https://github.com/zowe/zowe-explorer-vscode/issues/3078)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [x] These changes may need ported to the appropriate branches (list here): `next`