### PR TITLE
Fix children in tree nodes persisting on error

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
@@ -149,6 +149,10 @@ describe("ZoweDatasetNode Unit Tests", () => {
             profile: profileOne,
         });
         jest.spyOn(zosfiles.List, "allMembers").mockRejectedValueOnce(new Error(subNode.label as string));
+        // Populate node with children from previous search to ensure they are removed
+        subNode.children = [
+            new ZoweDatasetNode({ label: "old", collapsibleState: vscode.TreeItemCollapsibleState.None, session, profile: profileOne }),
+        ];
         subNode.dirty = true;
         const response = await subNode.getChildren();
         expect(response).toEqual([]);

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/ZoweJobNode.unit.test.ts
@@ -30,7 +30,7 @@ import { Profiles } from "../../../../src/configuration/Profiles";
 import { ZoweExplorerApiRegister } from "../../../../src/extending/ZoweExplorerApiRegister";
 import { ZoweLocalStorage } from "../../../../src/tools/ZoweLocalStorage";
 import { JobFSProvider } from "../../../../src/trees/job/JobFSProvider";
-import { ZoweJobNode } from "../../../../src/trees/job/ZoweJobNode";
+import { ZoweJobNode, ZoweSpoolNode } from "../../../../src/trees/job/ZoweJobNode";
 import { SharedContext } from "../../../../src/trees/shared/SharedContext";
 import { SharedTreeProviders } from "../../../../src/trees/shared/SharedTreeProviders";
 import { JobInit } from "../../../../src/trees/job/JobInit";
@@ -392,6 +392,15 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
         jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({
             getSpoolFiles: jest.fn().mockResolvedValue(new Error("Response Fail")),
         } as any);
+        // Populate node with children from previous search to ensure they are removed
+        globalMocks.testJobNode.children = [
+            new ZoweSpoolNode({
+                label: "old",
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                session: globalMocks.testSession,
+                profile: globalMocks.testProfile,
+            }),
+        ];
         globalMocks.testJobNode.dirty = true;
         const spools = await globalMocks.testJobNode.getChildren();
         expect(spools).toEqual([]);
@@ -442,6 +451,15 @@ describe("ZoweJobNode unit tests - Function getChildren", () => {
     it("should return empty list if there is error retrieving jobs", async () => {
         const globalMocks = await createGlobalMocks();
         await globalMocks.testJobsProvider.addSession("fake");
+        // Populate node with children from previous search to ensure they are removed
+        globalMocks.testJobsProvider.mSessionNodes[1].children = [
+            new ZoweJobNode({
+                label: "old",
+                collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                session: globalMocks.testSession,
+                profile: globalMocks.testProfile,
+            }),
+        ];
         globalMocks.testJobsProvider.mSessionNodes[1].filtered = true;
         globalMocks.mockGetJobsByParameters.mockRejectedValue(new Error("Response Fail"));
         jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce({

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
@@ -1685,6 +1685,7 @@ describe("USSTree Unit Tests - Function crossLparMove", () => {
                 profile: ussDirNode.getProfile(),
             }),
         ];
+        ussDirNode.dirty = false;
 
         const deleteMock = jest.spyOn(UssFSProvider.instance, "delete").mockResolvedValue(undefined);
         const readFileMock = jest.spyOn(UssFSProvider.instance, "readFile").mockResolvedValue(new Uint8Array([1, 2, 3]));

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/ZoweUSSNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/ZoweUSSNode.unit.test.ts
@@ -25,7 +25,7 @@ import {
     createInstanceOfProfile,
     createValidIProfile,
 } from "../../../__mocks__/mockCreators/shared";
-import { createUSSTree } from "../../../__mocks__/mockCreators/uss";
+import { createUSSNode, createUSSTree } from "../../../__mocks__/mockCreators/uss";
 import { Constants } from "../../../../src/configuration/Constants";
 import { ZoweLocalStorage } from "../../../../src/tools/ZoweLocalStorage";
 import { UssFSProvider } from "../../../../src/trees/uss/UssFSProvider";
@@ -846,6 +846,8 @@ describe("ZoweUSSNode Unit Tests - Function node.getChildren()", () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks(globalMocks);
 
+        // Populate node with children from previous search to ensure they are removed
+        blockMocks.childNode.children = [createUSSNode(globalMocks.session, globalMocks.profileOne)];
         blockMocks.childNode.contextValue = Constants.USS_SESSION_CONTEXT;
         blockMocks.childNode.fullPath = "Throw Error";
         blockMocks.childNode.dirty = true;
@@ -854,7 +856,8 @@ describe("ZoweUSSNode Unit Tests - Function node.getChildren()", () => {
             throw new Error("Throwing an error to check error handling for unit tests!");
         });
 
-        await blockMocks.childNode.getChildren();
+        const response = await blockMocks.childNode.getChildren();
+        expect(response).toEqual([]);
         expect(globalMocks.showErrorMessage.mock.calls.length).toEqual(1);
         expect(globalMocks.showErrorMessage.mock.calls[0][0]).toEqual(
             "Retrieving response from USS list API Error: Throwing an error to check error handling for unit tests!"

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -230,7 +230,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
         const cachedProfile = Profiles.getInstance().loadNamedProfile(this.getProfileName());
         const responses = await this.getDatasets(cachedProfile);
         if (responses == null) {
-            return this.children;
+            return [];
         }
 
         // push nodes to an object with property names to avoid duplicates

--- a/packages/zowe-explorer/src/trees/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/trees/job/ZoweJobNode.ts
@@ -139,7 +139,7 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
             // Fetch spool files under job node
             const spools = await this.getSpoolFiles(this.job);
             if (spools == null) {
-                return this.children;
+                return [];
             } else if (!spools.length) {
                 const noSpoolNode = new ZoweSpoolNode({
                     label: vscode.l10n.t("No spool files found"),
@@ -192,7 +192,7 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
             // Fetch jobs under session node
             const jobs = await this.getJobs(this._owner, this._prefix, this._searchId, this._jobStatus);
             if (jobs == null) {
-                return this.children;
+                return [];
             } else if (jobs.length === 0) {
                 const noJobsNode = new ZoweJobNode({
                     label: vscode.l10n.t("No jobs found"),

--- a/packages/zowe-explorer/src/trees/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/trees/uss/ZoweUSSNode.ts
@@ -206,7 +206,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         const cachedProfile = Profiles.getInstance().loadNamedProfile(this.getProfileName());
         const response = await this.getUssFiles(cachedProfile);
         if (!response.success) {
-            return this.children;
+            return [];
         }
 
         // If search path has changed, invalidate all children


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Fixes an issue where if you search for jobs with a valid ID, and then search a second time with an invalid job ID, the results from the first search persist instead of emptying the list of child nodes.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.0.1

Changelog: N/A since this issue does not exist in 3.0.0

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
