### PR TITLE
Allow deployment workflow to be triggered manually

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -11,11 +11,11 @@ on:
       - .github/release.config.js
       - .github/workflows/deployment.yml
       - lerna.json
-  # workflow_dispatch:
-  #   inputs:
-  #     version:
-  #       description: Override version to be published
-  #       required: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Override version to be published
+        required: false
 
 jobs:
   release:
@@ -27,6 +27,12 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Check permissions
+        if: ${{ github.event_name == 'workflow-dispatch' }}
+        uses: prince-chrismc/check-actor-permissions-action@v3
+        with:
+          permission: admin
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Updates our deployment workflow to allow it to be triggered manually only by repo admins.

Merging this PR into `main` branch should allow the deployment workflow to be triggered for any other branch.