### PR TITLE
Add npm script to strip l10n comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ packages/zowe-explorer/__tests__/__integration__/ci
 !packages/zowe-explorer/__tests__/__integration__/ci/zowe.config.json
 package.nls.*.json
 bundle.l10n.*.json
+bundle.l10n.json.template
 zedc/target

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1810,7 +1810,8 @@
     "createTestProfileData": "tsx ./scripts/createTestProfileData.ts",
     "createDemoNodes": "tsx ./scripts/createDemoNodes.ts",
     "generateLocalization": "pnpm dlx @vscode/l10n-dev export --o ./l10n ./src && node ./scripts/generatePoeditorJson.js",
-    "copy-secrets": "tsx ./scripts/getSecretsPrebuilds.ts"
+    "copy-secrets": "tsx ./scripts/getSecretsPrebuilds.ts",
+    "strip-l10n": "node ./scripts/stripL10nComments.js"
   },
   "engines": {
     "vscode": "^1.79.0"

--- a/packages/zowe-explorer/scripts/stripL10nComments.js
+++ b/packages/zowe-explorer/scripts/stripL10nComments.js
@@ -1,0 +1,11 @@
+// Strip comments out of bundle.l10n.json and sort properties by key
+const fs = require("fs");
+const jsonFilePath = process.argv[2] || (__dirname + "/../l10n/bundle.l10n.json");
+let l10nBundle = JSON.parse(fs.readFileSync(jsonFilePath, "utf-8"));
+for (const [k, v] of Object.entries(l10nBundle)) {
+    if (typeof v === "object") {
+        l10nBundle[k] = l10nBundle[k].message;
+    }
+}
+l10nBundle = Object.fromEntries(Object.entries(l10nBundle).sort(([a], [b]) => a.localeCompare(b)));
+fs.writeFileSync(jsonFilePath + ".template", JSON.stringify(l10nBundle, null, 2) + "\n");


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Adds a script that strips comments out of `bundle.l10n.json`, sorts properties by key, and saves a new file `bundle.l10n.json.template`.

Use this command to run the script from top level of repo: `pnpm --filter vscode-extension-for-zowe strip-l10n`

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.0.0

Changelog: N/A

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [x] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
