### PR TITLE
feat: 'Add to Workspace' context menu option (Data Sets & USS resources)

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Update Zowe SDKs to `8.2.0` to get the latest enhancements from Imperative.
 - Added expired JSON web token detection for profiles in each tree view (Data Sets, USS, Jobs). When a user performs a search on a profile, they are prompted to log in if their token expired. [#3175](https://github.com/zowe/zowe-explorer-vscode/issues/3175)
+- Add Data Set or USS resources to a virtual workspace with the new "Add to Workspace" context menu option. [#3265](https://github.com/zowe/zowe-explorer-vscode/issues/3265)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Update Zowe SDKs to `8.2.0` to get the latest enhancements from Imperative.
 - Added expired JSON web token detection for profiles in each tree view (Data Sets, USS, Jobs). When a user performs a search on a profile, they are prompted to log in if their token expired. [#3175](https://github.com/zowe/zowe-explorer-vscode/issues/3175)
-- Add Data Set or USS resources to a virtual workspace with the new "Add to Workspace" context menu option. [#3265](https://github.com/zowe/zowe-explorer-vscode/issues/3265)
+- Add a data set or USS resource to a virtual workspace with the new "Add to Workspace" context menu option. [#3265](https://github.com/zowe/zowe-explorer-vscode/issues/3265)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer/__tests__/__mocks__/vscode.ts
+++ b/packages/zowe-explorer/__tests__/__mocks__/vscode.ts
@@ -1320,6 +1320,23 @@ export namespace workspace {
     export function onDidOpenTextDocument<T>(listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]) {}
     export function onDidSaveTextDocument<T>(listener: (e: T) => any, thisArgs?: any, disposables?: Disposable[]) {}
 
+    export function updateWorkspaceFolders(
+        start: number,
+        deleteCount: number | undefined | null,
+        ...workspaceFoldersToAdd: {
+            /**
+             * The uri of a workspace folder that's to be added.
+             */
+            readonly uri: Uri;
+            /**
+             * The name of a workspace folder that's to be added.
+             */
+            readonly name?: string;
+        }[]
+    ): boolean {
+        return false;
+    }
+
     export function getConfiguration(configuration: string) {
         return {
             update: () => {

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -233,6 +233,7 @@ async function createGlobalMocks() {
             "zowe.saveSearch",
             "zowe.addFavorite",
             "zowe.removeFavorite",
+            "zowe.addToWorkspace",
             "zowe.removeFavProfile",
             "zowe.openWithEncoding",
             "zowe.issueTsoCmd",

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
@@ -555,6 +555,16 @@ describe("Test src/shared/extension", () => {
             expect(remoteLookupDsSpy).not.toHaveBeenCalled();
             expect(remoteLookupUssSpy).not.toHaveBeenCalled();
         });
+        it("logs an error if one occurs", async () => {
+            const fakeEventInfo = getFakeEventInfo([{ uri: vscode.Uri.from({ scheme: ZoweScheme.DS, path: "/lpar.zosmf/TEST.PDS" }) }]);
+            const sampleError = new Error("issue fetching data set");
+            const remoteLookupMock = jest.spyOn(DatasetFSProvider.instance, "remoteLookupForResource").mockRejectedValueOnce(sampleError);
+            const errorMock = jest.spyOn(ZoweLogger, "error").mockImplementation();
+            await SharedInit.setupRemoteWorkspaceFolders(fakeEventInfo);
+            expect(errorMock).toHaveBeenCalledWith(sampleError.message);
+            expect(remoteLookupMock).toHaveBeenCalled();
+            remoteLookupMock.mockRestore();
+        });
     });
 
     describe("emitZoweEventHook", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
@@ -576,6 +576,41 @@ describe("Shared utils unit tests - function addToWorkspace", () => {
         SharedUtils.addToWorkspace(ussNode, null as any);
         expect(updateWorkspaceFoldersMock).toHaveBeenCalledWith(0, null, { uri: ussNode.resourceUri, name: ussNode.label as string });
     });
+    it("adds a USS session w/ fullPath to the workspace", () => {
+        const ussNode = new ZoweUSSNode({
+            label: "sestest",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            contextOverride: Constants.USS_SESSION_CONTEXT,
+            profile: createIProfile(),
+            session: createISession(),
+        });
+        ussNode.fullPath = "/u/users/smpluser";
+        const updateWorkspaceFoldersMock = jest.spyOn(vscode.workspace, "updateWorkspaceFolders").mockImplementation();
+        SharedUtils.addToWorkspace(ussNode, null as any);
+        expect(updateWorkspaceFoldersMock).toHaveBeenCalledWith(0, null, {
+            uri: ussNode.resourceUri?.with({ path: `/sestest${ussNode.fullPath}` }),
+            name: `[${ussNode.label as string}] ${ussNode.fullPath}`,
+        });
+    });
+    it("displays an info message when adding a USS session w/o fullPath", () => {
+        const ussNode = new ZoweUSSNode({
+            label: "sestest",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            contextOverride: Constants.USS_SESSION_CONTEXT,
+            profile: createIProfile(),
+            session: createISession(),
+        });
+        ussNode.fullPath = "";
+        const updateWorkspaceFoldersMock = jest.spyOn(vscode.workspace, "updateWorkspaceFolders").mockImplementation();
+        const infoMessageSpy = jest.spyOn(Gui, "infoMessage");
+        updateWorkspaceFoldersMock.mockClear();
+        SharedUtils.addToWorkspace(ussNode, null as any);
+        expect(updateWorkspaceFoldersMock).not.toHaveBeenCalledWith(0, null, {
+            uri: ussNode.resourceUri?.with({ path: `/sestest${ussNode.fullPath}` }),
+            name: `[${ussNode.label as string}] ${ussNode.fullPath}`,
+        });
+        expect(infoMessageSpy).toHaveBeenCalledWith("A search must be set for sestest before it can be added to a workspace.");
+    });
     it("skips adding a resource that's already in the workspace", () => {
         const ussNode = new ZoweUSSNode({
             label: "textFile.txt",

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
@@ -25,6 +25,7 @@ import { SharedUtils } from "../../../../src/trees/shared/SharedUtils";
 import { ZoweUSSNode } from "../../../../src/trees/uss/ZoweUSSNode";
 import { AuthUtils } from "../../../../src/utils/AuthUtils";
 import { SharedTreeProviders } from "../../../../src/trees/shared/SharedTreeProviders";
+import { MockedProperty } from "../../../__mocks__/mockUtils";
 
 function createGlobalMocks() {
     const newMocks = {
@@ -549,5 +550,46 @@ describe("Shared utils unit tests - function parseFavorites", () => {
         const favData = SharedUtils.parseFavorites(["[testProfile]: "]);
         expect(favData.length).toBe(0);
         expect(warnSpy).toHaveBeenCalledWith("Failed to parse a saved favorite. Attempted to parse: [testProfile]: ");
+    });
+});
+
+describe("Shared utils unit tests - function addToWorkspace", () => {
+    it("adds a Data Set resource to the workspace", () => {
+        const datasetNode = new ZoweDatasetNode({
+            label: "EXAMPLE.DS",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            contextOverride: Constants.DS_DS_CONTEXT,
+            profile: createIProfile(),
+        });
+        const updateWorkspaceFoldersMock = jest.spyOn(vscode.workspace, "updateWorkspaceFolders").mockImplementation();
+        SharedUtils.addToWorkspace(datasetNode, null as any);
+        expect(updateWorkspaceFoldersMock).toHaveBeenCalledWith(0, null, { uri: datasetNode.resourceUri, name: datasetNode.label as string });
+    });
+    it("adds a USS resource to the workspace", () => {
+        const ussNode = new ZoweUSSNode({
+            label: "textFile.txt",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            contextOverride: Constants.USS_TEXT_FILE_CONTEXT,
+            profile: createIProfile(),
+        });
+        const updateWorkspaceFoldersMock = jest.spyOn(vscode.workspace, "updateWorkspaceFolders").mockImplementation();
+        SharedUtils.addToWorkspace(ussNode, null as any);
+        expect(updateWorkspaceFoldersMock).toHaveBeenCalledWith(0, null, { uri: ussNode.resourceUri, name: ussNode.label as string });
+    });
+    it("skips adding a resource that's already in the workspace", () => {
+        const ussNode = new ZoweUSSNode({
+            label: "textFile.txt",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            contextOverride: Constants.USS_TEXT_FILE_CONTEXT,
+            profile: createIProfile(),
+        });
+        const workspaceFolders = new MockedProperty(vscode.workspace, "workspaceFolders", {
+            value: [{ uri: ussNode.resourceUri, name: ussNode.label }],
+        });
+        const updateWorkspaceFoldersMock = jest.spyOn(vscode.workspace, "updateWorkspaceFolders").mockImplementation();
+        updateWorkspaceFoldersMock.mockClear();
+        SharedUtils.addToWorkspace(ussNode, null as any);
+        expect(updateWorkspaceFoldersMock).not.toHaveBeenCalledWith(0, null, { uri: ussNode.resourceUri, name: ussNode.label as string });
+        workspaceFolders[Symbol.dispose]();
     });
 });

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -845,7 +845,7 @@
           "group": "003_zowe_ussWorkspace@1"
         },
         {
-          "when": "view == zowe.uss.explorer && viewItem =~ /^(textFile.*|binaryFile.*|directory.*)/",
+          "when": "view == zowe.uss.explorer && viewItem =~ /^(directory.*|ussSession.*)/",
           "command": "zowe.addToWorkspace",
           "group": "003_zowe_ussWorkspace@2"
         },
@@ -1020,7 +1020,7 @@
           "group": "002_zowe_dsWorkspace@1"
         },
         {
-          "when": "view == zowe.ds.explorer && viewItem =~ /^(pds|ds|migr|member).*/",
+          "when": "view == zowe.ds.explorer && viewItem =~ /^pds.*/",
           "command": "zowe.addToWorkspace",
           "group": "002_zowe_dsWorkspace@2"
         },

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -212,6 +212,11 @@
         }
       },
       {
+        "command": "zowe.addToWorkspace",
+        "title": "%addToWorkspace%",
+        "category": "Zowe Explorer"
+      },
+      {
         "command": "zowe.ds.addSession",
         "title": "%addSession%",
         "category": "Zowe Explorer",
@@ -840,6 +845,11 @@
           "group": "003_zowe_ussWorkspace@1"
         },
         {
+          "when": "view == zowe.uss.explorer && viewItem =~ /^(textFile.*|binaryFile.*|directory.*)/",
+          "command": "zowe.addToWorkspace",
+          "group": "003_zowe_ussWorkspace@2"
+        },
+        {
           "when": "view == zowe.uss.explorer && viewItem =~ /^(?!.*_fav.*)ussSession.*/ && !listMultiSelection",
           "command": "zowe.addFavorite",
           "group": "003_zowe_ussWorkspace@3"
@@ -1008,6 +1018,11 @@
           "when": "view == zowe.ds.explorer && viewItem =~ /^(pds|ds|migr).*_fav.*/",
           "command": "zowe.removeFavorite",
           "group": "002_zowe_dsWorkspace@1"
+        },
+        {
+          "when": "view == zowe.ds.explorer && viewItem =~ /^(pds|ds|migr|member).*/",
+          "command": "zowe.addToWorkspace",
+          "group": "003_zowe_dsWorkspace@2"
         },
         {
           "when": "view == zowe.ds.explorer && viewItem == profile_fav && !listMultiSelection",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1022,7 +1022,7 @@
         {
           "when": "view == zowe.ds.explorer && viewItem =~ /^(pds|ds|migr|member).*/",
           "command": "zowe.addToWorkspace",
-          "group": "003_zowe_dsWorkspace@2"
+          "group": "002_zowe_dsWorkspace@2"
         },
         {
           "when": "view == zowe.ds.explorer && viewItem == profile_fav && !listMultiSelection",

--- a/packages/zowe-explorer/package.nls.json
+++ b/packages/zowe-explorer/package.nls.json
@@ -20,6 +20,7 @@
   "diff.overwrite": "Overwrite",
   "diff.useRemote": "Use Remote",
   "addFavorite": "Add to Favorites",
+  "addToWorkspace": "Add to Workspace",
   "removeFavProfile": "Remove profile from Favorites",
   "addSession": "Add Profile to Data Sets View",
   "createDataset": "Create New Data Set",

--- a/packages/zowe-explorer/src/configuration/Constants.ts
+++ b/packages/zowe-explorer/src/configuration/Constants.ts
@@ -16,7 +16,7 @@ import { imperative, PersistenceSchemaEnum } from "@zowe/zowe-explorer-api";
 import type { Profiles } from "./Profiles";
 
 export class Constants {
-    public static readonly COMMAND_COUNT = 99;
+    public static readonly COMMAND_COUNT = 100;
     public static readonly MAX_SEARCH_HISTORY = 5;
     public static readonly MAX_FILE_HISTORY = 10;
     public static readonly MS_PER_SEC = 1000;

--- a/packages/zowe-explorer/src/trees/shared/SharedInit.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedInit.ts
@@ -394,7 +394,13 @@ export class SharedInit {
             (f) => f.uri.scheme === ZoweScheme.DS || f.uri.scheme === ZoweScheme.USS
         );
         for (const folder of newWorkspaces) {
-            await (folder.uri.scheme === ZoweScheme.DS ? DatasetFSProvider.instance : UssFSProvider.instance).remoteLookupForResource(folder.uri);
+            try {
+                await (folder.uri.scheme === ZoweScheme.DS ? DatasetFSProvider.instance : UssFSProvider.instance).remoteLookupForResource(folder.uri);
+            } catch (err) {
+                if (err instanceof Error) {
+                    ZoweLogger.error(err.toString());
+                }
+            }
         }
     }
 

--- a/packages/zowe-explorer/src/trees/shared/SharedInit.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedInit.ts
@@ -398,7 +398,7 @@ export class SharedInit {
                 await (folder.uri.scheme === ZoweScheme.DS ? DatasetFSProvider.instance : UssFSProvider.instance).remoteLookupForResource(folder.uri);
             } catch (err) {
                 if (err instanceof Error) {
-                    ZoweLogger.error(err.toString());
+                    ZoweLogger.error(err.message);
                 }
             }
         }

--- a/packages/zowe-explorer/src/trees/shared/SharedInit.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedInit.ts
@@ -214,6 +214,7 @@ export class SharedInit {
                     }
                 })
             );
+            context.subscriptions.push(vscode.commands.registerCommand("zowe.addToWorkspace", SharedUtils.addToWorkspace));
             context.subscriptions.push(
                 vscode.commands.registerCommand("zowe.removeFavProfile", (node: IZoweTreeNode) =>
                     SharedTreeProviders.getProviderForNode(node).removeFavProfile(node.label as string, true)

--- a/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
@@ -287,4 +287,28 @@ export class SharedUtils {
     public static getSessionLabel(node: IZoweTreeNode): string {
         return (SharedContext.isSession(node) ? node : node.getSessionNode()).label as string;
     }
+
+    /**
+     * Adds one or more Data Sets/USS nodes to a workspace.
+     * @param node Single node selection
+     * @param nodeList List of selected nodes
+     */
+    public static addToWorkspace(
+        this: void,
+        node: IZoweUSSTreeNode | IZoweDatasetTreeNode,
+        nodeList: IZoweUSSTreeNode[] | IZoweDatasetTreeNode[]
+    ): void {
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+        const selectedNodes = SharedUtils.getSelectedNodeList(node, nodeList);
+        for (const item of selectedNodes) {
+            if (workspaceFolders?.some((folder) => folder.uri === item.resourceUri)) {
+                continue;
+            }
+
+            vscode.workspace.updateWorkspaceFolders(workspaceFolders?.length ?? 0, null, {
+                uri: item.resourceUri,
+                name: item.label as string,
+            });
+        }
+    }
 }

--- a/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
@@ -301,13 +301,29 @@ export class SharedUtils {
         const workspaceFolders = vscode.workspace.workspaceFolders;
         const selectedNodes = SharedUtils.getSelectedNodeList(node, nodeList);
         for (const item of selectedNodes) {
-            if (workspaceFolders?.some((folder) => folder.uri === item.resourceUri)) {
+            let resourceUri = item.resourceUri;
+            const isSession = SharedContext.isSession(item);
+            if (isSession) {
+                if (item.fullPath?.length > 0) {
+                    resourceUri = item.resourceUri.with({ path: path.posix.join(item.resourceUri.path, item.fullPath) });
+                } else {
+                    Gui.infoMessage(
+                        vscode.l10n.t({
+                            message: "A search must be set for {0} before it can be added to a workspace.",
+                            args: [item.label as string],
+                            comment: "Name of USS session",
+                        })
+                    );
+                    continue;
+                }
+            }
+            if (workspaceFolders?.some((folder) => folder.uri === resourceUri)) {
                 continue;
             }
 
             vscode.workspace.updateWorkspaceFolders(workspaceFolders?.length ?? 0, null, {
-                uri: item.resourceUri,
-                name: item.label as string,
+                uri: resourceUri,
+                name: isSession ? `[${item.label as string}] ${item.fullPath}` : (item.label as string),
             });
         }
     }


### PR DESCRIPTION
## Proposed changes

Resolves #3265 

Doc: 

Virtual workspaces can be used to access multiple resources from the Explorer pane, such as local files or resources from other schemes. Zowe Explorer v3 now supports virtual workspaces for Data Sets and USS files or folders.

To add a resource to a virtual workspace:
1. Click the magnifying glass icon beside a profile in the Data Sets or Unix System Services (USS) tree.
2. Type in a data set search pattern or a USS file path and execute the search.
3. Once resources are listed in the tree view, right click on an item and select the "Add to Workspace" context menu option.
4. A message "Extension Zowe Explorer has added X folder(s) to the workspace" is presented in the status bar. The resource is accessible in the Explorer pane of VS Code.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.1.0

Changelog:

- Add Data Set or USS resources to a virtual workspace with the new "Add to Workspace" context menu option. [#3265](https://github.com/zowe/zowe-explorer-vscode/issues/3265)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [x] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
