### PR TITLE
Remove extRefresh cmd & FTP registration popup

### DIFF
--- a/packages/zowe-explorer-ftp-extension/CHANGELOG.md
+++ b/packages/zowe-explorer-ftp-extension/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "zowe-explorer-ftp-extension" extension will be docum
 
 ### Bug fixes
 
+- Removed popup notification of successful registration with Zowe Explorer and log the success instead. [#2862](https://github.com/zowe/zowe-explorer-vscode/issues/2862)
+
 ## `3.0.0-next.202409132122`
 
 ### New features and enhancements

--- a/packages/zowe-explorer-ftp-extension/src/extension.ts
+++ b/packages/zowe-explorer-ftp-extension/src/extension.ts
@@ -44,7 +44,7 @@ async function registerFtpApis(): Promise<boolean> {
         await zoweExplorerApi.getExplorerExtenderApi().initForZowe(pType, schema);
         await zoweExplorerApi.getExplorerExtenderApi().reloadProfiles(pType);
 
-        await Gui.showMessage("Zowe Explorer was modified for FTP support.", { logger: globals.LOGGER });
+        globals.LOGGER.logImperativeMessage("Zowe Explorer was modified for FTP support.", MessageSeverity.INFO);
 
         return true;
     }

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fix issue with extender profiles not being included in fresh team configuration file. [#3122](https://github.com/zowe/zowe-explorer-vscode/issues/3122)
 - Fixed issue where file extensions were removed from data sets, causing language detection to sometimes fail for Zowe Explorer extenders. [#3121](https://github.com/zowe/zowe-explorer-vscode/issues/3121)
 - Fixed an issue where copying and pasting a file/folder in the USS tree would fail abruptly, displaying an error. [#3128](https://github.com/zowe/zowe-explorer-vscode/issues/3128)
+- Removal of broken VSC command to `Zowe Explorer: Refresh Zowe Explorer`, use VS Code's `Extensions: Refresh` command instead. [#3100](https://github.com/zowe/zowe-explorer-vscode/issues/3100)
 
 ## `3.0.0-next.202409132122`
 

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -242,7 +242,6 @@ async function createGlobalMocks() {
             "zowe.compareWithSelectedReadOnly",
             "zowe.compareFileStarted",
             "zowe.placeholderCommand",
-            "zowe.extRefresh",
         ],
     };
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
@@ -18,7 +18,6 @@ import { Constants } from "../../../../src/configuration/Constants";
 import { Profiles } from "../../../../src/configuration/Profiles";
 import { SharedActions } from "../../../../src/trees/shared/SharedActions";
 import { LocalFileManagement } from "../../../../src/management/LocalFileManagement";
-import { ZoweLogger } from "../../../../src/tools/ZoweLogger";
 import { ZoweExplorerApiRegister } from "../../../../src/extending/ZoweExplorerApiRegister";
 import { SharedInit } from "../../../../src/trees/shared/SharedInit";
 import { TsoCommandHandler } from "../../../../src/commands/TsoCommandHandler";

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
@@ -319,44 +319,6 @@ describe("Test src/shared/extension", () => {
 
         processSubscriptions(commands, test);
     });
-    describe("registerRefreshCommand", () => {
-        const context: any = { subscriptions: [] };
-        const activate = jest.fn();
-        const deactivate = jest.fn();
-        const dispose = jest.fn();
-        let extRefreshCallback;
-        const spyExecuteCommand = jest.fn();
-
-        beforeAll(() => {
-            Object.defineProperty(vscode.commands, "registerCommand", {
-                value: (_: string, fun: () => void) => {
-                    extRefreshCallback = fun;
-                    return { dispose };
-                },
-            });
-            Object.defineProperty(vscode.commands, "executeCommand", { value: spyExecuteCommand });
-            SharedInit.registerRefreshCommand(context, activate, deactivate);
-        });
-
-        beforeEach(() => {
-            jest.clearAllMocks();
-        });
-
-        afterAll(() => {
-            jest.restoreAllMocks();
-        });
-
-        it("Test assuming we are unable to dispose of the subscription", async () => {
-            const testError = new Error("test");
-            dispose.mockRejectedValue(testError);
-            await extRefreshCallback();
-            expect(spyExecuteCommand).not.toHaveBeenCalled();
-            expect(deactivate).toHaveBeenCalled();
-            expect(ZoweLogger.error).toHaveBeenCalledWith(testError);
-            expect(dispose).toHaveBeenCalled();
-            expect(activate).toHaveBeenCalled();
-        });
-    });
 
     describe("watchConfigProfile", () => {
         let context: any;

--- a/packages/zowe-explorer/l10n/poeditor.json
+++ b/packages/zowe-explorer/l10n/poeditor.json
@@ -29,9 +29,6 @@
   "zowe.profileManagement": {
     "Manage Profile": ""
   },
-  "zowe.extRefresh": {
-    "Refresh Zowe Explorer": ""
-  },
   "zowe.editHistory": {
     "Edit History": ""
   },

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -112,11 +112,6 @@
         "when": "focusedView == zowe.uss.explorer"
       },
       {
-        "command": "zowe.extRefresh",
-        "key": "ctrl+alt+z",
-        "mac": "cmd+alt+z"
-      },
-      {
         "command": "zowe.editHistory",
         "key": "ctrl+alt+y",
         "mac": "cmd+alt+y"
@@ -167,15 +162,6 @@
         "command": "zowe.profileManagement",
         "title": "%zowe.profileManagement%",
         "category": "Zowe Explorer"
-      },
-      {
-        "command": "zowe.extRefresh",
-        "title": "%zowe.extRefresh%",
-        "category": "Zowe Explorer",
-        "icon": {
-          "light": "./resources/light/refresh.svg",
-          "dark": "./resources/dark/refresh.svg"
-        }
       },
       {
         "command": "zowe.editHistory",

--- a/packages/zowe-explorer/package.nls.json
+++ b/packages/zowe-explorer/package.nls.json
@@ -9,7 +9,6 @@
   "zowe.placeholderCommand": "Placeholder",
   "zowe.promptCredentials": "Update Credentials",
   "zowe.profileManagement": "Manage Profile",
-  "zowe.extRefresh": "Refresh Zowe Explorer",
   "zowe.editHistory": "Edit History",
   "zowe.ds.explorer": "Data Sets",
   "zowe.uss.explorer": "Unix System Services (USS)",

--- a/packages/zowe-explorer/src/configuration/Constants.ts
+++ b/packages/zowe-explorer/src/configuration/Constants.ts
@@ -17,7 +17,7 @@ import type { Profiles } from "./Profiles";
 
 export class Constants {
     public static CONFIG_PATH: string;
-    public static readonly COMMAND_COUNT = 100;
+    public static readonly COMMAND_COUNT = 99;
     public static readonly MAX_SEARCH_HISTORY = 5;
     public static readonly MAX_FILE_HISTORY = 10;
     public static readonly MS_PER_SEC = 1000;

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -50,7 +50,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
     );
     SharedInit.registerCommonCommands(context, providers);
     SharedInit.registerZosConsoleView(context);
-    SharedInit.registerRefreshCommand(context, activate, deactivate);
     ZoweExplorerExtender.createInstance(providers.ds, providers.uss, providers.job);
 
     SharedInit.watchConfigProfile(context);

--- a/packages/zowe-explorer/src/trees/shared/SharedInit.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedInit.ts
@@ -48,28 +48,6 @@ import { CertificateWizard } from "../../utils/CertificateWizard";
 import { ZosConsoleViewProvider } from "../../zosconsole/ZosConsolePanel";
 
 export class SharedInit {
-    public static registerRefreshCommand(
-        context: vscode.ExtensionContext,
-        activate: (_context: vscode.ExtensionContext) => Promise<ZoweExplorerApiRegister>,
-        deactivate: () => Promise<void>
-    ): void {
-        ZoweLogger.trace("shared.init.registerRefreshCommand called.");
-        // set a command to silently reload extension
-        context.subscriptions.push(
-            vscode.commands.registerCommand("zowe.extRefresh", async () => {
-                await deactivate();
-                for (const sub of context.subscriptions) {
-                    try {
-                        await sub.dispose();
-                    } catch (e) {
-                        ZoweLogger.error(e);
-                    }
-                }
-                await activate(context);
-            })
-        );
-    }
-
     public static registerCommonCommands(context: vscode.ExtensionContext, providers: Definitions.IZoweProviders): void {
         ZoweLogger.trace("shared.init.registerCommonCommands called.");
 


### PR DESCRIPTION
## Proposed changes

fix for #2862 & #3100 

log writing can be found at `~/.vscode/extension/zowe.zowe-explorer-ftp-extension-3.0.0-next-SNAPSHOT/logs`

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.0 GA

Changelog:

ZE - Removal of broken VSC command `Zowe Explorer: Refresh Zowe Explorer`, use VS Code's `Extensions: Refresh` command instead. [#3100](https://github.com/zowe/zowe-explorer-vscode/issues/3100)
zFTP - Removed popup notification of successful registration with Zowe Explorer and log the success instead. [#2862](https://github.com/zowe/zowe-explorer-vscode/issues/2862)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
