### PR TITLE
Fix infinite loop when fetching USS resources with stat()

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed issue where users were not prompted to enter credentials if a 401 error was encountered when opening files, data sets or spools in the editor. [#3197](https://github.com/zowe/zowe-explorer-vscode/issues/3197)
 - Fixed issue where profile credential updates or token changes were not reflected within the filesystem. [#3289](https://github.com/zowe/zowe-explorer-vscode/issues/3289)
 - Fixed issue to update the success message when changing authentication from token to basic through the 'Change Authentication' option.
+- Fixed an issue where fetching a USS file using `UssFSProvider.stat()` with a `fetch=true` query would cause Zowe Explorer to get stuck in an infinite loop.
 
 ## `3.0.2`
 

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -148,7 +148,6 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         try {
             response = await ZoweExplorerApiRegister.getUssApi(profile).fileList(ussPath);
             // If request was successful, create directories for the path if it doesn't exist
-            //why are creating directories for the path
             if (response.success && !keepRelative && response.apiResponse.items?.[0]?.mode?.startsWith("d") && !this.exists(uri)) {
                 await vscode.workspace.fs.createDirectory(uri.with({ query: "" }));
             }

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -148,8 +148,9 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         try {
             response = await ZoweExplorerApiRegister.getUssApi(profile).fileList(ussPath);
             // If request was successful, create directories for the path if it doesn't exist
+            //why are creating directories for the path
             if (response.success && !keepRelative && response.apiResponse.items?.[0]?.mode?.startsWith("d") && !this.exists(uri)) {
-                await vscode.workspace.fs.createDirectory(uri);
+                await vscode.workspace.fs.createDirectory(uri.with({ query: "" }));
             }
         } catch (err) {
             if (err instanceof Error) {
@@ -187,7 +188,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
             let parentDir = this._lookupParentDirectory(uri, true);
             if (parentDir == null) {
                 const parentPath = path.posix.join(uri.path, "..");
-                const parentUri = uri.with({ path: parentPath });
+                const parentUri = uri.with({ path: parentPath, query: "" });
                 await vscode.workspace.fs.createDirectory(parentUri);
                 parentDir = this._lookupParentDirectory(uri, false);
                 parentDir.metadata = this._getInfoFromUri(parentUri);


### PR DESCRIPTION
## Proposed changes

Extenders can fetch a USS resource on demand using `vscode.workspace.fs.stat()` with the `fetch=true` query. When done with a USS file that has not expanded in the USS tree view, Zowe Explorer gets stuck in an infinite loop of calling `stat()` over and over again. Here's how it happens:

1. `vscode.workspace.fs.stat()` is called for a USS resource with the fetch query set to true. Example: `vscode.workspace.fs.stat(zowe-uss:/zosmf/user/test.txt)`
2. `UssFSProvider.remoteLookupForResource()` is called to fetch the file from the host.
3. This eventually calls `UssFSProvider.fetchEntries()`. `fetchEntries()` checks if the parent directory of the requested file is in the file system. If it's not, `await vscode.workspace.fs.createDirectory(parentUri)` is called on line 191 to create it.
4. `stat()` is called again for the `parentUri` with a `fetch=true` query as a result of calling `vscode.workspace.fs.createDirectory()`. (I believe this is due to the VS Code file system base implementation. It surprised me but looking at the call stack that is what I see)
5.  `UssFSProvider.remoteLookupForResource()` is called to fetch the directory from the host. This eventually calls `UssFSProvider.fetchEntries()`
6. When `listFiles()` is called in `fetchEntries()`, if the resource requested is a directory that does not already exist in the file system, we call `vscode.workspace.fs.createDirectory()` with the directory's URI. This is the same exact URI that is used when calling `createDirectory()` in step 3. 

Basically, Zowe Explorer keeps calling `vscode.workspace.fs.createDirectory()` for the parent of the requested file over and over again without ever resolving. This does not happen when using tree views because of how directories are expanded from the top-down. In this case, I as an extender am requesting a file from a parent directory that has not been created.

There are improvements we can make to improve the `UssFSProvider` for extenders, but with the goal of trying to get a fix for this issue into the v3.0.3 release, I tried to keep my changes minimal. I added code that sets the query of the `parentUri` to an empty string when calling `vscode.workspace.fs.createDirectory()` in `fetchEntries()`. This prevents it from entering the infinite loop by not trying to fetch the requested resource's parent.

This change will not impact the tree view, as those views do not make use of the fetch query. This change will only fix functionality for extenders.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog: 

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
