### PR TITLE
fix: use `vscode.workspace.fs` for `delete` and `rename`

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where the contents of an editor did not update when polling spool content or using the "Pull from Mainframe" action with jobs. [#3249](https://github.com/zowe/zowe-explorer-vscode/pull/3249)
 - Fixed an issue where Zowe Explorer sometimes prompted the user to convert V1 profiles when changes were made to a team configuration after initialization. [#3246](https://github.com/zowe/zowe-explorer-vscode/pull/3246)
 - Fixed an issue where the encoding of a USS file was not automatically detected when opened for the first time. [#3253](https://github.com/zowe/zowe-explorer-vscode/pull/3253)
+- Fixed an issue where renaming a USS file or data set did not update the opened editor with the new location. [#3260](https://github.com/zowe/zowe-explorer-vscode/issues/3260)
 
 ## `3.0.1`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where the contents of an editor did not update when polling spool content or using the "Pull from Mainframe" action with jobs. [#3249](https://github.com/zowe/zowe-explorer-vscode/pull/3249)
 - Fixed an issue where Zowe Explorer sometimes prompted the user to convert V1 profiles when changes were made to a team configuration after initialization. [#3246](https://github.com/zowe/zowe-explorer-vscode/pull/3246)
 - Fixed an issue where the encoding of a USS file was not automatically detected when opened for the first time. [#3253](https://github.com/zowe/zowe-explorer-vscode/pull/3253)
-- Fixed an issue where renaming a USS file or data set did not update the opened editor with the new location. [#3260](https://github.com/zowe/zowe-explorer-vscode/issues/3260)
+- Fixed an issue where renaming or deleting a USS file or data set did not update the opened editor. [#3260](https://github.com/zowe/zowe-explorer-vscode/issues/3260)
 
 ## `3.0.1`
 

--- a/packages/zowe-explorer/__tests__/__mocks__/vscode.ts
+++ b/packages/zowe-explorer/__tests__/__mocks__/vscode.ts
@@ -1498,6 +1498,11 @@ export namespace workspace {
     }
 }
 
+// We need to do this since "delete" is a reserved keyword and cannot be defined as a function name.
+Object.defineProperty(workspace.fs, "delete", {
+    value: jest.fn(),
+});
+
 export interface InputBoxOptions {
     placeholder?: string;
 }

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
@@ -66,7 +66,7 @@ function createGlobalMocks() {
         testFavoritesNode: createDatasetFavoritesNode(),
         testDatasetTree: null,
         getContentsSpy: null,
-        fspDelete: jest.spyOn(DatasetFSProvider.prototype, "delete").mockImplementation(),
+        fspDelete: jest.spyOn(vscode.workspace.fs, "delete").mockImplementation(),
         statusBarMsgSpy: null,
         mvsApi: null,
         mockShowWarningMessage: jest.fn(),
@@ -96,7 +96,6 @@ function createGlobalMocks() {
         value: newMocks.mockShowWarningMessage,
         configurable: true,
     });
-    Object.defineProperty(vscode.workspace.fs, "delete", { value: jest.fn(), configurable: true });
     Object.defineProperty(vscode.window, "showInputBox", { value: jest.fn(), configurable: true });
     Object.defineProperty(vscode.workspace, "openTextDocument", { value: jest.fn(), configurable: true });
     Object.defineProperty(vscode.workspace, "getConfiguration", { value: jest.fn(), configurable: true });
@@ -487,7 +486,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         blockMocks.testDatasetTree.getTreeView.mockReturnValueOnce(treeView);
         globalMocks.mockShowWarningMessage.mockResolvedValueOnce("Delete");
 
-        jest.spyOn(DatasetFSProvider.instance, "delete").mockImplementation();
+        jest.spyOn(vscode.workspace.fs, "delete").mockImplementation();
         await DatasetActions.deleteDatasetPrompt(blockMocks.testDatasetTree);
 
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith(
@@ -721,7 +720,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
         });
 
         mocked(vscode.window.showQuickPick).mockResolvedValueOnce("Delete" as any);
-        const deleteSpy = jest.spyOn(DatasetFSProvider.instance, "delete").mockImplementation();
+        const deleteSpy = jest.spyOn(vscode.workspace.fs, "delete").mockImplementation();
         await DatasetActions.deleteDataset(node, blockMocks.testDatasetTree);
         expect(deleteSpy).toHaveBeenCalledWith(node.resourceUri, { recursive: false });
     });
@@ -737,7 +736,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
         });
 
         mocked(vscode.window.showQuickPick).mockResolvedValueOnce("Delete" as any);
-        const deleteSpy = jest.spyOn(DatasetFSProvider.instance, "delete").mockImplementation();
+        const deleteSpy = jest.spyOn(vscode.workspace.fs, "delete").mockImplementation();
         await DatasetActions.deleteDataset(node, blockMocks.testDatasetTree);
         expect(deleteSpy).toHaveBeenCalledWith(node.resourceUri, { recursive: false });
     });
@@ -753,7 +752,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
         });
 
         mocked(vscode.window.showQuickPick).mockResolvedValueOnce("Delete" as any);
-        jest.spyOn(DatasetFSProvider.instance, "delete").mockRejectedValueOnce(Error("not found"));
+        jest.spyOn(vscode.workspace.fs, "delete").mockRejectedValueOnce(Error("not found"));
         await expect(DatasetActions.deleteDataset(node, blockMocks.testDatasetTree)).rejects.toThrow("not found");
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith("Unable to find file " + node.label?.toString());
     });
@@ -769,7 +768,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
         });
 
         mocked(vscode.window.showQuickPick).mockResolvedValueOnce("Delete" as any);
-        jest.spyOn(DatasetFSProvider.instance, "delete").mockRejectedValueOnce(Error(""));
+        jest.spyOn(vscode.workspace.fs, "delete").mockRejectedValueOnce(Error(""));
         await expect(DatasetActions.deleteDataset(node, blockMocks.testDatasetTree)).rejects.toThrow("");
         expect(mocked(Gui.errorMessage)).toHaveBeenCalledWith("Error");
     });
@@ -792,7 +791,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
         node.contextValue = Constants.DS_PDS_CONTEXT + Constants.FAV_SUFFIX;
 
         mocked(vscode.window.showQuickPick).mockResolvedValueOnce("Delete" as any);
-        const deleteSpy = jest.spyOn(DatasetFSProvider.instance, "delete");
+        const deleteSpy = jest.spyOn(vscode.workspace.fs, "delete");
 
         await DatasetActions.deleteDataset(node, blockMocks.testDatasetTree);
 
@@ -812,7 +811,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
         const child = new ZoweDatasetNode({ label: "child", collapsibleState: vscode.TreeItemCollapsibleState.None, parentNode: parent });
 
         mocked(vscode.window.showQuickPick).mockResolvedValueOnce("Delete" as any);
-        const deleteSpy = jest.spyOn(DatasetFSProvider.instance, "delete").mockImplementation();
+        const deleteSpy = jest.spyOn(vscode.workspace.fs, "delete").mockImplementation();
 
         await DatasetActions.deleteDataset(child, blockMocks.testDatasetTree);
         expect(deleteSpy).toHaveBeenCalledWith(child.resourceUri, { recursive: false });
@@ -841,7 +840,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
         blockMocks.testDatasetTree.mFavorites[0].children.push(child);
 
         mocked(vscode.window.showQuickPick).mockResolvedValueOnce("Delete" as any);
-        const deleteSpy = jest.spyOn(DatasetFSProvider.instance, "delete").mockImplementation();
+        const deleteSpy = jest.spyOn(vscode.workspace.fs, "delete").mockImplementation();
         await DatasetActions.deleteDataset(child, blockMocks.testDatasetTree);
         expect(deleteSpy).toHaveBeenCalledWith(child.resourceUri, { recursive: false });
         expect(blockMocks.testDatasetTree.removeFavorite).toHaveBeenCalledWith(child);
@@ -864,7 +863,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
         });
 
         mocked(vscode.window.showQuickPick).mockResolvedValueOnce("Delete" as any);
-        const deleteSpy = jest.spyOn(DatasetFSProvider.instance, "delete").mockImplementation();
+        const deleteSpy = jest.spyOn(vscode.workspace.fs, "delete").mockImplementation();
         deleteSpy.mockClear();
         await expect(DatasetActions.deleteDataset(child, blockMocks.testDatasetTree)).rejects.toThrow("Cannot delete, item invalid.");
         expect(deleteSpy).not.toHaveBeenCalled();

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
@@ -2234,7 +2234,7 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
             mvsApi,
             profileInstance,
             mockCheckCurrentProfile,
-            rename: jest.spyOn(DatasetFSProvider.instance, "rename").mockImplementation(),
+            rename: jest.spyOn(vscode.workspace.fs, "rename").mockImplementation(),
         };
     }
 
@@ -2481,7 +2481,7 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
         favProfileNode.children.push(favParent);
         testTree.mFavorites.push(favProfileNode);
         const renameDataSetMemberSpy = jest.spyOn((DatasetTree as any).prototype, "renameDataSetMember");
-        const renameMock = jest.spyOn(DatasetFSProvider.instance, "rename").mockImplementation();
+        const renameMock = jest.spyOn(vscode.workspace.fs, "rename").mockImplementation();
 
         await testTree.rename(child);
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/JobFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/JobFSProvider.unit.test.ts
@@ -321,7 +321,7 @@ describe("delete", () => {
         const lookupParentDirMock = jest
             .spyOn(JobFSProvider.instance as any, "_lookupParentDirectory")
             .mockReturnValueOnce({ ...testEntries.session });
-        await JobFSProvider.instance.delete(testUris.job, { recursive: true, deleteRemote: true });
+        await JobFSProvider.instance.delete(testUris.job, { recursive: true });
         const jobInfo = testEntries.job.job;
         expect(jobInfo).not.toBeUndefined();
         expect(mockUssApi.deleteJob).toHaveBeenCalledWith(jobInfo?.jobname || "TESTJOB", jobInfo?.jobid || "JOB12345");
@@ -341,7 +341,7 @@ describe("delete", () => {
         fakeJob.job = testEntries.job.job;
         const lookupMock = jest.spyOn(JobFSProvider.instance as any, "lookup").mockReturnValueOnce(fakeSpool);
         const lookupParentDirMock = jest.spyOn(JobFSProvider.instance as any, "_lookupParentDirectory").mockReturnValueOnce(fakeJob);
-        await JobFSProvider.instance.delete(testUris.spool, { recursive: true, deleteRemote: true });
+        await JobFSProvider.instance.delete(testUris.spool, { recursive: true });
         expect(mockUssApi.deleteJob).not.toHaveBeenCalled();
         expect(lookupParentDirMock).not.toHaveBeenCalled();
         ussApiMock.mockRestore();

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/JobTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/JobTree.unit.test.ts
@@ -135,7 +135,7 @@ async function createGlobalMocks() {
     };
 
     jest.spyOn(JobFSProvider.instance, "createDirectory").mockImplementation(globalMocks.FileSystemProvider.createDirectory);
-    jest.spyOn(JobFSProvider.instance, "delete").mockImplementation(globalMocks.FileSystemProvider.delete);
+    jest.spyOn(vscode.workspace.fs, "delete").mockImplementation(globalMocks.FileSystemProvider.delete);
     jest.spyOn(Gui, "createTreeView").mockImplementation(globalMocks.createTreeView);
     Object.defineProperty(ProfilesCache, "getConfigInstance", {
         value: jest.fn(() => {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
@@ -104,7 +104,7 @@ function createGlobalMocks() {
     };
 
     jest.spyOn(UssFSProvider.instance, "createDirectory").mockImplementation(globalMocks.FileSystemProvider.createDirectory);
-    jest.spyOn(UssFSProvider.instance, "rename").mockImplementation(globalMocks.FileSystemProvider.rename);
+    jest.spyOn(vscode.workspace.fs, "rename").mockImplementation(globalMocks.FileSystemProvider.rename);
 
     globalMocks.mockTextDocuments.push(globalMocks.mockTextDocumentDirty);
     globalMocks.mockTextDocuments.push(globalMocks.mockTextDocumentClean);
@@ -1690,7 +1690,7 @@ describe("USSTree Unit Tests - Function crossLparMove", () => {
         ];
         ussDirNode.dirty = false;
 
-        const deleteMock = jest.spyOn(UssFSProvider.instance, "delete").mockResolvedValue(undefined);
+        const deleteMock = jest.spyOn(vscode.workspace.fs, "delete").mockResolvedValue(undefined);
         const readFileMock = jest.spyOn(UssFSProvider.instance, "readFile").mockResolvedValue(new Uint8Array([1, 2, 3]));
         const writeFileMock = jest.spyOn(UssFSProvider.instance, "writeFile").mockResolvedValue(undefined);
         const existsMock = jest.spyOn(UssFSProvider.instance, "exists").mockReturnValueOnce(false);

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/ZoweUSSNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/ZoweUSSNode.unit.test.ts
@@ -430,7 +430,7 @@ describe("ZoweUSSNode Unit Tests - Function node.rename()", () => {
                 uss: { addSingleSession: jest.fn(), mSessionNodes: [], refresh: jest.fn() } as any,
                 job: { addSingleSession: jest.fn(), mSessionNodes: [], refresh: jest.fn() } as any,
             }),
-            renameSpy: jest.spyOn(UssFSProvider.instance, "rename").mockImplementation(),
+            renameSpy: jest.spyOn(vscode.workspace.fs, "rename").mockImplementation(),
             getEncodingForFile: jest.spyOn(UssFSProvider.instance as any, "getEncodingForFile").mockReturnValue(undefined),
         };
         newMocks.ussDir.contextValue = Constants.USS_DIR_CONTEXT;
@@ -443,7 +443,7 @@ describe("ZoweUSSNode Unit Tests - Function node.rename()", () => {
 
         const newFullPath = "/u/user/newName";
         const errMessageMock = jest.spyOn(Gui, "errorMessage").mockImplementation();
-        const renameMock = jest.spyOn(UssFSProvider.instance, "rename").mockRejectedValueOnce(new Error("Rename error: file is busy"));
+        const renameMock = jest.spyOn(vscode.workspace.fs, "rename").mockRejectedValueOnce(new Error("Rename error: file is busy"));
         await blockMocks.ussDir.rename(newFullPath);
 
         expect(errMessageMock).toHaveBeenCalledWith("Rename error: file is busy");
@@ -631,7 +631,7 @@ describe("ZoweUSSNode Unit Tests - Function node.deleteUSSNode()", () => {
                 session: globalMocks.session,
                 profile: globalMocks.profileOne,
             }),
-            fspDelete: jest.spyOn(UssFSProvider.instance, "delete").mockImplementation(),
+            fspDelete: jest.spyOn(vscode.workspace.fs, "delete").mockImplementation(),
         };
 
         newMocks.ussNode = new ZoweUSSNode({
@@ -679,7 +679,7 @@ describe("ZoweUSSNode Unit Tests - Function node.deleteUSSNode()", () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks(globalMocks);
         globalMocks.mockShowWarningMessage.mockResolvedValueOnce("Delete");
-        jest.spyOn(UssFSProvider.instance, "delete").mockImplementationOnce(() => {
+        jest.spyOn(vscode.workspace.fs, "delete").mockImplementationOnce(() => {
             throw Error("testError");
         });
 

--- a/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
@@ -1171,7 +1171,7 @@ export class DatasetActions {
             }
             await datasetProvider.checkCurrentProfile(node);
             if (Profiles.getInstance().validProfile !== Validation.ValidationType.INVALID) {
-                await DatasetFSProvider.instance.delete(node.resourceUri, { recursive: false });
+                await vscode.workspace.fs.delete(node.resourceUri, { recursive: false });
             } else {
                 return;
             }

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
@@ -1167,7 +1167,7 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
             const newUri = node.resourceUri.with({
                 path: path.posix.join(path.posix.dirname(node.resourceUri.path), afterMemberName),
             });
-            await DatasetFSProvider.instance.rename(node.resourceUri, newUri, { overwrite: false });
+            await vscode.workspace.fs.rename(node.resourceUri, newUri, { overwrite: false });
             node.resourceUri = newUri;
             node.label = afterMemberName;
             node.tooltip = afterMemberName;
@@ -1222,7 +1222,7 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
             const newUri = node.resourceUri.with({
                 path: path.posix.join(path.posix.dirname(node.resourceUri.path), afterDataSetName),
             });
-            await DatasetFSProvider.instance.rename(node.resourceUri, newUri, { overwrite: false });
+            await vscode.workspace.fs.rename(node.resourceUri, newUri, { overwrite: false });
 
             // Rename corresponding node in Sessions or Favorites section (whichever one Rename wasn't called from)
             if (SharedContext.isFavorite(node)) {

--- a/packages/zowe-explorer/src/trees/job/JobFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/job/JobFSProvider.ts
@@ -281,7 +281,7 @@ export class JobFSProvider extends BaseProvider implements vscode.FileSystemProv
      * @param options Options for deleting the spool file or job
      * - `deleteRemote` - Deletes the job from the remote system if set to true.
      */
-    public async delete(uri: vscode.Uri, options: { readonly recursive: boolean; readonly deleteRemote: boolean }): Promise<void> {
+    public async delete(uri: vscode.Uri, options: { readonly recursive: boolean }): Promise<void> {
         const entry = this.lookup(uri, false);
         const isJob = FsJobsUtils.isJobEntry(entry);
         if (!isJob) {
@@ -291,10 +291,7 @@ export class JobFSProvider extends BaseProvider implements vscode.FileSystemProv
         const parent = this._lookupParentDirectory(uri, false);
 
         const profInfo = FsAbstractUtils.getInfoForUri(uri, Profiles.getInstance());
-
-        if (options.deleteRemote) {
-            await ZoweExplorerApiRegister.getJesApi(profInfo.profile).deleteJob(entry.job.jobname, entry.job.jobid);
-        }
+        await ZoweExplorerApiRegister.getJesApi(profInfo.profile).deleteJob(entry.job.jobname, entry.job.jobid);
         parent.entries.delete(entry.name);
         this._fireSoon({ type: vscode.FileChangeType.Deleted, uri });
     }

--- a/packages/zowe-explorer/src/trees/job/JobTree.ts
+++ b/packages/zowe-explorer/src/trees/job/JobTree.ts
@@ -218,7 +218,7 @@ export class JobTree extends ZoweTreeProvider<IZoweJobTreeNode> implements Types
     public async delete(node: IZoweJobTreeNode): Promise<void> {
         ZoweLogger.trace("JobTree.delete called.");
 
-        await JobFSProvider.instance.delete(node.resourceUri, { recursive: false, deleteRemote: true });
+        await vscode.workspace.fs.delete(node.resourceUri, { recursive: false });
         const favNode = this.relabelFavoritedJob(node);
         favNode.contextValue = SharedContext.asFavorite(favNode);
         await this.removeFavorite(favNode);

--- a/packages/zowe-explorer/src/trees/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/trees/uss/USSTree.ts
@@ -126,7 +126,7 @@ export class USSTree extends ZoweTreeProvider<IZoweUSSTreeNode> implements Types
                     true
                 );
             }
-            await UssFSProvider.instance.delete(sourceUri, { recursive: true });
+            await vscode.workspace.fs.delete(sourceUri, { recursive: true });
         } else {
             // create a file on the remote system for writing
             try {
@@ -160,7 +160,7 @@ export class USSTree extends ZoweTreeProvider<IZoweUSSTreeNode> implements Types
 
             if (!recursiveCall) {
                 // Delete any files from the selection on the source LPAR
-                await UssFSProvider.instance.delete(sourceNode.resourceUri, { recursive: false });
+                await vscode.workspace.fs.delete(sourceNode.resourceUri, { recursive: false });
             }
         }
     }

--- a/packages/zowe-explorer/src/trees/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/trees/uss/ZoweUSSNode.ts
@@ -416,7 +416,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
             return;
         }
         try {
-            await UssFSProvider.instance.delete(this.resourceUri, { recursive: this.isFolder });
+            await vscode.workspace.fs.delete(this.resourceUri, { recursive: this.isFolder });
         } catch (err) {
             ZoweLogger.error(err);
             if (err instanceof Error) {

--- a/packages/zowe-explorer/src/trees/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/trees/uss/ZoweUSSNode.ts
@@ -364,7 +364,7 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         });
 
         try {
-            await UssFSProvider.instance.rename(oldUri, newUri, { overwrite: false });
+            await vscode.workspace.fs.rename(oldUri, newUri, { overwrite: false });
         } catch (err) {
             Gui.errorMessage(err.message);
             return;


### PR DESCRIPTION
## Proposed changes

VS Code does not explicitly document that you need to use their `vscode.workspace.fs` façade when deleting or renaming entries in a file system implementation. If you do it directly through the implementation, other services (such as the editor service) are not made aware of the change.

This will make the editors behave properly such that:
- a deleted URI is reflected *permanently* in an open editor
- a renamed URI is updated in the editor to show the new path with existing contents

## Release Notes

Milestone: 3.0.3

Changelog:

- Fixed an issue where renaming or deleting a USS file or data set did not update the opened editor. [#3260](https://github.com/zowe/zowe-explorer-vscode/issues/3260)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have ~added~ updated new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
