### PR TITLE
fix: TypeError when listing data sets after opening one w/ encoding

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where a migrated data set is unusable after it is recalled through Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where a recalled PDS is expandable after it is migrated through Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where data set nodes did not update if migrated or recalled outside of Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
+- Fixed an issue where listing data sets resulted in an error after opening a data set with an encoding. [#3347](https://github.com/zowe/zowe-explorer-vscode/issues/3347)
 
 ## `3.0.3`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
@@ -3297,30 +3297,31 @@ describe("Dataset Tree Unit Tests - Sorting and Filtering operations", () => {
 
 describe("Dataset Tree Unit Tests - Function openWithEncoding", () => {
     it("sets binary encoding if selection was made", async () => {
-        const setEncodingMock = jest.spyOn(DatasetFSProvider.instance, "setEncodingForFile").mockImplementation();
         const node = new ZoweDatasetNode({ label: "encodingTest", collapsibleState: vscode.TreeItemCollapsibleState.None });
+        const setEncodingMock = jest.spyOn(node, "setEncoding").mockImplementation();
         node.openDs = jest.fn();
         jest.spyOn(SharedUtils, "promptForEncoding").mockResolvedValueOnce({ kind: "binary" });
         await DatasetTree.prototype.openWithEncoding(node);
-        expect(setEncodingMock).toHaveBeenCalledWith(node.resourceUri, { kind: "binary" });
+        expect(setEncodingMock).toHaveBeenCalledWith({ kind: "binary" });
         expect(node.openDs).toHaveBeenCalledTimes(1);
         setEncodingMock.mockRestore();
     });
 
     it("sets text encoding if selection was made", async () => {
-        const setEncodingMock = jest.spyOn(DatasetFSProvider.instance, "setEncodingForFile").mockImplementation();
+        jest.spyOn(DatasetFSProvider.instance, "exists").mockReturnValueOnce(true);
         const node = new ZoweDatasetNode({ label: "encodingTest", collapsibleState: vscode.TreeItemCollapsibleState.None });
+        const setEncodingMock = jest.spyOn(node, "setEncoding").mockImplementation();
         node.openDs = jest.fn();
         jest.spyOn(SharedUtils, "promptForEncoding").mockResolvedValueOnce({ kind: "text" });
         await DatasetTree.prototype.openWithEncoding(node);
-        expect(setEncodingMock).toHaveBeenCalledWith(node.resourceUri, { kind: "text" });
+        expect(setEncodingMock).toHaveBeenCalledWith({ kind: "text" });
         expect(node.openDs).toHaveBeenCalledTimes(1);
         setEncodingMock.mockRestore();
     });
 
     it("does not set encoding if prompt was cancelled", async () => {
-        const setEncodingSpy = jest.spyOn(DatasetFSProvider.instance, "setEncodingForFile");
         const node = new ZoweDatasetNode({ label: "encodingTest", collapsibleState: vscode.TreeItemCollapsibleState.None });
+        const setEncodingSpy = jest.spyOn(node, "setEncoding");
         node.openDs = jest.fn();
         jest.spyOn(SharedUtils, "promptForEncoding").mockResolvedValueOnce(undefined);
         await DatasetTree.prototype.openWithEncoding(node);

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
@@ -658,9 +658,16 @@ describe("ZoweDatasetNode Unit Tests - Function node.openDs()", () => {
 });
 
 describe("ZoweDatasetNode Unit Tests - Function node.setEncoding()", () => {
-    const setEncodingForFileMock = jest.spyOn(DatasetFSProvider.instance, "setEncodingForFile").mockImplementation();
+    let setEncodingForFileMock: jest.SpyInstance;
+    let existsMock: jest.SpyInstance;
+
+    beforeAll(() => {
+        setEncodingForFileMock = jest.spyOn(DatasetFSProvider.instance, "setEncodingForFile").mockImplementation();
+        existsMock = jest.spyOn(DatasetFSProvider.instance, "exists").mockReturnValue(true);
+    });
 
     afterAll(() => {
+        existsMock.mockRestore();
         setEncodingForFileMock.mockRestore();
     });
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
@@ -124,9 +124,6 @@ describe("ZoweDatasetNode Unit Tests", () => {
         expect(testNode.getSession()).toBeDefined();
     });
 
-    /*************************************************************************************************************
-     * Creates an ZoweDatasetNode and checks that its members are all initialized by the constructor
-     *************************************************************************************************************/
     it("calls setEncoding when constructing a node with encoding", () => {
         jest.spyOn(BaseProvider.prototype, "setEncodingForFile").mockImplementationOnce(() => {});
         const makeEmptyDsWithEncodingMock = jest.spyOn(DatasetFSProvider.instance, "makeEmptyDsWithEncoding").mockImplementationOnce(() => {});

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
@@ -10,7 +10,7 @@
  */
 
 import * as vscode from "vscode";
-import { DsEntry, Gui, imperative, PdsEntry, Validation, ZoweScheme } from "@zowe/zowe-explorer-api";
+import { BaseProvider, DsEntry, Gui, imperative, PdsEntry, Validation, ZoweScheme } from "@zowe/zowe-explorer-api";
 import * as zosfiles from "@zowe/zos-files-for-zowe-sdk";
 import {
     createSessCfgFromArgs,
@@ -122,6 +122,29 @@ describe("ZoweDatasetNode Unit Tests", () => {
         expect(testNode.label).toBeDefined();
         expect(testNode.getParent()).toBeUndefined();
         expect(testNode.getSession()).toBeDefined();
+    });
+
+    /*************************************************************************************************************
+     * Creates an ZoweDatasetNode and checks that its members are all initialized by the constructor
+     *************************************************************************************************************/
+    it("calls setEncoding when constructing a node with encoding", () => {
+        jest.spyOn(BaseProvider.prototype, "setEncodingForFile").mockImplementationOnce(() => {});
+        const makeEmptyDsWithEncodingMock = jest.spyOn(DatasetFSProvider.instance, "makeEmptyDsWithEncoding").mockImplementationOnce(() => {});
+        const setEncodingSpy = jest.spyOn(ZoweDatasetNode.prototype, "setEncoding");
+        const testNode = new ZoweDatasetNode({
+            label: "BRTVS99",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            contextOverride: Constants.DS_DS_CONTEXT,
+            encoding: { kind: "binary" },
+            profile: createIProfile(),
+            parentNode: createDatasetSessionNode(createISession(), createIProfile()),
+        });
+
+        expect(testNode.label).toBe("BRTVS99");
+        expect(testNode.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
+        expect(setEncodingSpy).toHaveBeenCalled();
+        expect(makeEmptyDsWithEncodingMock).toHaveBeenCalled();
+        setEncodingSpy.mockRestore();
     });
 
     /*************************************************************************************************************

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
@@ -528,7 +528,9 @@ describe("Shared utils unit tests - function promptForEncoding", () => {
             parentNode,
             contextOverride: Constants.DS_MEMBER_CONTEXT,
         });
+        const existsMock = jest.spyOn(DatasetFSProvider.instance, "exists").mockReturnValueOnce(true);
         node.setEncoding(otherEncoding);
+        expect(existsMock).toHaveBeenCalled();
         blockMocks.getEncodingForFile.mockReturnValueOnce(undefined);
         await SharedUtils.promptForEncoding(node);
         expect(blockMocks.showQuickPick).toHaveBeenCalled();

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -81,9 +81,6 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
         } else {
             this.contextValue = isBinary ? Constants.DS_DS_BINARY_CONTEXT : Constants.DS_DS_CONTEXT;
         }
-        if (opts.encoding != null) {
-            this.setEncoding(opts.encoding);
-        }
         this.tooltip = this.label as string;
         const icon = IconGenerator.getIconByNode(this);
         if (icon) {
@@ -134,7 +131,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             }
 
             if (opts.encoding != null) {
-                DatasetFSProvider.instance.makeEmptyDsWithEncoding(this.resourceUri, opts.encoding);
+                this.setEncoding(opts.encoding);
             }
         }
     }
@@ -313,8 +310,8 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                     } else if (!SharedContext.isMigrated(dsNode) && item.migr?.toUpperCase() === "YES") {
                         dsNode.datasetMigrated();
                     }
-                    // Creates a ZoweDatasetNode for a PDS
                 } else if (item.migr && item.migr.toUpperCase() === "YES") {
+                    // Creates a ZoweDatasetNode for a migrated dataset
                     dsNode = new ZoweDatasetNode({
                         label: item.dsname,
                         collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -323,8 +320,8 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                         profile: cachedProfile,
                     });
                     elementChildren[dsNode.label.toString()] = dsNode;
-                    // Creates a ZoweDatasetNode for a VSAM file
                 } else if (item.dsorg === "PO" || item.dsorg === "PO-E") {
+                    // Creates a ZoweDatasetNode for a PDS
                     dsNode = new ZoweDatasetNode({
                         label: item.dsname,
                         collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
@@ -332,8 +329,8 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                         profile: cachedProfile,
                     });
                     elementChildren[dsNode.label.toString()] = dsNode;
-                    // Creates a ZoweDatasetNode for a dataset with imperative errors
                 } else if (item.error instanceof imperative.ImperativeError) {
+                    // Creates a ZoweDatasetNode for a dataset with imperative errors
                     dsNode = new ZoweDatasetNode({
                         label: item.dsname,
                         collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -344,8 +341,8 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                     dsNode.command = { command: "zowe.placeholderCommand", title: "" };
                     dsNode.errorDetails = item.error; // Save imperative error to avoid extra z/OS requests
                     elementChildren[dsNode.label.toString()] = dsNode;
-                    // Creates a ZoweDatasetNode for a migrated dataset
                 } else if (item.dsorg === "VS") {
+                    // Creates a ZoweDatasetNode for a VSAM file
                     let altLabel = item.dsname;
                     let endPoint = altLabel.indexOf(".DATA");
                     if (endPoint === -1) {
@@ -713,7 +710,11 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
         } else {
             this.contextValue = isMemberNode ? Constants.DS_MEMBER_CONTEXT : Constants.DS_DS_CONTEXT;
         }
-        DatasetFSProvider.instance.setEncodingForFile(this.resourceUri, encoding);
+        if (DatasetFSProvider.instance.exists(this.resourceUri)) {
+            DatasetFSProvider.instance.setEncodingForFile(this.resourceUri, encoding);
+        } else {
+            DatasetFSProvider.instance.makeEmptyDsWithEncoding(this.resourceUri, encoding);
+        }
         const fullPath = isMemberNode ? `${this.getParent().label as string}(${this.label as string})` : (this.label as string);
         if (encoding != null) {
             this.updateEncodingInMap(fullPath, encoding);

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -71,9 +71,6 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
 
     public constructor(opts: Definitions.IZoweDatasetTreeOpts) {
         super(opts.label, opts.collapsibleState, opts.parentNode, opts.session, opts.profile);
-        if (opts.encoding != null) {
-            this.setEncoding(opts.encoding);
-        }
         const isBinary = opts.encoding?.kind === "binary";
         if (opts.contextOverride) {
             this.contextValue = opts.contextOverride;
@@ -83,6 +80,9 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             this.contextValue = isBinary ? Constants.DS_MEMBER_BINARY_CONTEXT : Constants.DS_MEMBER_CONTEXT;
         } else {
             this.contextValue = isBinary ? Constants.DS_DS_BINARY_CONTEXT : Constants.DS_DS_CONTEXT;
+        }
+        if (opts.encoding != null) {
+            this.setEncoding(opts.encoding);
         }
         this.tooltip = this.label as string;
         const icon = IconGenerator.getIconByNode(this);


### PR DESCRIPTION
## Proposed changes

Resolves #3347 

### How to test

1. Set a valid search pattern on a profile in your Data Sets tree.
2. Open one of the datasets in the list with a specific encoding - right-click -> "Open with Encoding"
3. Select an encoding to open the data set in an editor tab.
4. Once opened, set a search pattern on your profile that returns no results (ex: PROWOBUF).
5. Then, set the same search pattern used in step 1.
6. Once the search is finished, the data sets are listed without any errors.

Following the same steps when using the `main` branch or 3.0.3 VSIX results in a TypeError.

## Release Notes

Milestone: 3.1.0 (or a 3.0.4 if needed?)

Changelog:

- Fixed an issue where listing data sets resulted in an error after opening a data set with an encoding. [#3347](https://github.com/zowe/zowe-explorer-vscode/issues/3347)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
