### PR TITLE
fix: Only show "No configs detected" prompt if ZE opened

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where renaming or deleting a USS file or data set did not update the opened editor. [#3260](https://github.com/zowe/zowe-explorer-vscode/issues/3260)
 - Fixed an issue during initialization where a broken team configuration file caused the "Show Config" action in the error dialog to stop working. [#3273](https://github.com/zowe/zowe-explorer-vscode/issues/3273)
 - Fixed issue where switching the authentication methods would cause `Cannot read properties of undefined` error. [#3142](https://github.com/zowe/zowe-explorer-vscode/issues/3142)
+- Fixed issue where Zowe Explorer would present the "No configs detected" notification before it was used in a workspace without a Zowe config. [#3280](https://github.com/zowe/zowe-explorer-vscode/issues/3280)
 
 ## `3.0.2`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue during initialization where a broken team configuration file caused the "Show Config" action in the error dialog to stop working. [#3273](https://github.com/zowe/zowe-explorer-vscode/issues/3273)
 - Fixed issue where switching the authentication methods would cause `Cannot read properties of undefined` error. [#3142](https://github.com/zowe/zowe-explorer-vscode/issues/3142)
 - Fixed an issue where calling `vscode.workspace.fs.readFile` with a PDS member URI would throw an error when the PDS already existed as a filesystem entry. [#3267](https://github.com/zowe/zowe-explorer-vscode/issues/3267)
-- Fixed issue where Zowe Explorer would present the "No configs detected" notification before it was used in a workspace without a Zowe config. [#3280](https://github.com/zowe/zowe-explorer-vscode/issues/3280)
+- Fixed issue where Zowe Explorer would present the "No configs detected" notification when initialized in a workspace without a Zowe team configuration. [#3280](https://github.com/zowe/zowe-explorer-vscode/issues/3280)
 
 ## `3.0.2`
 

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -1299,6 +1299,10 @@ describe("ProfilesUtils unit tests", () => {
             const profInfoMock = jest.spyOn(ProfilesUtils, "getProfileInfo").mockResolvedValue({
                 getTeamConfig: () => ({ exists: false }),
             } as any);
+            const noConfigDialogShownMock = new MockedProperty(ProfilesUtils, "noConfigDialogShown", {
+                configurable: true,
+                value: false,
+            });
             const onlyV1ProfsExistMock = new MockedProperty(imperative.ProfileInfo, "onlyV1ProfilesExist", {
                 configurable: true,
                 get: () => false,
@@ -1315,11 +1319,16 @@ describe("ProfilesUtils unit tests", () => {
             executeCommandMock.mockRestore();
             profInfoMock.mockRestore();
             onlyV1ProfsExistMock[Symbol.dispose]();
+            noConfigDialogShownMock[Symbol.dispose]();
         });
         it("does not prompt the user if they have a Zowe team config", async () => {
             const profInfoMock = jest.spyOn(ProfilesUtils, "getProfileInfo").mockResolvedValue({
                 getTeamConfig: () => ({ exists: true }),
             } as any);
+            const noConfigDialogShownMock = new MockedProperty(ProfilesUtils, "noConfigDialogShown", {
+                configurable: true,
+                value: false,
+            });
             const onlyV1ProfsExistMock = new MockedProperty(imperative.ProfileInfo, "onlyV1ProfilesExist", {
                 configurable: true,
                 get: () => false,
@@ -1333,11 +1342,16 @@ describe("ProfilesUtils unit tests", () => {
             expect(profInfoMock).toHaveBeenCalled();
             profInfoMock.mockRestore();
             onlyV1ProfsExistMock[Symbol.dispose]();
+            noConfigDialogShownMock[Symbol.dispose]();
         });
         it("does not prompt the user if they have v1 profiles", async () => {
             const profInfoMock = jest.spyOn(ProfilesUtils, "getProfileInfo").mockResolvedValue({
                 getTeamConfig: () => ({ exists: false }),
             } as any);
+            const noConfigDialogShownMock = new MockedProperty(ProfilesUtils, "noConfigDialogShown", {
+                configurable: true,
+                value: false,
+            });
             const onlyV1ProfsExistMock = new MockedProperty(imperative.ProfileInfo, "onlyV1ProfilesExist", {
                 configurable: true,
                 get: () => true,
@@ -1351,6 +1365,7 @@ describe("ProfilesUtils unit tests", () => {
             expect(profInfoMock).toHaveBeenCalled();
             profInfoMock.mockRestore();
             onlyV1ProfsExistMock[Symbol.dispose]();
+            noConfigDialogShownMock[Symbol.dispose]();
         });
     });
 

--- a/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/ProfilesUtils.unit.test.ts
@@ -1270,6 +1270,13 @@ describe("ProfilesUtils unit tests", () => {
     });
 
     describe("promptUserWithNoConfigs", () => {
+        it("returns early if user was already prompted in this session", async () => {
+            const noConfigDialogShownMock = new MockedProperty(ProfilesUtils, "noConfigDialogShown", { value: true });
+            const getProfInfoSpy = jest.spyOn(ProfilesUtils, "getProfileInfo");
+            await ProfilesUtils.promptUserWithNoConfigs();
+            expect(getProfInfoSpy).not.toHaveBeenCalled();
+            noConfigDialogShownMock[Symbol.dispose]();
+        });
         it("returns early if profileInfo is nullish", async () => {
             const profInfoMock = jest.spyOn(ProfilesUtils, "getProfileInfo").mockResolvedValue(undefined as any);
             const showMessageSpy = jest.spyOn(Gui, "showMessage");
@@ -1278,6 +1285,7 @@ describe("ProfilesUtils unit tests", () => {
             profInfoMock.mockRestore();
         });
         it("prompts the user if they don't have any Zowe client configs", async () => {
+            const noConfigDialogShownMock = new MockedProperty(ProfilesUtils, "noConfigDialogShown", { value: false });
             const profInfoMock = jest.spyOn(ProfilesUtils, "getProfileInfo").mockResolvedValue({
                 getTeamConfig: () => ({ exists: false }),
             } as any);
@@ -1294,6 +1302,7 @@ describe("ProfilesUtils unit tests", () => {
             expect(profInfoMock).toHaveBeenCalled();
             profInfoMock.mockRestore();
             onlyV1ProfsExistMock[Symbol.dispose]();
+            noConfigDialogShownMock[Symbol.dispose]();
         });
         it("executes zowe.ds.addSession if the user selects 'Create New' in the prompt", async () => {
             const profInfoMock = jest.spyOn(ProfilesUtils, "getProfileInfo").mockResolvedValue({

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -47,6 +47,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
         },
         async () => {
             await SharedInit.setupRemoteWorkspaceFolders();
+            SharedTreeProviders.ds.getTreeView().onDidChangeVisibility(async (e) => {
+                if (e.visible) {
+                    await ProfilesUtils.promptUserWithNoConfigs();
+                }
+            });
         }
     );
     SharedInit.registerCommonCommands(context, providers);
@@ -56,7 +61,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
     SharedInit.watchConfigProfile(context);
     await SharedInit.watchForZoweButtonClick();
 
-    await ProfilesUtils.promptUserWithNoConfigs();
     return ZoweExplorerApiRegister.getInstance();
 }
 /**

--- a/packages/zowe-explorer/src/extension.ts
+++ b/packages/zowe-explorer/src/extension.ts
@@ -47,11 +47,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<ZoweEx
         },
         async () => {
             await SharedInit.setupRemoteWorkspaceFolders();
-            SharedTreeProviders.ds.getTreeView().onDidChangeVisibility(async (e) => {
-                if (e.visible) {
-                    await ProfilesUtils.promptUserWithNoConfigs();
-                }
-            });
         }
     );
     SharedInit.registerCommonCommands(context, providers);

--- a/packages/zowe-explorer/src/trees/dataset/DatasetInit.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetInit.ts
@@ -20,6 +20,7 @@ import { SharedActions } from "../shared/SharedActions";
 import { SharedContext } from "../shared/SharedContext";
 import { SharedInit } from "../shared/SharedInit";
 import { SharedUtils } from "../shared/SharedUtils";
+import { ProfilesUtils } from "../../utils/ProfilesUtils";
 
 export class DatasetInit {
     public static async createDatasetTree(log: imperative.Logger): Promise<DatasetTree> {
@@ -30,6 +31,12 @@ export class DatasetInit {
         return tree;
     }
 
+    public static async datasetTreeVisibilityChanged(this: void, e: vscode.TreeViewVisibilityChangeEvent): Promise<void> {
+        if (e.visible) {
+            await ProfilesUtils.promptUserWithNoConfigs();
+        }
+    }
+
     public static async initDatasetProvider(context: vscode.ExtensionContext): Promise<DatasetTree> {
         ZoweLogger.trace("DatasetInit.initDatasetProvider called.");
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider(ZoweScheme.DS, DatasetFSProvider.instance, { isCaseSensitive: true }));
@@ -37,6 +44,8 @@ export class DatasetInit {
         if (datasetProvider == null) {
             return null;
         }
+
+        datasetProvider.getTreeView().onDidChangeVisibility(DatasetInit.datasetTreeVisibilityChanged);
 
         context.subscriptions.push(
             vscode.commands.registerCommand("zowe.all.config.init", async () => {

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -28,6 +28,7 @@ export enum ProfilesConvertStatus {
 
 export class ProfilesUtils {
     public static PROFILE_SECURITY: string | boolean = Constants.ZOWE_CLI_SCM;
+    private static noConfigDialogShown: boolean = false;
 
     /**
      * Check if the credential manager's vsix is installed for use
@@ -401,7 +402,6 @@ export class ProfilesUtils {
      *
      * This aims to help direct new Zowe Explorer users to create a new team configuration.
      */
-    private static noConfigDialogShown: boolean = false;
     public static async promptUserWithNoConfigs(): Promise<void> {
         if (ProfilesUtils.noConfigDialogShown) {
             return;

--- a/packages/zowe-explorer/src/utils/ProfilesUtils.ts
+++ b/packages/zowe-explorer/src/utils/ProfilesUtils.ts
@@ -401,7 +401,12 @@ export class ProfilesUtils {
      *
      * This aims to help direct new Zowe Explorer users to create a new team configuration.
      */
+    private static noConfigDialogShown: boolean = false;
     public static async promptUserWithNoConfigs(): Promise<void> {
+        if (ProfilesUtils.noConfigDialogShown) {
+            return;
+        }
+
         const profInfo = await ProfilesUtils.getProfileInfo();
         if (profInfo == null) {
             return;
@@ -418,6 +423,7 @@ export class ProfilesUtils {
                     await vscode.commands.executeCommand("zowe.ds.addSession");
                 }
             });
+            ProfilesUtils.noConfigDialogShown = true;
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Fixes #3280

## Release Notes

Milestone: 3.0.3

Changelog:

- Fixed issue where Zowe Explorer would present the "No configs detected" notification before it was used in a workspace without a Zowe config. [#3280](https://github.com/zowe/zowe-explorer-vscode/issues/3280)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):