### PR TITLE
[v2] fix(profiles): Pass `homeDir, projectDir` when creating `ProfileInfo` instance

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 ### Bug fixes
 
 - Fix issue where the Zowe Explorer VS Code command `Refresh Zowe Explorer` failed catastrophically. [#3100](https://github.com/zowe/zowe-explorer-vscode/issues/3100)
+- Fixed an issue where the `ProfilesUtils.getProfileInfo` function returned a new `ProfileInfo` instance that did not respect the `ZOWE_CLI_HOME` environment variable and workspace paths. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)
 
 ## `2.18.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -1077,4 +1077,15 @@ describe("ProfilesUtils unit tests", () => {
             );
         });
     });
+
+    describe("setupDefaultCredentialManager", () => {
+        it("calls readProfilesFromDisk with homeDir and projectDir", async () => {
+            const readProfilesFromDiskMock = jest.spyOn(zowe.imperative.ProfileInfo.prototype, "readProfilesFromDisk").mockImplementation();
+            await profUtils.ProfilesUtils.setupDefaultCredentialManager();
+            expect(readProfilesFromDiskMock).toHaveBeenCalledWith({
+                homeDir: zowe.getZoweDir(),
+                projectDir: vscode.workspace.workspaceFolders?.[0].uri.fsPath,
+            });
+        });
+    });
 });

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -371,8 +371,12 @@ export class ProfilesUtils {
             const profileInfo = new imperative.ProfileInfo("zowe", {
                 credMgrOverride: defaultCredentialManager,
             });
+            const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
             // Trigger initialize() function of credential manager to throw an error early if failed to load
-            await profileInfo.readProfilesFromDisk();
+            await profileInfo.readProfilesFromDisk({
+                homeDir: getZoweDir(),
+                projectDir: workspaceFolder ? getFullPath(workspaceFolder) : undefined,
+            });
             return profileInfo;
         } catch (err) {
             if (err instanceof imperative.ProfInfoErr && err.errorCode === imperative.ProfInfoErr.LOAD_CRED_MGR_FAILED) {


### PR DESCRIPTION
## Proposed changes

Fixed a bug where a new `ProfileInfo` instance was being created when initializing Zowe profiles, but that instance was missing the `homeDir` and `projectDir` from its constructor options.

## Release Notes

Milestone: 2.18.1

Changelog:

- Fixed an issue where `ProfilesUtils.getProfileInfo` returned a new `ProfileInfo` instance that did not respect the home directory or workspace paths. [#3168](https://github.com/zowe/zowe-explorer-vscode/issues/3168)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):