### PR TITLE
fix(profiles): Pass `homeDir, projectDir` when creating `ProfileInfo` instance

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed an issue where Zowe Explorer displayed a "No Zowe client configurations" prompt when a project, user-level config exists but no global config was present. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
+- Fixed an issue where `ProfilesUtils.getProfileInfo` returned a new `ProfileInfo` instance that did not respect the home directory or workspace paths. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
+
 ## `3.0.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ### Bug fixes
 
 - Fixed an issue where Zowe Explorer displayed a "No Zowe client configurations" prompt when a project, user-level config exists but no global config was present. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
-- Fixed an issue where `ProfilesUtils.getProfileInfo` returned a new `ProfileInfo` instance that did not respect the home directory or workspace paths. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
+- Fixed an issue where the `ProfilesUtils.getProfileInfo` function returned a new `ProfileInfo` instance that did not respect the `ZOWE_CLI_HOME` environment variable and workspace paths. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
 
 ## `3.0.0`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
-- Fixed an issue where Zowe Explorer displayed a "No Zowe client configurations" prompt when a project, user-level config exists but no global config was present. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
-- Fixed an issue where the `ProfilesUtils.getProfileInfo` function returned a new `ProfileInfo` instance that did not respect the `ZOWE_CLI_HOME` environment variable and workspace paths. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
+- Fixed an issue where Zowe Explorer displayed a "No Zowe client configurations" prompt when a project user configuration existed but no global configuration was present. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
+- Fixed an issue where the `ProfilesUtils.getProfileInfo` function returned a new `ProfileInfo` instance that ignored the `ZOWE_CLI_HOME` environment variable and workspace paths. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
 
 ## `3.0.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -13,7 +13,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as util from "util";
 import * as vscode from "vscode";
-import { Gui, imperative, ProfilesCache, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
+import { FileManagement, Gui, imperative, ProfilesCache, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import { createAltTypeIProfile, createInstanceOfProfile, createValidIProfile } from "../../__mocks__/mockCreators/shared";
 import { MockedProperty } from "../../__mocks__/mockUtils";
 import { Constants } from "../../../src/configuration/Constants";
@@ -248,6 +248,7 @@ describe("ProfilesUtils unit tests", () => {
             value: [
                 {
                     uri: {
+                        scheme: "file",
                         fsPath: "./test",
                     },
                 },
@@ -1312,6 +1313,17 @@ describe("ProfilesUtils unit tests", () => {
             expect(profInfoMock).toHaveBeenCalled();
             profInfoMock.mockRestore();
             onlyV1ProfsExistMock[Symbol.dispose]();
+        });
+    });
+
+    describe("setupDefaultCredentialManager", () => {
+        it("calls readProfilesFromDisk with homeDir and projectDir", async () => {
+            const readProfilesFromDiskMock = jest.spyOn(imperative.ProfileInfo.prototype, "readProfilesFromDisk").mockImplementation();
+            await ProfilesUtils.setupDefaultCredentialManager();
+            expect(readProfilesFromDiskMock).toHaveBeenCalledWith({
+                homeDir: FileManagement.getZoweDir(),
+                projectDir: vscode.workspace.workspaceFolders?.[0].uri.fsPath,
+            });
         });
     });
 });

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -187,8 +187,13 @@ export class ProfilesUtils {
             const profileInfo = new imperative.ProfileInfo("zowe", {
                 credMgrOverride: defaultCredentialManager,
             });
+
+            const workspacePath = ZoweVsCodeExtension.workspaceRoot?.uri.fsPath;
             // Trigger initialize() function of credential manager to throw an error early if failed to load
-            await profileInfo.readProfilesFromDisk();
+            await profileInfo.readProfilesFromDisk({
+                homeDir: FileManagement.getZoweDir(),
+                projectDir: workspacePath ? FileManagement.getFullPath(workspacePath) : undefined,
+            });
             return profileInfo;
         } catch (err) {
             if (err instanceof imperative.ProfInfoErr && err.errorCode === imperative.ProfInfoErr.LOAD_CRED_MGR_FAILED) {


### PR DESCRIPTION
## Proposed changes

Fixed a bug where a new `ProfileInfo` instance was being created when initializing Zowe profiles, but that instance was missing the `homeDir` and `projectDir` from its constructor options.

## Release Notes

Milestone: 3.0.1

Changelog:

- Fixed an issue where Zowe Explorer displayed a "No Zowe client configurations" prompt when a project user configuration existed but no global configuration was present. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
- Fixed an issue where the `ProfilesUtils.getProfileInfo` function returned a new `ProfileInfo` instance that ignored the `ZOWE_CLI_HOME` environment variable and workspace paths. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [x] These changes may need ported to the appropriate branches (list here): `v2-lts`