### PR TITLE
fix(ci): Use `ubuntu-22.04` images to get access to libsecret

### DIFF
--- a/.github/workflows/zowe-explorer-ci.yml
+++ b/.github/workflows/zowe-explorer-ci.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
         # order operating systems from best to worst
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-22.04, macos-latest]
 
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository) && !contains(github.event.head_commit.message, '[ci skip]')
 

--- a/.github/workflows/zowe-explorer-ci.yml
+++ b/.github/workflows/zowe-explorer-ci.yml
@@ -51,24 +51,24 @@ jobs:
 
       - name: Unlock Keyring
         id: unlock-keyring
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
+        if: matrix.os == 'ubuntu-22.04' && matrix.node-version == '20.x'
         uses: t1m0thyj/unlock-keyring@v1
       
       - name: Integration tests
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
+        if: matrix.os == 'ubuntu-22.04' && matrix.node-version == '20.x'
         run: xvfb-run pnpm test:integration --exclude "Activation.feature"
         working-directory: packages/zowe-explorer
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
+        if: matrix.os == 'ubuntu-22.04' && matrix.node-version == '20.x'
         with:
           name: zowe-explorer-results
           path: packages/zowe-explorer/results/
 
       - name: Upload API test results
         uses: actions/upload-artifact@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
+        if: matrix.os == 'ubuntu-22.04' && matrix.node-version == '20.x'
         with:
           name: zowe-explorer-api-results
           path: packages/zowe-explorer-api/results/
@@ -80,12 +80,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Package VSIX
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
+        if: matrix.os == 'ubuntu-22.04' && matrix.node-version == '20.x'
         run: pnpm package
         working-directory: packages/zowe-explorer
 
       - name: Archive VSIX artifact
-        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '20.x'
+        if: matrix.os == 'ubuntu-22.04' && matrix.node-version == '20.x'
         uses: actions/upload-artifact@v4
         with:
           name: zowe-explorer-vsix


### PR DESCRIPTION
## Proposed changes

`libsecret` was removed from the Ubuntu 24.04 runner images. For the time being, we can use the `ubuntu-22.04` image in CI until we get clarification on whether this change was intentional.
