### PR TITLE
fix: add ProfileInfo.getTeamConfig.exists check to v1 profile prompt

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -351,6 +351,11 @@ async function createGlobalMocks() {
             "zowe.automaticProfileValidation": true,
         }),
     });
+    jest.spyOn(ProfilesUtils, "getProfileInfo").mockResolvedValue({
+        getTeamConfig: jest.fn().mockReturnValue({
+            exists: jest.fn(),
+        }),
+    } as any);
     Object.defineProperty(globalMocks.mockProfilesCache, "getProfileInfo", {
         value: jest.fn(() => {
             return { value: globalMocks.mockProfCacheProfileInfo, configurable: true };


### PR DESCRIPTION
## Proposed changes

Works around a bug with `imperative.ProfileInfo.onlyV1ProfilesExist` - it currently looks at the team config on `ImperativeConfig.instance`, but this is not defined through Zowe Explorer, so the getter function ignores presence of a team config.

## Release Notes

Milestone: 3.0.2

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have ~added~ updated new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
