### PR TITLE
fix(ux): Hide Zowe Resources panel until content is shown

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
+- Added placeholder text to the TableViewProvider (used for "Zowe Resources" panel) to provide clarity when a table is not visible. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
+
 ## `3.0.0-next.202409132122`
 
 ### New features and enhancements

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
-- Added placeholder text to the TableViewProvider (used for "Zowe Resources" panel) to provide clarity when a table is not visible. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
+- Updated the `TableViewProvider.setTableView` function to show the Zowe Resources panel if a table is provided. If `null` is passed, the Zowe Resources panel will be hidden. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
 
 ## `3.0.0-next.202409132122`
 

--- a/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
+++ b/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
@@ -102,6 +102,17 @@ export class TableViewProvider implements WebviewViewProvider {
 
         if (this.tableView != null) {
             this.tableView.resolveForView(this.view);
+        } else if (this.view) {
+            this.view.webview.html = `
+            <html>
+                <head>
+                </head>
+                <body>
+                    <p style="color: var(--vscode-debugIcon-breakpointDisabledForeground)">
+                        Execute a filter search in Zowe Explorer and select the "Show as table" option to present resources in this view.
+                    </p>
+                </body>
+            </html>`
         }
     }
 }

--- a/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
+++ b/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
@@ -48,7 +48,7 @@ export class TableViewProvider implements WebviewViewProvider {
                 </head>
                 <body>
                     <p style="color: var(--vscode-debugIcon-breakpointDisabledForeground)">
-                        Execute a filter search in Zowe Explorer and select the "Show as table" option to present resources in this view.
+                        Right-click on a profile in Zowe Explorer and select the "Show as table" option to present its search results in this view.
                     </p>
                 </body>
             </html>`;

--- a/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
+++ b/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
@@ -48,7 +48,7 @@ export class TableViewProvider implements WebviewViewProvider {
      * Retrieve the singleton instance of the TableViewProvider.
      * @returns the TableViewProvider instance used by Zowe Explorer
      */
-public static getInstance(): TableViewProvider {
+    public static getInstance(): TableViewProvider {
         if (!this.instance) {
             this.instance = new TableViewProvider();
         }

--- a/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
+++ b/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
@@ -42,6 +42,17 @@ export class TableViewProvider implements WebviewViewProvider {
 
     private static instance: TableViewProvider;
 
+    public static readonly FALLBACK_HTML = `
+            <html>
+                <head>
+                </head>
+                <body>
+                    <p style="color: var(--vscode-debugIcon-breakpointDisabledForeground)">
+                        Execute a filter search in Zowe Explorer and select the "Show as table" option to present resources in this view.
+                    </p>
+                </body>
+            </html>`;
+
     private constructor() {}
 
     /**
@@ -103,16 +114,7 @@ export class TableViewProvider implements WebviewViewProvider {
         if (this.tableView != null) {
             this.tableView.resolveForView(this.view);
         } else if (this.view) {
-            this.view.webview.html = `
-            <html>
-                <head>
-                </head>
-                <body>
-                    <p style="color: var(--vscode-debugIcon-breakpointDisabledForeground)">
-                        Execute a filter search in Zowe Explorer and select the "Show as table" option to present resources in this view.
-                    </p>
-                </body>
-            </html>`
+            this.view.webview.html = TableViewProvider.FALLBACK_HTML;
         }
     }
 }

--- a/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
+++ b/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
@@ -42,24 +42,13 @@ export class TableViewProvider implements WebviewViewProvider {
 
     private static instance: TableViewProvider;
 
-    public static readonly FALLBACK_HTML = `
-            <html>
-                <head>
-                </head>
-                <body>
-                    <p style="color: var(--vscode-debugIcon-breakpointDisabledForeground)">
-                        Right-click on a profile in Zowe Explorer and select the "Show as table" option to present its search results in this view.
-                    </p>
-                </body>
-            </html>`;
-
     private constructor() {}
 
     /**
      * Retrieve the singleton instance of the TableViewProvider.
      * @returns the TableViewProvider instance used by Zowe Explorer
      */
-    public static getInstance(): TableViewProvider {
+public static getInstance(): TableViewProvider {
         if (!this.instance) {
             this.instance = new TableViewProvider();
         }
@@ -81,8 +70,11 @@ export class TableViewProvider implements WebviewViewProvider {
             if (this.view != null) {
                 this.view.webview.html = "";
             }
+            await commands.executeCommand("setContext", "zowe.vscode-extension-for-zowe.showZoweResources", false);
             return;
         }
+
+        await commands.executeCommand("setContext", "zowe.vscode-extension-for-zowe.showZoweResources", true);
 
         if (this.view) {
             this.tableView.resolveForView(this.view);
@@ -113,8 +105,6 @@ export class TableViewProvider implements WebviewViewProvider {
 
         if (this.tableView != null) {
             this.tableView.resolveForView(this.view);
-        } else if (this.view) {
-            this.view.webview.html = TableViewProvider.FALLBACK_HTML;
         }
     }
 }

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Added placeholder text to the "Zowe Resources" panel to provide clarity when a table is not visible. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
+
 ## `3.0.0-next.202409132122`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
-- Added placeholder text to the "Zowe Resources" panel to provide clarity when a table is not visible. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
+- The "Zowe Resources" panel is now hidden by default until it is used to display a table or other data. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
 
 ## `3.0.0-next.202409132122`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
-- The "Zowe Resources" panel is now hidden by default until it is used to display a table or other data. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
+- The "Zowe Resources" panel is now hidden by default until Zowe Explorer reveals it to display a table or other data. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
 
 ## `3.0.0-next.202409132122`
 

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -73,7 +73,8 @@
         {
           "type": "webview",
           "id": "zowe-resources",
-          "name": "%zowe.resources.name%"
+          "name": "%zowe.resources.name%",
+          "when": "zowe.vscode-extension-for-zowe.showZoweResources"
         }
       ],
       "zowezosconsole": [


### PR DESCRIPTION
## Proposed changes

Hides the "Zowe Resources" panel until a table view is provided to the `TableViewProvider`.
We (as well as extenders) can also hide the panel by invoking `TableViewProvider.setTableView` with `null` as the parameter.

## Release Notes

Milestone: vNext

Changelog:

- Added placeholder text to the "Zowe Resources" panel to provide clarity when a table is not visible.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
