### PR TITLE
fix(uss): Support "Pull from Mainframe" w/ binary files

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where a recalled PDS is expandable after it is migrated through Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where data set nodes did not update if migrated or recalled outside of Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where listing data sets resulted in an error after opening a data set with an encoding. [#3347](https://github.com/zowe/zowe-explorer-vscode/issues/3347)
+- Fixed an issue where opening a USS file as binary and attempting to "Pull from Mainframe" caused the status bar message to persist indefinitely. [#3355](https://github.com/zowe/zowe-explorer-vscode/issues/3355)
 
 ## `3.0.3`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -29,7 +29,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where a recalled PDS is expandable after it is migrated through Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where data set nodes did not update if migrated or recalled outside of Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where listing data sets resulted in an error after opening a data set with an encoding. [#3347](https://github.com/zowe/zowe-explorer-vscode/issues/3347)
-- Fixed an issue where opening a USS file as binary and attempting to "Pull from Mainframe" caused the status bar message to persist indefinitely. [#3355](https://github.com/zowe/zowe-explorer-vscode/issues/3355)
+- Fixed an issue where binary USS files were not fetched using the "Pull from Mainframe" context menu option. [#3355](https://github.com/zowe/zowe-explorer-vscode/issues/3355)
 
 ## `3.0.3`
 

--- a/packages/zowe-explorer/__tests__/__mocks__/vscode.ts
+++ b/packages/zowe-explorer/__tests__/__mocks__/vscode.ts
@@ -842,6 +842,10 @@ export class Disposable {
      * @param callOnDispose Function that disposes something.
      */
     constructor() {}
+    /**
+     * Dispose this object.
+     */
+    public dispose(): any {}
 }
 
 export function RelativePattern(base: string, pattern: string) {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSInit.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSInit.unit.test.ts
@@ -16,6 +16,7 @@ import { SharedContext } from "../../../../src/trees/shared/SharedContext";
 import { USSInit } from "../../../../src/trees/uss/USSInit";
 import { SharedActions } from "../../../../src/trees/shared/SharedActions";
 import { SharedInit } from "../../../../src/trees/shared/SharedInit";
+import { Gui } from "@zowe/zowe-explorer-api";
 
 describe("Test src/uss/extension", () => {
     describe("initUSSProvider", () => {
@@ -26,6 +27,7 @@ describe("Test src/uss/extension", () => {
             context: { subscriptions: new Array() },
             value: { test: "uss", refreshUSS: jest.fn(), openUSS: jest.fn(), deleteUSSNode: jest.fn(), getUSSDocumentFilePath: jest.fn() },
             _: { _: "_" },
+            statusMsg: { dispose: jest.fn() },
         };
         const ussFileProvider: { [key: string]: jest.Mock } = {
             createZoweSession: jest.fn(),
@@ -52,6 +54,8 @@ describe("Test src/uss/extension", () => {
                 mock: [
                     { spy: jest.spyOn(SharedContext, "isDocument"), arg: [test.value], ret: true },
                     { spy: jest.spyOn(SharedContext, "isUssDirectory"), arg: [test.value], ret: false },
+                    { spy: jest.spyOn(Gui, "setStatusBarMessage"), arg: ["$(sync~spin) Pulling from Mainframe..."], ret: test.statusMsg },
+                    { spy: jest.spyOn(test.statusMsg, "dispose"), arg: [] },
                 ],
             },
             {

--- a/packages/zowe-explorer/src/trees/uss/USSInit.ts
+++ b/packages/zowe-explorer/src/trees/uss/USSInit.ts
@@ -55,7 +55,7 @@ export class USSInit {
             vscode.commands.registerCommand("zowe.uss.refreshUSS", async (node, nodeList) => {
                 const statusMsg = Gui.setStatusBarMessage(`$(sync~spin) ${vscode.l10n.t("Pulling from Mainframe...")}`);
                 let selectedNodes = SharedUtils.getSelectedNodeList(node, nodeList) as IZoweUSSTreeNode[];
-                selectedNodes = selectedNodes.filter((x) => SharedContext.isDocument(x));
+                selectedNodes = selectedNodes.filter((x) => SharedContext.isDocument(x) || SharedContext.isBinary(node));
                 for (const item of selectedNodes) {
                     if (SharedContext.isUssDirectory(item)) {
                         // just refresh item to grab latest files

--- a/packages/zowe-explorer/src/trees/uss/USSInit.ts
+++ b/packages/zowe-explorer/src/trees/uss/USSInit.ts
@@ -71,8 +71,8 @@ export class USSInit {
                         });
                         statusMsg2.dispose();
                     }
-                    statusMsg.dispose();
                 }
+                statusMsg.dispose();
             })
         );
         context.subscriptions.push(


### PR DESCRIPTION
## Proposed changes

Fixes #3355 

## Release Notes

Milestone: 3.1.0

Changelog:

- Fixed an issue where binary USS files were not fetched using the "Pull from Mainframe" context menu option. [#3355](https://github.com/zowe/zowe-explorer-vscode/issues/3355)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [x] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have ~added new~ updated test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
