### PR TITLE
fix(v3): Hide conflict icons during normal diff; fix remote lookup causing local side of conflict to update

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -116,6 +116,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 - Fixed an issue where the `ZoweVsCodeExtension.updateCredentials` method could remove credentials from session when input prompt was cancelled. [#3009](https://github.com/zowe/zowe-explorer-vscode/pull/3009)
 - Fixed an issue where the loaded configuration could be overridden when extenders retrieved the Zowe home directory. [#2994](https://github.com/zowe/zowe-explorer-vscode/pull/2994)
 - Update Zowe SDKs to `8.0.0-next.202407232256` for technical currency. [#2994](https://github.com/zowe/zowe-explorer-vscode/pull/2994)
+- Fixed an issue where remote lookup functionality caused the local side of a conflict to be overwritten with the remote contents.
 
 ## `3.0.0-next.202404242037`
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/fs/BaseProvider.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/fs/BaseProvider.unit.test.ts
@@ -636,3 +636,17 @@ describe("_reopenEditorForRelocatedUri", () => {
         tabGroupsMock[Symbol.dispose]();
     });
 });
+
+describe("onCloseEvent", () => {
+    it("disposes the event if all visible text editors are not in a conflict", () => {
+        const fakeProvider = { _lookupAsFile: jest.fn(), onDocClosedEventDisposable: { dispose: jest.fn() } };
+        const visibleTextEditorsMock = new MockedProperty(vscode.window, "visibleTextEditors", undefined, [
+            { document: { uri: vscode.Uri.from({ scheme: ZoweScheme.DS, path: "/profile/DATA.SET.TWO" }) } },
+        ]);
+        (BaseProvider as any).onCloseEvent.bind(fakeProvider)({
+            uri: vscode.Uri.from({ scheme: ZoweScheme.DS, query: "conflict=true", path: "/profile/DATA.SET" }),
+        });
+        expect(fakeProvider.onDocClosedEventDisposable.dispose).toHaveBeenCalled();
+        visibleTextEditorsMock[Symbol.dispose]();
+    });
+});

--- a/packages/zowe-explorer-api/src/fs/BaseProvider.ts
+++ b/packages/zowe-explorer-api/src/fs/BaseProvider.ts
@@ -306,7 +306,7 @@ export class BaseProvider {
                     fsEntry.inDiffView = false;
                 }
 
-                if (vscode.window.visibleTextEditors.every((editor) => !editor.document.uri.query.includes("conflict=true"))) {
+                if (vscode.window.visibleTextEditors.every((editor) => !editor.document.uri.query?.includes("conflict=true"))) {
                     vscode.commands.executeCommand("setContext", "zowe.vscode-extension-for-zowe.inConflict", false);
                     this.onDocClosedEventDisposable.dispose();
                 }

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -74,6 +74,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Addressed breaking changes from the Zowe Explorer API package.[#2952](https://github.com/zowe/zowe-explorer-vscode/issues/2952)
 - Fixed data set not opening when the token has expired. [#3001](https://github.com/zowe/zowe-explorer-vscode/issues/3001)
 - Fixed an issue where upgrading from Zowe Explorer v1 and selecting "Reload Extensions" causes Zowe Explorer v3 to fail during initialization. [#3051](https://github.com/zowe/zowe-explorer-vscode/pull/3051)
+- Fixed an issue where remote lookup functionality caused the local side of a conflict to be overwritten with the remote contents.
+- Fixed an issue where the remote conflict icons showed when using the "Compare with Selected" feature.
 
 ## `3.0.0-next.202404242037`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
@@ -570,6 +570,11 @@ describe("stat", () => {
         expect(lookupMock).toHaveBeenCalledWith(conflictUri, false);
         lookupMock.mockRestore();
     });
+    it("returns a file as-is when query has inDiff parameter", async () => {
+        const lookupMock = jest.spyOn(DatasetFSProvider.instance as any, "lookup").mockReturnValueOnce(testEntries.ps);
+        await expect(DatasetFSProvider.instance.stat(testUris.ps.with({ query: "inDiff=true" }))).resolves.toStrictEqual(testEntries.ps);
+        expect(lookupMock).toHaveBeenCalledWith(testUris.ps.with({ query: "inDiff=true" }), false);
+    });
     it("calls lookup for a profile URI", async () => {
         const lookupMock = jest.spyOn(DatasetFSProvider.instance as any, "lookup").mockReturnValue(testEntries.session);
         const res = await DatasetFSProvider.instance.stat(testUris.session);

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
@@ -94,6 +94,11 @@ describe("stat", () => {
         });
         expect(lookupMock).toHaveBeenCalledWith(testUris.conflictFile, false);
     });
+    it("returns a file as-is when query has inDiff parameter", async () => {
+        lookupMock.mockReturnValueOnce(testEntries.file);
+        await expect(UssFSProvider.instance.stat(testUris.file.with({ query: "inDiff=true" }))).resolves.toStrictEqual(testEntries.file);
+        expect(lookupMock).toHaveBeenCalledWith(testUris.file, false);
+    });
 });
 
 describe("move", () => {

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -684,12 +684,12 @@
         {
           "command": "zowe.diff.useLocalContent",
           "group": "navigation@0",
-          "when": "resourceScheme =~ /zowe-.*/ && isInDiffEditor"
+          "when": "resourceScheme =~ /zowe-.*/ && isInDiffEditor && zowe.vscode-extension-for-zowe.inConflict"
         },
         {
           "command": "zowe.diff.useRemoteContent",
           "group": "navigation@1",
-          "when": "resourceScheme =~ /zowe-.*/ && isInDiffEditor"
+          "when": "resourceScheme =~ /zowe-.*/ && isInDiffEditor && zowe.vscode-extension-for-zowe.inConflict"
         }
       ],
       "view/title": [

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -95,6 +95,8 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
             const queryParams = new URLSearchParams(uri.query);
             if (queryParams.has("conflict")) {
                 return { ...this.lookup(uri, false), permissions: vscode.FilePermission.Readonly };
+            } else if (queryParams.has("inDiff")) {
+                return this.lookup(uri, false);
             }
             isFetching = queryParams.has("fetch") && queryParams.get("fetch") === "true";
         }
@@ -389,7 +391,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         const isConflict = urlQuery.has("conflict");
 
         // we need to fetch the contents from the mainframe if the file hasn't been accessed yet
-        if (!file.wasAccessed || isConflict) {
+        if ((!file.wasAccessed && !urlQuery.has("inDiff")) || isConflict) {
             await this.fetchDatasetAtUri(uri, { isConflict });
             if (!isConflict) {
                 file.wasAccessed = true;

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -67,6 +67,8 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
             const queryParams = new URLSearchParams(uri.query);
             if (queryParams.has("conflict")) {
                 return { ...this.lookup(uri, false), permissions: vscode.FilePermission.Readonly };
+            } else if (queryParams.has("inDiff")) {
+                return this.lookup(uri, false);
             }
             isFetching = queryParams.has("fetch") && queryParams.get("fetch") === "true";
         }
@@ -315,7 +317,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         // Fetch contents from the mainframe if:
         // - the file hasn't been accessed yet
         // - fetching a conflict from the remote FS
-        if (!file.wasAccessed || isConflict) {
+        if ((!file.wasAccessed && !urlQuery.has("inDiff")) || isConflict) {
             await this.fetchFileAtUri(uri, { isConflict });
             if (!isConflict) {
                 file.wasAccessed = true;


### PR DESCRIPTION
## Proposed changes

- Fixes a bug with the BaseProvider where the new remote lookup functionality caused the local side of conflict to update during a conflict resolution.
- Fixes the issue where conflict icons show when comparing two files w/ a Zowe scheme.

## Release Notes

Milestone: vNext

Changelog:

- Fixed an issue where remote lookup functionality caused the local side of a conflict to be overwritten with the remote contents.
- Fixed an issue where the remote conflict icons showed when using the "Compare with Selected" feature.


## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
