### PR TITLE
fix(v3): Continue refresh even when team config doesn't exist

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 - Added the `BaseProfileAuthOptions` interface to define base profile authentication options for SSO login and logout. [#3076](https://github.com/zowe/zowe-explorer-vscode/pull/3076)
 - Deprecated the methods `ZoweVsCodeExtension.loginWithBaseProfile` and `ZoweVsCodeExtension.logoutWithBaseProfile`. Use `ZoweVsCodeExtension.ssoLogin` and `ZoweVsCodeExtension.ssoLogout` instead, which use the `BaseProfileAuthOptions` interface and allow you to choose whether the token value in the base profile should have precedence in case there are conflicts. [#3076](https://github.com/zowe/zowe-explorer-vscode/pull/3076)
+- Fixed bug in `ProfilesCache` class where old profiles were still accessible after deleting a Team configuration file. [#3124](https://github.com/zowe/zowe-explorer-vscode/issues/3124)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -271,6 +271,9 @@ describe("ProfilesCache", () => {
             await profCache.refresh(fakeApiRegister as unknown as Types.IApiRegisterClient);
             expect(getTeamConfigMock).not.toHaveBeenCalled();
             expect(getProfileInfoMock).toHaveBeenCalled();
+            expect(profCache.allProfiles).toStrictEqual([]);
+            expect((profCache as any).profilesByType.size).toBe(0);
+            expect((profCache as any).defaultProfileByType.size).toBe(0);
         });
 
         it("should refresh profile data for multiple profile types", async () => {

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ProfilesCache.unit.test.ts
@@ -262,6 +262,17 @@ describe("ProfilesCache", () => {
             registeredApiTypes: jest.fn().mockReturnValue(profileTypes),
         };
 
+        it("should still try to refresh even if the team config doesn't exist", async () => {
+            const profCache = new ProfilesCache(fakeLogger as unknown as imperative.Logger);
+            const getTeamConfigMock = jest.spyOn(imperative.ProfileInfo.prototype, "getTeamConfig").mockReturnValue({
+                exists: false,
+            } as any);
+            const getProfileInfoMock = jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([]));
+            await profCache.refresh(fakeApiRegister as unknown as Types.IApiRegisterClient);
+            expect(getTeamConfigMock).not.toHaveBeenCalled();
+            expect(getProfileInfoMock).toHaveBeenCalled();
+        });
+
         it("should refresh profile data for multiple profile types", async () => {
             const profCache = new ProfilesCache(fakeLogger as unknown as imperative.Logger);
             jest.spyOn(profCache, "getProfileInfo").mockResolvedValue(createProfInfoMock([lpar1Profile, zftpProfile]));

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -146,9 +146,6 @@ export class ProfilesCache {
     public async refresh(apiRegister?: IRegisterClient): Promise<void> {
         const allProfiles: imperative.IProfileLoaded[] = [];
         const mProfileInfo = await this.getProfileInfo();
-        if (!mProfileInfo.getTeamConfig().exists) {
-            return;
-        }
         const allTypes = this.getAllProfileTypes(apiRegister?.registeredApiTypes() ?? []);
         allTypes.push("ssh");
         allTypes.push("base");

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - The "Zowe Resources" panel is now hidden by default until Zowe Explorer reveals it to display a table or other data. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
 - Fixed behavior of logout action when token is defined in both base profile and parent profile. [#3076](https://github.com/zowe/zowe-explorer-vscode/issues/3076)
-- Fixed bug where old profiles remained in the Zowe Explorer tree views after deleting a Team configuration file. [#3124](https://github.com/zowe/zowe-explorer-vscode/issues/3124)
+- Fixed bug that displayed obsolete profiles in the Zowe Explorer tree views after the associated team configuration file was deleted. [#3124](https://github.com/zowe/zowe-explorer-vscode/issues/3124)
 
 ## `3.0.0-next.202409132122`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - The "Zowe Resources" panel is now hidden by default until Zowe Explorer reveals it to display a table or other data. [#3113](https://github.com/zowe/zowe-explorer-vscode/issues/3113)
 - Fixed behavior of logout action when token is defined in both base profile and parent profile. [#3076](https://github.com/zowe/zowe-explorer-vscode/issues/3076)
+- Fixed bug where old profiles remained in the Zowe Explorer tree views after deleting a Team configuration file. [#3124](https://github.com/zowe/zowe-explorer-vscode/issues/3124)
 
 ## `3.0.0-next.202409132122`
 


### PR DESCRIPTION
## Proposed changes

Fixed a bug where old profiles remained in the Zowe Explorer tree views after deleting a Team configuration file. [#3124](https://github.com/zowe/zowe-explorer-vscode/issues/3124)

## How to test

Set a breakpoint at the end of `ProfilesCache.refresh` and then delete your team config.
Notice that at the end of the refresh call, all of the cache structures are emptied as a result. All profiles from that team config will be removed from the tree views.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: vNext

Changelogs:

- **ZE:** Fixed bug where old profiles remained in the Zowe Explorer tree views after deleting a Team configuration file. [#3124](https://github.com/zowe/zowe-explorer-vscode/issues/3124)
- **ZE API:** Fixed bug in `ProfilesCache` class where old profiles were still accessible after deleting a Team configuration file. [#3124](https://github.com/zowe/zowe-explorer-vscode/issues/3124)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):