### PR TITLE
fix(v2): Toggle off Auto Save and warn user after save error

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where a migrated data set is unusable after it is recalled through Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where a recalled PDS is expandable after it is migrated through Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where data set nodes did not update if migrated or recalled outside of Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
+- Fixed an issue when Auto Save is enabled where a failed UNIX file or data set save operation resulted in an indefinite loop of additional save requests. [#2406](https://github.com/zowe/zowe-explorer-vscode/issues/2406), [#2627](https://github.com/zowe/zowe-explorer-vscode/issues/2627)
 
 ## `2.18.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/abstract/ZoweSaveQueue.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/abstract/ZoweSaveQueue.unit.test.ts
@@ -23,7 +23,7 @@ describe("ZoweSaveQueue - unit tests", () => {
         const globalMocks = {
             errorMessageSpy: jest.spyOn(Gui, "errorMessage"),
             markDocumentUnsavedSpy: jest.spyOn(workspaceUtils, "markDocumentUnsaved"),
-            checkAutoSaveForErrorMock: jest.spyOn(workspaceUtils, "checkAutoSaveForError").mockImplementation(),
+            handleAutoSaveOnErrorMock: jest.spyOn(workspaceUtils, "handleAutoSaveOnError").mockImplementation(),
             processNextSpy: jest.spyOn(ZoweSaveQueue as any, "processNext"),
             allSpy: jest.spyOn(ZoweSaveQueue, "all"),
             trees: {

--- a/packages/zowe-explorer/__tests__/__unit__/abstract/ZoweSaveQueue.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/abstract/ZoweSaveQueue.unit.test.ts
@@ -14,7 +14,6 @@ import { createUSSTree } from "../../../__mocks__/mockCreators/uss";
 import { saveUSSFile } from "../../../src/uss/actions";
 import * as workspaceUtils from "../../../src/utils/workspace";
 import { Gui } from "@zowe/zowe-explorer-api";
-import * as globals from "../../../src/globals";
 import * as vscode from "vscode";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 
@@ -24,6 +23,7 @@ describe("ZoweSaveQueue - unit tests", () => {
         const globalMocks = {
             errorMessageSpy: jest.spyOn(Gui, "errorMessage"),
             markDocumentUnsavedSpy: jest.spyOn(workspaceUtils, "markDocumentUnsaved"),
+            checkAutoSaveForErrorMock: jest.spyOn(workspaceUtils, "checkAutoSaveForError").mockImplementation(),
             processNextSpy: jest.spyOn(ZoweSaveQueue as any, "processNext"),
             allSpy: jest.spyOn(ZoweSaveQueue, "all"),
             trees: {
@@ -117,5 +117,47 @@ describe("ZoweSaveQueue - unit tests", () => {
                 'Failed to upload changes for [failingFile](command:vscode.open?["/some/failing/path"]): Example error'
             );
         }
+    });
+
+    describe("markAllUnsaved", () => {
+        function getBlockMocks(): Record<string, jest.SpyInstance> {
+            return {
+                markDocumentUnsaved: jest.spyOn(workspaceUtils, "markDocumentUnsaved").mockClear().mockImplementation(),
+            };
+        }
+
+        it("marks all documents as unsaved in the queue", async () => {
+            const blockMocks = getBlockMocks();
+            (ZoweSaveQueue as any).savingQueue = [
+                {
+                    savedFile: { fileName: "some.jcl" },
+                } as any,
+                {
+                    savedFile: { fileName: "SOME.C.DS(MEM).c" } as any,
+                } as any,
+            ];
+            await ZoweSaveQueue.markAllUnsaved();
+            expect(blockMocks.markDocumentUnsaved).toHaveBeenCalledTimes(2);
+        });
+
+        it("clears the queue if clearQueue is true", async () => {
+            (ZoweSaveQueue as any).savingQueue = [
+                {
+                    savedFile: { fileName: "some.jcl" },
+                } as any,
+            ];
+            await ZoweSaveQueue.markAllUnsaved();
+            expect((ZoweSaveQueue as any).savingQueue.length).toBe(0);
+        });
+
+        it("does not clear the queue if clearQueue is false", async () => {
+            (ZoweSaveQueue as any).savingQueue = [
+                {
+                    savedFile: { fileName: "some.jcl" },
+                } as any,
+            ];
+            await ZoweSaveQueue.markAllUnsaved(false);
+            expect((ZoweSaveQueue as any).savingQueue.length).toBe(1);
+        });
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -43,6 +43,7 @@ import { getNodeLabels } from "../../../src/dataset/utils";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 import { mocked } from "../../../__mocks__/mockUtils";
 import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
+import * as workspaceUtils from "../../../src/utils/workspace";
 
 // Missing the definition of path module, because I need the original logic for tests
 jest.mock("fs");
@@ -1073,6 +1074,7 @@ describe("Dataset Actions Unit Tests - Function saveFile", () => {
             profileInstance,
             testDatasetTree,
             uploadContentSpy,
+            handleAutoSaveOnError: jest.spyOn(workspaceUtils, "handleAutoSaveOnError").mockImplementation(),
         };
     }
 
@@ -1238,6 +1240,7 @@ describe("Dataset Actions Unit Tests - Function saveFile", () => {
         (testDocument as any).fileName = path.join(globals.DS_DIR, testDocument.fileName);
 
         await dsActions.saveFile(testDocument, blockMocks.testDatasetTree);
+        expect(blockMocks.handleAutoSaveOnError).toHaveBeenCalled();
 
         expect(globalMocks.concatChildNodes).toBeCalled();
         expect(mocked(Gui.errorMessage)).toBeCalledWith("failed");

--- a/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/actions.unit.test.ts
@@ -463,7 +463,7 @@ describe("USS Action Unit Tests - Function saveUSSFile", () => {
             ussNode: createUSSNode(globalMocks.testSession, globalMocks.testProfile),
             ussFavoriteNode: createFavoriteUSSNode(globalMocks.testSession, globalMocks.testProfile),
             putUSSPayload: jest.fn().mockResolvedValue(`{"stdout":[""]}`),
-            checkAutoSaveForError: jest.spyOn(workspaceUtils, "checkAutoSaveForError"),
+            handleAutoSaveOnError: jest.spyOn(workspaceUtils, "handleAutoSaveOnError"),
             // Disable auto save for most of the test cases
             getDirectValue: jest.spyOn(SettingsConfig, "getDirectValue").mockReturnValueOnce("off"),
         };
@@ -549,7 +549,7 @@ describe("USS Action Unit Tests - Function saveUSSFile", () => {
         );
     });
 
-    it("calls checkForAutoSave in the event of an error", async () => {
+    it("calls handleAutoSaveOnError in the event of an error", async () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = await createBlockMocks(globalMocks);
 
@@ -561,7 +561,7 @@ describe("USS Action Unit Tests - Function saveUSSFile", () => {
         globalMocks.withProgress.mockReturnValueOnce(blockMocks.testResponse);
 
         await ussNodeActions.saveUSSFile(blockMocks.testDoc, blockMocks.testUSSTree);
-        expect(blockMocks.checkAutoSaveForError).toHaveBeenCalled();
+        expect(blockMocks.handleAutoSaveOnError).toHaveBeenCalled();
     });
 
     it("Tests that saveUSSFile fails when save fails", async () => {
@@ -590,7 +590,7 @@ describe("USS Action Unit Tests - Function saveUSSFile", () => {
         globalMocks.withProgress.mockRejectedValueOnce(Error("Test Error"));
 
         await ussNodeActions.saveUSSFile(blockMocks.testDoc, blockMocks.testUSSTree);
-        expect(blockMocks.checkAutoSaveForError).toHaveBeenCalled();
+        expect(blockMocks.handleAutoSaveOnError).toHaveBeenCalled();
         expect(globalMocks.showErrorMessage.mock.calls.length).toBe(1);
         expect(globalMocks.showErrorMessage.mock.calls[0][0]).toBe("Error: Test Error");
         expect(mocked(vscode.workspace.applyEdit)).toHaveBeenCalledTimes(2);

--- a/packages/zowe-explorer/__tests__/__unit__/utils/workspace.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/workspace.unit.test.ts
@@ -271,9 +271,18 @@ describe("Workspace Utils Unit Tests - function handleAutoSaveOnError", () => {
         );
     });
 
-    it("reactivates Auto Save if 'Enable Auto Save' clicked", async () => {
+    it("does nothing if 'Enable Auto Save' clicked and Auto Save is already on", async () => {
         const blockMocks = getBlockMocks(true, "Enable Auto Save");
         await workspaceUtils.handleAutoSaveOnError();
+        expect(blockMocks.executeCommand).toHaveBeenCalledWith("workbench.action.toggleAutoSave");
+        expect(blockMocks.executeCommand).toHaveBeenCalledTimes(1);
+    });
+
+    it("reactivates Auto Save if 'Enable Auto Save' clicked", async () => {
+        const blockMocks = getBlockMocks(true, "Enable Auto Save");
+        blockMocks.getDirectValue.mockReturnValueOnce("off");
+        await workspaceUtils.handleAutoSaveOnError();
+        expect(blockMocks.executeCommand).toHaveBeenCalledTimes(2);
         expect(blockMocks.executeCommand).toHaveBeenCalledWith("workbench.action.toggleAutoSave");
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/utils/workspace.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/workspace.unit.test.ts
@@ -220,7 +220,7 @@ describe("Workspace Utils Unit Tests - function awaitForDocumentBeingSaved", () 
     });
 });
 
-describe("Workspace Utils Unit Tests - function checkAutoSaveForError", () => {
+describe("Workspace Utils Unit Tests - function handleAutoSaveOnError", () => {
     function getBlockMocks(autoSaveEnabled: boolean = true, userResponse?: string): Record<string, jest.SpyInstance> {
         const executeCommand = jest.spyOn(vscode.commands, "executeCommand").mockClear();
         const getDirectValue = jest.spyOn(SettingsConfig, "getDirectValue");
@@ -245,26 +245,26 @@ describe("Workspace Utils Unit Tests - function checkAutoSaveForError", () => {
 
     it("returns early if Auto Save is disabled", async () => {
         const blockMocks = getBlockMocks(false);
-        await workspaceUtils.checkAutoSaveForError();
+        await workspaceUtils.handleAutoSaveOnError();
         expect(blockMocks.getDirectValue).toHaveBeenCalledWith("files.autoSave");
         expect(blockMocks.executeCommand).not.toHaveBeenCalled();
     });
 
     it("toggles off auto save if enabled", async () => {
         const blockMocks = getBlockMocks(true);
-        await workspaceUtils.checkAutoSaveForError();
+        await workspaceUtils.handleAutoSaveOnError();
         expect(blockMocks.executeCommand).toHaveBeenCalledWith("workbench.action.toggleAutoSave");
     });
 
     it("calls ZoweSaveQueue.markAllUnsaved to mark documents unsaved and clear queue", async () => {
         const blockMocks = getBlockMocks(true);
-        await workspaceUtils.checkAutoSaveForError();
+        await workspaceUtils.handleAutoSaveOnError();
         expect(blockMocks.markAllUnsaved).toHaveBeenCalled();
     });
 
     it("prompts the user to reactivate Auto Save in event of save error", async () => {
         const blockMocks = getBlockMocks(true);
-        await workspaceUtils.checkAutoSaveForError();
+        await workspaceUtils.handleAutoSaveOnError();
         expect(blockMocks.errorMessage).toHaveBeenCalledWith(
             "Zowe Explorer encountered a save error and has disabled Auto Save. Once the issue is addressed, enable Auto Save and try again.",
             { items: ["Enable Auto Save"] }
@@ -273,7 +273,7 @@ describe("Workspace Utils Unit Tests - function checkAutoSaveForError", () => {
 
     it("reactivates Auto Save if 'Enable Auto Save' clicked", async () => {
         const blockMocks = getBlockMocks(true, "Enable Auto Save");
-        await workspaceUtils.checkAutoSaveForError();
+        await workspaceUtils.handleAutoSaveOnError();
         expect(blockMocks.executeCommand).toHaveBeenCalledWith("workbench.action.toggleAutoSave");
     });
 });

--- a/packages/zowe-explorer/i18n/sample/src/uss/USSTree.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/uss/USSTree.i18n.json
@@ -1,6 +1,5 @@
 {
   "Favorites": "Favorites",
-  "renameUSS.unsavedWork": "Unable to rename {0} because you have unsaved changes in this {1}. Please save your work before renaming the {1}.",
   "renameUSS.enterName": "Enter a new name for the {0}",
   "renameUSS.error": "Unable to rename node:",
   "renameUSS.duplicateName": "A {0} already exists with this name. Please choose a different name.",

--- a/packages/zowe-explorer/i18n/sample/src/utils/TreeViewUtils.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/utils/TreeViewUtils.i18n.json
@@ -1,0 +1,4 @@
+{
+  "uss.renameNode": "Rename",
+  "unsavedChanges.errorMsg": "Unable to {0} {1} because you have unsaved changes in this {2}. Please save your work and try again."
+}

--- a/packages/zowe-explorer/i18n/sample/src/utils/workspace.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/utils/workspace.i18n.json
@@ -1,0 +1,4 @@
+{
+  "zowe.autoSaveToggled": "Zowe Explorer encountered a save error and has disabled Auto Save. Once the issue is addressed, enable Auto Save and try again.",
+  "zowe.enableAutoSave": "Enable Auto Save"
+}

--- a/packages/zowe-explorer/src/abstract/ZoweSaveQueue.ts
+++ b/packages/zowe-explorer/src/abstract/ZoweSaveQueue.ts
@@ -12,7 +12,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { Gui, IZoweTree, IZoweTreeNode } from "@zowe/zowe-explorer-api";
-import { markDocumentUnsaved } from "../utils/workspace";
+import { checkAutoSaveForError, markDocumentUnsaved } from "../utils/workspace";
 import { ZoweLogger } from "../utils/LoggerUtils";
 
 // Set up localization
@@ -57,6 +57,20 @@ export class ZoweSaveQueue {
     private static savingQueue: SaveRequest[] = [];
 
     /**
+     * Marks all documents in the save queue as unsaved.
+     * @param clearQueue Whether to clear the queue after marking the documents as unsaved (default: `true`)
+     */
+    public static async markAllUnsaved(clearQueue: boolean = true): Promise<void> {
+        for (const { savedFile } of this.savingQueue) {
+            await markDocumentUnsaved(savedFile);
+        }
+
+        if (clearQueue) {
+            this.savingQueue = [];
+        }
+    }
+
+    /**
      * Iterate over the queue and process next item until it is empty.
      */
     private static async processNext(): Promise<void> {
@@ -71,6 +85,7 @@ export class ZoweSaveQueue {
         } catch (err) {
             ZoweLogger.error(err);
             await markDocumentUnsaved(nextRequest.savedFile);
+            await checkAutoSaveForError();
             await Gui.errorMessage(
                 localize(
                     "processNext.error.uploadFailed",

--- a/packages/zowe-explorer/src/abstract/ZoweSaveQueue.ts
+++ b/packages/zowe-explorer/src/abstract/ZoweSaveQueue.ts
@@ -12,7 +12,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { Gui, IZoweTree, IZoweTreeNode } from "@zowe/zowe-explorer-api";
-import { checkAutoSaveForError, markDocumentUnsaved } from "../utils/workspace";
+import { handleAutoSaveOnError, markDocumentUnsaved } from "../utils/workspace";
 import { ZoweLogger } from "../utils/LoggerUtils";
 
 // Set up localization
@@ -85,7 +85,7 @@ export class ZoweSaveQueue {
         } catch (err) {
             ZoweLogger.error(err);
             await markDocumentUnsaved(nextRequest.savedFile);
-            await checkAutoSaveForError();
+            await handleAutoSaveOnError();
             await Gui.errorMessage(
                 localize(
                     "processNext.error.uploadFailed",

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -33,7 +33,7 @@ import { Profiles } from "../Profiles";
 import { getIconByNode } from "../generators/icons";
 import { ZoweDatasetNode } from "./ZoweDatasetNode";
 import * as contextually from "../shared/context";
-import { markDocumentUnsaved, setFileSaved } from "../utils/workspace";
+import { checkAutoSaveForError, markDocumentUnsaved, setFileSaved } from "../utils/workspace";
 import { IUploadOptions } from "@zowe/zos-files-for-zowe-sdk";
 import { ZoweLogger } from "../utils/LoggerUtils";
 import { ProfileManagement } from "../utils/ProfileManagement";
@@ -1566,6 +1566,7 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
             return;
         }
     } catch (err) {
+        await checkAutoSaveForError();
         await markDocumentUnsaved(doc);
         await errorHandling(err, sesName);
         return;
@@ -1610,10 +1611,12 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
         } else if (!uploadResponse.success && uploadResponse.commandResponse.includes("Rest API failure with HTTP(S) status 412")) {
             resolveFileConflict(node, prof, doc, label);
         } else {
+            await checkAutoSaveForError();
             await markDocumentUnsaved(doc);
             api.Gui.errorMessage(uploadResponse.commandResponse);
         }
     } catch (err) {
+        await checkAutoSaveForError();
         await markDocumentUnsaved(doc);
         await errorHandling(err, sesName);
     }

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -33,7 +33,7 @@ import { Profiles } from "../Profiles";
 import { getIconByNode } from "../generators/icons";
 import { ZoweDatasetNode } from "./ZoweDatasetNode";
 import * as contextually from "../shared/context";
-import { checkAutoSaveForError, markDocumentUnsaved, setFileSaved } from "../utils/workspace";
+import { handleAutoSaveOnError, markDocumentUnsaved, setFileSaved } from "../utils/workspace";
 import { IUploadOptions } from "@zowe/zos-files-for-zowe-sdk";
 import { ZoweLogger } from "../utils/LoggerUtils";
 import { ProfileManagement } from "../utils/ProfileManagement";
@@ -1566,7 +1566,7 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
             return;
         }
     } catch (err) {
-        await checkAutoSaveForError();
+        await handleAutoSaveOnError();
         await markDocumentUnsaved(doc);
         await errorHandling(err, sesName);
         return;
@@ -1611,12 +1611,12 @@ export async function saveFile(doc: vscode.TextDocument, datasetProvider: api.IZ
         } else if (!uploadResponse.success && uploadResponse.commandResponse.includes("Rest API failure with HTTP(S) status 412")) {
             resolveFileConflict(node, prof, doc, label);
         } else {
-            await checkAutoSaveForError();
+            await handleAutoSaveOnError();
             await markDocumentUnsaved(doc);
             api.Gui.errorMessage(uploadResponse.commandResponse);
         }
     } catch (err) {
-        await checkAutoSaveForError();
+        await handleAutoSaveOnError();
         await markDocumentUnsaved(doc);
         await errorHandling(err, sesName);
     }

--- a/packages/zowe-explorer/src/uss/actions.ts
+++ b/packages/zowe-explorer/src/uss/actions.ts
@@ -21,7 +21,7 @@ import { Profiles } from "../Profiles";
 import { ZoweExplorerApiRegister } from "../ZoweExplorerApiRegister";
 import { isBinaryFileSync } from "isbinaryfile";
 import * as contextually from "../shared/context";
-import { checkAutoSaveForError, markDocumentUnsaved, setFileSaved } from "../utils/workspace";
+import { handleAutoSaveOnError, markDocumentUnsaved, setFileSaved } from "../utils/workspace";
 import * as nls from "vscode-nls";
 import { refreshAll } from "../shared/refresh";
 import { autoDetectEncoding, fileExistsCaseSensitiveSync } from "./utils";
@@ -319,7 +319,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: IZo
             LocalFileManagement.removeRecoveredFile(doc);
             // this part never runs! zowe.Upload.fileToUSSFile doesn't return success: false, it just throws the error which is caught below!!!!!
         } else {
-            await checkAutoSaveForError();
+            await handleAutoSaveOnError();
             await markDocumentUnsaved(doc);
             Gui.errorMessage(uploadResponse.commandResponse);
         }
@@ -329,7 +329,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: IZo
         if (errorMessage.includes("Rest API failure with HTTP(S) status 412")) {
             resolveFileConflict(node, prof, doc, remote);
         } else {
-            await checkAutoSaveForError();
+            await handleAutoSaveOnError();
             await markDocumentUnsaved(doc);
             await errorHandling(err, sesName);
         }

--- a/packages/zowe-explorer/src/uss/actions.ts
+++ b/packages/zowe-explorer/src/uss/actions.ts
@@ -21,7 +21,7 @@ import { Profiles } from "../Profiles";
 import { ZoweExplorerApiRegister } from "../ZoweExplorerApiRegister";
 import { isBinaryFileSync } from "isbinaryfile";
 import * as contextually from "../shared/context";
-import { markDocumentUnsaved, setFileSaved } from "../utils/workspace";
+import { checkAutoSaveForError, markDocumentUnsaved, setFileSaved } from "../utils/workspace";
 import * as nls from "vscode-nls";
 import { refreshAll } from "../shared/refresh";
 import { autoDetectEncoding, fileExistsCaseSensitiveSync } from "./utils";
@@ -319,6 +319,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: IZo
             LocalFileManagement.removeRecoveredFile(doc);
             // this part never runs! zowe.Upload.fileToUSSFile doesn't return success: false, it just throws the error which is caught below!!!!!
         } else {
+            await checkAutoSaveForError();
             await markDocumentUnsaved(doc);
             Gui.errorMessage(uploadResponse.commandResponse);
         }
@@ -328,6 +329,7 @@ export async function saveUSSFile(doc: vscode.TextDocument, ussFileProvider: IZo
         if (errorMessage.includes("Rest API failure with HTTP(S) status 412")) {
             resolveFileConflict(node, prof, doc, remote);
         } else {
+            await checkAutoSaveForError();
             await markDocumentUnsaved(doc);
             await errorHandling(err, sesName);
         }

--- a/packages/zowe-explorer/src/utils/workspace.ts
+++ b/packages/zowe-explorer/src/utils/workspace.ts
@@ -16,6 +16,17 @@ import {
     workspaceUtilFileSaveInterval,
     workspaceUtilFileSaveMaxIterationCount,
 } from "../config/constants";
+import { SettingsConfig } from "./SettingsConfig";
+import { Gui } from "@zowe/zowe-explorer-api";
+
+// Set up localization
+import * as nls from "vscode-nls";
+import { ZoweSaveQueue } from "../abstract/ZoweSaveQueue";
+nls.config({
+    messageFormat: nls.MessageFormat.bundle,
+    bundleFormat: nls.BundleFormat.standalone,
+})();
+const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 interface IExtTextEditor extends vscode.TextEditor {
     id: string;
@@ -142,4 +153,44 @@ export async function markDocumentUnsaved(document: vscode.TextDocument): Promis
     const edits2 = new vscode.WorkspaceEdit();
     edits2.delete(document.uri, new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 1)));
     await vscode.workspace.applyEdit(edits2);
+}
+
+/**
+ * Call in the event of a save error. This function checks if `Auto Save` is enabled:
+ * - If enabled, it is toggled off to prevent an error loop and an error message is shown to inform the user.
+ * - If disabled, the function returns.
+ *
+ * The user can either dismiss the message or click the "Enable Auto Save" button to reactivate the `Auto Save` feature.
+ */
+export async function checkAutoSaveForError(): Promise<void> {
+    // If auto save is disabled, return. Otherwise, toggle it off
+    if (SettingsConfig.getDirectValue("files.autoSave") === "off") {
+        return;
+    }
+    await vscode.commands.executeCommand("workbench.action.toggleAutoSave");
+
+    // Mark remaining documents in queue as unsaved and clear the queue
+    await ZoweSaveQueue.markAllUnsaved();
+
+    // Inform the user that `Auto Save` was disabled and offer a button to re-enable it
+    Gui.errorMessage(
+        localize(
+            "zowe.autoSaveToggled",
+            "Zowe Explorer encountered a save error and has disabled Auto Save. Once the issue is addressed, enable Auto Save and try again."
+        ),
+        {
+            items: [localize("zowe.enableAutoSave", "Enable Auto Save")],
+        }
+    ).then(async (value) => {
+        if (!value) {
+            // User dismissed the message
+            return;
+        }
+
+        // Toggle auto save back on IFF it wasn't already reactivated
+        // (the prompt can be answered or dismissed at any point after its shown)
+        if (SettingsConfig.getDirectValue("files.autoSave") === "off") {
+            await vscode.commands.executeCommand("workbench.action.toggleAutoSave");
+        }
+    });
 }

--- a/packages/zowe-explorer/src/utils/workspace.ts
+++ b/packages/zowe-explorer/src/utils/workspace.ts
@@ -162,7 +162,7 @@ export async function markDocumentUnsaved(document: vscode.TextDocument): Promis
  *
  * The user can either dismiss the message or click the "Enable Auto Save" button to reactivate the `Auto Save` feature.
  */
-export async function checkAutoSaveForError(): Promise<void> {
+export async function handleAutoSaveOnError(): Promise<void> {
     // If auto save is disabled, return. Otherwise, toggle it off
     if (SettingsConfig.getDirectValue("files.autoSave") === "off") {
         return;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4731,7 +4731,7 @@ cross-env@^5.2.0:
   dependencies:
     cross-spawn "^6.0.5"
 
-cross-spawn@7.0.6, cross-spawn@^6.0.5, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
+cross-spawn@7.0.6, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -4739,6 +4739,17 @@ cross-spawn@7.0.6, cross-spawn@^6.0.5, cross-spawn@^7.0.0, cross-spawn@^7.0.2, c
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+cross-spawn@^6.0.5:
+  version "6.0.6"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz#30d0efa0712ddb7eb5a76e1e8721bffafa6b5d57"
+  integrity sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 crypt@0.0.2:
   version "0.0.2"
@@ -8778,6 +8789,11 @@ next-tick@1, next-tick@^1.1.0:
   resolved "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
+  integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
 nise@^1.4.5:
   version "1.5.3"
   resolved "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz"
@@ -9361,6 +9377,11 @@ path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
   integrity sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=
+
+path-key@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+  integrity sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==
 
 path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -10308,7 +10329,7 @@ semver-greatest-satisfied-range@^1.1.0:
   dependencies:
     sver-compat "^1.5.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.5.0, semver@^5.6.0:
   version "5.7.2"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -10379,12 +10400,24 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==
+  dependencies:
+    shebang-regex "^1.0.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
 
 shebang-regex@^3.0.0:
   version "3.0.0"
@@ -11899,7 +11932,7 @@ which@4.0.0, which@^4.0.0:
   dependencies:
     isexe "^3.1.1"
 
-which@^1.2.14, which@^1.3.1:
+which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
## Proposed changes

Fixes #2406, #2627 

**Error message shown when Auto Save is enabled:**
![image](https://github.com/user-attachments/assets/0831bec6-49a8-4a7f-b52d-266164796a94)

### How to test

- Locate a UNIX file or data set with insufficient write permissions.
- Open this resource in Zowe Explorer.
- Enable Auto Save and make changes to the file
- Notice that when the save error occurs, the document is marked unsaved and no more save requests are made. Notice that Auto Save is also disabled.
  - Try enabling the Auto Save feature using either the "Enable Auto Save" option in this dialog, or by using the Command Palette -> "Files: Toggle Auto Save". The process will repeat at this point, but the save request will only happen once.

When Auto Save is used with v2.18.0, save requests were continuously added for each data set and file that failed to save. Even if you would try to close the file or dismiss the error, another request would be added, and a reload of VS Code was necessary to stop the loop.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 2.18.1

Changelog:

- Fixed an issue when Auto Save is enabled where a failed UNIX file or data set save operation resulted in an indefinite loop of additional save requests. [#2406](https://github.com/zowe/zowe-explorer-vscode/issues/2406), [#2627](https://github.com/zowe/zowe-explorer-vscode/issues/2627)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [x] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
