### PR TITLE
Add ability to view Job Spool with encoding

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 - Added support for extenders to obtain an updated Session that will includes VS Code proxy settings values if set, `getProfileSessionWithVscProxy`. [#3010](https://github.com/zowe/zowe-explorer-vscode/issues/3010)
 - Added support for VS Code proxy settings with zosmf profile types. [#3010](https://github.com/zowe/zowe-explorer-vscode/issues/3010)
 - Added optional `getLocalStorage` function to the `IApiExplorerExtender` interface to expose local storage access to Zowe Explorer extenders. [#3180](https://github.com/zowe/zowe-explorer-vscode/issues/3180)
+- Added optional `setEncoding`, `getEncoding`, and `getEncodingInMap` functions to the `IZoweJobTreeNode` interface. [#3361](https://github.com/zowe/zowe-explorer-vscode/pull/3361)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -507,22 +507,31 @@ export interface IZoweJobTreeNode extends IZoweTreeNode {
     /**
      * Sets the encoding of the job node
      *
-     * @returns {void}
+     * @returns {void | PromiseLike<void>}
      */
-    setEncoding?(encoding: ZosEncoding): void;
+    setEncoding?(encoding: ZosEncoding): void | PromiseLike<void>;
 
     /**
      * Gets the encoding of the job node
      *
-     * @returns {ZosEncoding}
+     * @returns {ZosEncoding | PromiseLike<ZosEncoding>}
      */
-    getEncoding?(): ZosEncoding;
+    getEncoding?(): ZosEncoding | PromiseLike<ZosEncoding>;
 
     /**
      * Gets the encoding of a job node given a path
      *
-     * @param {string} uriPath the basepath of the node
-     * @returns {ZosEncoding}
+     * @param {string} uriPath the path of the node
+     * @returns {ZosEncoding | PromiseLike<ZosEncoding>}
      */
     getEncodingInMap?(uriPath: string): ZosEncoding | PromiseLike<ZosEncoding>;
+
+    /**
+     * Updates the encoding of a job node given a path
+     *
+     * @param {string} uriPath the path of the node
+     * @param {ZosEncoding} encoding the encoding to apply
+     * @returns {void | PromiseLike<void>}
+     */
+    updateEncodingInMap?(uriPath: string, encoding: ZosEncoding): void | PromiseLike<void>;
 }

--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -503,4 +503,18 @@ export interface IZoweJobTreeNode extends IZoweTreeNode {
      * @returns {Promise<IZoweJobTreeNode[]>}
      */
     getChildren(): Promise<IZoweJobTreeNode[]>;
+
+    /**
+     * Sets the encoding of the job node
+     *
+     * @returns {void}
+     */
+    setEncoding?(encoding: ZosEncoding): void;
+
+    /**
+     * Gets the encoding of the job node
+     *
+     * @returns {ZosEncoding}
+     */
+    getEncoding?(): ZosEncoding;
 }

--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -517,4 +517,12 @@ export interface IZoweJobTreeNode extends IZoweTreeNode {
      * @returns {ZosEncoding}
      */
     getEncoding?(): ZosEncoding;
+
+    /**
+     * Gets the encoding of a job node given a path
+     *
+     * @param {string} uriPath the basepath of the node
+     * @returns {ZosEncoding}
+     */
+    getEncodingInMap?(uriPath: string): ZosEncoding | PromiseLike<ZosEncoding>;
 }

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Allow extenders to add context menu actions to a top level node, i.e. data sets, USS, Jobs, by encoding the profile type in the context value. [#3309](https://github.com/zowe/zowe-explorer-vscode/pull/3309)
 - You can now add multiple partitioned data sets or USS directories to your workspace at once using the "Add to Workspace" feature. [#3324](https://github.com/zowe/zowe-explorer-vscode/issues/3324)
 - Exposed read and write access to local storage keys for Zowe Explorer extenders. [#3180](https://github.com/zowe/zowe-explorer-vscode/issues/3180)
+- Added `Open with Encoding` to the context menu of Job Spool files. [#1941](https://github.com/zowe/zowe-explorer-vscode/issues/1941)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/JobTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/JobTree.unit.test.ts
@@ -11,8 +11,15 @@
 
 import * as vscode from "vscode";
 import * as zosjobs from "@zowe/zos-jobs-for-zowe-sdk";
-import { Gui, imperative, IZoweJobTreeNode, ProfilesCache, Validation, Poller } from "@zowe/zowe-explorer-api";
-import { createIJobFile, createIJobObject, createJobFavoritesNode, createJobSessionNode, MockJobDetail } from "../../../__mocks__/mockCreators/jobs";
+import { Gui, imperative, IZoweJobTreeNode, ProfilesCache, Validation, Poller, ZosEncoding } from "@zowe/zowe-explorer-api";
+import {
+    createIJobFile,
+    createIJobObject,
+    createJobFavoritesNode,
+    createJobNode,
+    createJobSessionNode,
+    MockJobDetail,
+} from "../../../__mocks__/mockCreators/jobs";
 import {
     createIProfile,
     createISession,
@@ -1165,5 +1172,149 @@ describe("ZosJobsProvider Unit Test - Filter Jobs", () => {
         await testTree.filterJobsDialog(node1);
         expect(filterJobsSpy).toHaveBeenCalled();
         expect(filterJobsSpy).toHaveBeenCalledWith(node1);
+    });
+});
+
+describe("openWithEncoding", () => {
+    beforeEach(async () => {
+        await createGlobalMocks();
+        jest.restoreAllMocks();
+    });
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+    it("should open a Job Spool file with an encoding (binary, prompted)", async () => {
+        const testTree = new JobTree();
+
+        const spoolNode = new ZoweSpoolNode({ label: "SPOOL", collapsibleState: vscode.TreeItemCollapsibleState.None, spool: createIJobFile() });
+
+        const encoding: ZosEncoding = { kind: "binary" };
+
+        const promptMock = jest.spyOn(SharedUtils, "promptForEncoding").mockResolvedValue(encoding);
+        const executeCommandMock = jest.spyOn(vscode.commands, "executeCommand").mockImplementation();
+        const fetchSpoolAtUriMock = jest.spyOn(JobFSProvider.instance, "fetchSpoolAtUri").mockImplementation();
+        const setEncodingSpy = jest.spyOn(spoolNode, "setEncoding").mockImplementation();
+
+        await testTree.openWithEncoding(spoolNode);
+        expect(promptMock).toHaveBeenCalledWith(spoolNode);
+        expect(promptMock).toHaveBeenCalledTimes(1);
+        expect(setEncodingSpy).toHaveBeenCalledWith(encoding);
+        expect(fetchSpoolAtUriMock).toHaveBeenCalledTimes(1);
+        expect(executeCommandMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should open a Job Spool file with an encoding (binary, provided)", async () => {
+        const testTree = new JobTree();
+
+        const spoolNode = new ZoweSpoolNode({ label: "SPOOL", collapsibleState: vscode.TreeItemCollapsibleState.None, spool: createIJobFile() });
+
+        const encoding: ZosEncoding = { kind: "binary" };
+
+        const promptMock = jest.spyOn(SharedUtils, "promptForEncoding");
+        const executeCommandMock = jest.spyOn(vscode.commands, "executeCommand").mockImplementation();
+        const setEncodingSpy = jest.spyOn(spoolNode, "setEncoding").mockImplementation();
+        const fetchSpoolAtUriMock = jest.spyOn(JobFSProvider.instance, "fetchSpoolAtUri").mockImplementation();
+
+        await testTree.openWithEncoding(spoolNode, encoding);
+        expect(promptMock).toHaveBeenCalledTimes(0);
+        expect(setEncodingSpy).toHaveBeenCalledWith(encoding);
+        expect(fetchSpoolAtUriMock).toHaveBeenCalledTimes(1);
+        expect(executeCommandMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should open a Job Spool file with an encoding (ascii, prompted)", async () => {
+        const testTree = new JobTree();
+
+        const spoolNode = new ZoweSpoolNode({ label: "SPOOL", collapsibleState: vscode.TreeItemCollapsibleState.None, spool: createIJobFile() });
+
+        const encoding: ZosEncoding = { kind: "text" };
+
+        const promptMock = jest.spyOn(SharedUtils, "promptForEncoding").mockResolvedValue(encoding);
+        const executeCommandMock = jest.spyOn(vscode.commands, "executeCommand").mockImplementation();
+        const fetchSpoolAtUriMock = jest.spyOn(JobFSProvider.instance, "fetchSpoolAtUri").mockImplementation();
+        const setEncodingSpy = jest.spyOn(spoolNode, "setEncoding").mockImplementation();
+
+        await testTree.openWithEncoding(spoolNode);
+        expect(promptMock).toHaveBeenCalledWith(spoolNode);
+        expect(promptMock).toHaveBeenCalledTimes(1);
+        expect(setEncodingSpy).toHaveBeenCalledWith(encoding);
+        expect(fetchSpoolAtUriMock).toHaveBeenCalledTimes(1);
+        expect(executeCommandMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should open a Job Spool file with an encoding (ascii, provided)", async () => {
+        const testTree = new JobTree();
+
+        const spoolNode = new ZoweSpoolNode({ label: "SPOOL", collapsibleState: vscode.TreeItemCollapsibleState.None, spool: createIJobFile() });
+
+        const encoding: ZosEncoding = { kind: "text" };
+
+        const promptMock = jest.spyOn(SharedUtils, "promptForEncoding");
+        const executeCommandMock = jest.spyOn(vscode.commands, "executeCommand").mockImplementation();
+        const setEncodingSpy = jest.spyOn(spoolNode, "setEncoding").mockImplementation();
+        const fetchSpoolAtUriMock = jest.spyOn(JobFSProvider.instance, "fetchSpoolAtUri").mockImplementation();
+
+        await testTree.openWithEncoding(spoolNode, encoding);
+        expect(promptMock).toHaveBeenCalledTimes(0);
+        expect(setEncodingSpy).toHaveBeenCalledWith(encoding);
+        expect(fetchSpoolAtUriMock).toHaveBeenCalledTimes(1);
+        expect(executeCommandMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should open a Job Spool file with an encoding (other, prompted)", async () => {
+        const testTree = new JobTree();
+
+        const spoolNode = new ZoweSpoolNode({ label: "SPOOL", collapsibleState: vscode.TreeItemCollapsibleState.None, spool: createIJobFile() });
+
+        const encoding: ZosEncoding = { kind: "other", codepage: "IBM-1147" };
+
+        const promptMock = jest.spyOn(SharedUtils, "promptForEncoding").mockResolvedValue(encoding);
+        const executeCommandMock = jest.spyOn(vscode.commands, "executeCommand").mockImplementation();
+        const fetchSpoolAtUriMock = jest.spyOn(JobFSProvider.instance, "fetchSpoolAtUri").mockImplementation();
+        const setEncodingSpy = jest.spyOn(spoolNode, "setEncoding").mockImplementation();
+
+        await testTree.openWithEncoding(spoolNode);
+        expect(promptMock).toHaveBeenCalledWith(spoolNode);
+        expect(promptMock).toHaveBeenCalledTimes(1);
+        expect(setEncodingSpy).toHaveBeenCalledWith(encoding);
+        expect(fetchSpoolAtUriMock).toHaveBeenCalledTimes(1);
+        expect(executeCommandMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should open a Job Spool file with an encoding (other, provided)", async () => {
+        const testTree = new JobTree();
+
+        const spoolNode = new ZoweSpoolNode({ label: "SPOOL", collapsibleState: vscode.TreeItemCollapsibleState.None, spool: createIJobFile() });
+
+        const encoding: ZosEncoding = { kind: "other", codepage: "IBM-1147" };
+
+        const promptMock = jest.spyOn(SharedUtils, "promptForEncoding");
+        const executeCommandMock = jest.spyOn(vscode.commands, "executeCommand").mockImplementation();
+        const setEncodingSpy = jest.spyOn(spoolNode, "setEncoding").mockImplementation();
+        const fetchSpoolAtUriMock = jest.spyOn(JobFSProvider.instance, "fetchSpoolAtUri").mockImplementation();
+
+        await testTree.openWithEncoding(spoolNode, encoding);
+        expect(promptMock).toHaveBeenCalledTimes(0);
+        expect(setEncodingSpy).toHaveBeenCalledWith(encoding);
+        expect(fetchSpoolAtUriMock).toHaveBeenCalledTimes(1);
+        expect(executeCommandMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("should open a Job Spool file with an encoding (undefined, prompted)", async () => {
+        const testTree = new JobTree();
+
+        const spoolNode = new ZoweSpoolNode({ label: "SPOOL", collapsibleState: vscode.TreeItemCollapsibleState.None, spool: createIJobFile() });
+
+        const promptMock = jest.spyOn(SharedUtils, "promptForEncoding").mockResolvedValue(undefined);
+        const executeCommandMock = jest.spyOn(vscode.commands, "executeCommand").mockImplementation();
+        const fetchSpoolAtUriMock = jest.spyOn(JobFSProvider.instance, "fetchSpoolAtUri").mockImplementation();
+        const setEncodingSpy = jest.spyOn(spoolNode, "setEncoding").mockImplementation();
+
+        await testTree.openWithEncoding(spoolNode);
+        expect(promptMock).toHaveBeenCalledWith(spoolNode);
+        expect(promptMock).toHaveBeenCalledTimes(1);
+        expect(setEncodingSpy).toHaveBeenCalledTimes(0);
+        expect(fetchSpoolAtUriMock).toHaveBeenCalledTimes(0);
+        expect(executeCommandMock).toHaveBeenCalledTimes(0);
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/JobTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/JobTree.unit.test.ts
@@ -12,14 +12,7 @@
 import * as vscode from "vscode";
 import * as zosjobs from "@zowe/zos-jobs-for-zowe-sdk";
 import { Gui, imperative, IZoweJobTreeNode, ProfilesCache, Validation, Poller, ZosEncoding } from "@zowe/zowe-explorer-api";
-import {
-    createIJobFile,
-    createIJobObject,
-    createJobFavoritesNode,
-    createJobNode,
-    createJobSessionNode,
-    MockJobDetail,
-} from "../../../__mocks__/mockCreators/jobs";
+import { createIJobFile, createIJobObject, createJobFavoritesNode, createJobSessionNode, MockJobDetail } from "../../../__mocks__/mockCreators/jobs";
 import {
     createIProfile,
     createISession,

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/ZoweJobNode.unit.test.ts
@@ -13,7 +13,7 @@ jest.mock("@zowe/zos-jobs-for-zowe-sdk");
 import * as vscode from "vscode";
 import * as zosjobs from "@zowe/zos-jobs-for-zowe-sdk";
 import * as zosmf from "@zowe/zosmf-for-zowe-sdk";
-import { createIJobFile, createIJobObject, createJobSessionNode } from "../../../__mocks__/mockCreators/jobs";
+import { createIJobFile, createIJobObject, createJobNode, createJobSessionNode } from "../../../__mocks__/mockCreators/jobs";
 import { imperative, IZoweJobTreeNode, ProfilesCache, Gui, Sorting } from "@zowe/zowe-explorer-api";
 import { TreeViewUtils } from "../../../../src/utils/TreeViewUtils";
 import {
@@ -34,6 +34,8 @@ import { ZoweJobNode, ZoweSpoolNode } from "../../../../src/trees/job/ZoweJobNod
 import { SharedContext } from "../../../../src/trees/shared/SharedContext";
 import { SharedTreeProviders } from "../../../../src/trees/shared/SharedTreeProviders";
 import { JobInit } from "../../../../src/trees/job/JobInit";
+import { ZoweLogger } from "../../../../src/tools/ZoweLogger";
+import * as path from "path";
 
 async function createGlobalMocks() {
     const globalMocks = {
@@ -810,6 +812,154 @@ describe("ZoweJobNode unit tests - Function saveSearch", () => {
 
         globalMocks.testJobsProvider.saveSearch(favJob);
         expect(expectedJob.contextValue).toEqual(favJob.contextValue);
+    });
+});
+
+describe("ZoweJobNode unit tests - Function getEncodingInMap", () => {
+    it("should get the encoding in the map", async () => {
+        const globalMocks = await createGlobalMocks();
+        JobFSProvider.instance.encodingMap["fakePath"] = { kind: "text" };
+        const encoding = globalMocks.testJobNode.getEncodingInMap("fakePath");
+        expect(encoding).toEqual({ kind: "text" });
+    });
+});
+
+describe("ZoweJobNode unit tests - Function updateEncodingInMap", () => {
+    it("should update the encoding in the map", async () => {
+        const globalMocks = await createGlobalMocks();
+        globalMocks.testJobNode.updateEncodingInMap("fakePath", { kind: "binary" });
+        expect(JobFSProvider.instance.encodingMap["fakePath"]).toEqual({ kind: "binary" });
+    });
+});
+
+describe("ZoweJobNode unit tests - Function getEncoding", () => {
+    it("should update the encoding of the node", () => {
+        const testNode = createJobNode(createJobSessionNode(createISession(), createIProfile()), createIProfile());
+        const getEncodingForFileSpy = jest
+            .spyOn(JobFSProvider.instance, "getEncodingForFile")
+            .mockReturnValue({ kind: "other", codepage: "IBM-1147" });
+        const encoding = testNode.getEncoding();
+        expect(getEncodingForFileSpy).toHaveBeenCalledTimes(1);
+        expect(getEncodingForFileSpy).toHaveBeenCalledWith(testNode.resourceUri);
+        expect(encoding).toEqual({ kind: "other", codepage: "IBM-1147" });
+    });
+});
+
+describe("ZoweJobNode unit tests - Function setEncoding", () => {
+    const zoweLoggerTraceSpy = jest.spyOn(ZoweLogger, "trace").mockImplementation();
+    const setEncodingForFileSpy = jest.spyOn(JobFSProvider.instance, "setEncodingForFile").mockImplementation();
+    const existsSpy = jest.spyOn(JobFSProvider.instance, "exists");
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        JobFSProvider.instance.encodingMap = {};
+    });
+
+    afterAll(() => {
+        zoweLoggerTraceSpy.mockRestore();
+        setEncodingForFileSpy.mockRestore();
+        existsSpy.mockRestore();
+    });
+
+    it("should error if set encoding is called on a non-spool node", () => {
+        const testNode = createJobNode(createJobSessionNode(createISession(), createIProfile()), createIProfile());
+        const updateEncodingSpy = jest.spyOn(testNode, "updateEncodingInMap");
+
+        testNode.dirty = false;
+
+        let e: Error;
+        try {
+            testNode.setEncoding({ kind: "text" });
+        } catch (err) {
+            e = err;
+        }
+
+        expect(e).toBeDefined();
+        expect(e.message).toEqual("Cannot set encoding for node with context job");
+        expect(existsSpy).not.toHaveBeenCalled();
+        expect(setEncodingForFileSpy).not.toHaveBeenCalled();
+        expect(updateEncodingSpy).not.toHaveBeenCalled();
+        expect(testNode.dirty).toEqual(false);
+    });
+
+    it("should error if the resource does not exist", () => {
+        const testNode = new ZoweSpoolNode({ label: "SPOOL", collapsibleState: vscode.TreeItemCollapsibleState.None, spool: createIJobFile() });
+        const updateEncodingSpy = jest.spyOn(testNode, "updateEncodingInMap");
+        testNode.dirty = false;
+
+        existsSpy.mockReturnValueOnce(false);
+
+        let e: Error;
+        try {
+            testNode.setEncoding({ kind: "text" });
+        } catch (err) {
+            e = err;
+        }
+
+        expect(e).toBeDefined();
+        expect(e.message).toEqual("Cannot set encoding for non-existent node");
+        expect(existsSpy).toHaveBeenCalledWith(testNode.resourceUri);
+        expect(setEncodingForFileSpy).not.toHaveBeenCalled();
+        expect(updateEncodingSpy).not.toHaveBeenCalled();
+        expect(testNode.dirty).toEqual(false);
+    });
+
+    it("should delete a null encoding from the provider", () => {
+        const testParentNode = createJobNode(createJobSessionNode(createISession(), createIProfile()), createIProfile());
+        const testNode = new ZoweSpoolNode({
+            label: "SPOOL",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            spool: createIJobFile(),
+            parentNode: testParentNode,
+        });
+        const updateEncodingSpy = jest.spyOn(testNode, "updateEncodingInMap").mockImplementation();
+        const basename = path.posix.basename(testNode.resourceUri.path);
+
+        testNode.dirty = false;
+        JobFSProvider.instance.encodingMap[basename] = { kind: "text" };
+        existsSpy.mockReturnValueOnce(true);
+
+        let e: Error;
+        try {
+            testNode.setEncoding(null);
+        } catch (err) {
+            e = err;
+        }
+
+        expect(e).not.toBeDefined();
+        expect(existsSpy).toHaveBeenCalledWith(testNode.resourceUri);
+        expect(setEncodingForFileSpy).toHaveBeenCalledWith(testNode.resourceUri, null);
+        expect(updateEncodingSpy).not.toHaveBeenCalled();
+        expect(JobFSProvider.instance.encodingMap[basename]).not.toBeDefined();
+        expect(testNode.dirty).toEqual(true);
+    });
+
+    it("should update the encoding in the provider map", () => {
+        const testParentNode = createJobNode(createJobSessionNode(createISession(), createIProfile()), createIProfile());
+        const testNode = new ZoweSpoolNode({
+            label: "SPOOL",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            spool: createIJobFile(),
+            parentNode: testParentNode,
+        });
+        const basename = path.posix.basename(testNode.resourceUri.path);
+        const updateEncodingSpy = jest.spyOn(testNode, "updateEncodingInMap").mockImplementation();
+
+        testNode.dirty = false;
+        existsSpy.mockReturnValueOnce(true);
+
+        let e: Error;
+        try {
+            testNode.setEncoding({ kind: "binary" });
+        } catch (err) {
+            e = err;
+        }
+
+        expect(e).not.toBeDefined();
+        expect(existsSpy).toHaveBeenCalledWith(testNode.resourceUri);
+        expect(setEncodingForFileSpy).toHaveBeenCalledWith(testNode.resourceUri, { kind: "binary" });
+        expect(updateEncodingSpy).toHaveBeenCalledWith(basename, { kind: "binary" });
+        expect(testNode.dirty).toEqual(true);
     });
 });
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/ZoweJobNode.unit.test.ts
@@ -35,7 +35,6 @@ import { SharedContext } from "../../../../src/trees/shared/SharedContext";
 import { SharedTreeProviders } from "../../../../src/trees/shared/SharedTreeProviders";
 import { JobInit } from "../../../../src/trees/job/JobInit";
 import { ZoweLogger } from "../../../../src/tools/ZoweLogger";
-import * as path from "path";
 
 async function createGlobalMocks() {
     const globalMocks = {
@@ -913,10 +912,10 @@ describe("ZoweJobNode unit tests - Function setEncoding", () => {
             parentNode: testParentNode,
         });
         const updateEncodingSpy = jest.spyOn(testNode, "updateEncodingInMap").mockImplementation();
-        const basename = path.posix.basename(testNode.resourceUri.path);
+        const nodePath = testNode.resourceUri.path;
 
         testNode.dirty = false;
-        JobFSProvider.instance.encodingMap[basename] = { kind: "text" };
+        JobFSProvider.instance.encodingMap[nodePath] = { kind: "text" };
         existsSpy.mockReturnValueOnce(true);
 
         let e: Error;
@@ -930,7 +929,7 @@ describe("ZoweJobNode unit tests - Function setEncoding", () => {
         expect(existsSpy).toHaveBeenCalledWith(testNode.resourceUri);
         expect(setEncodingForFileSpy).toHaveBeenCalledWith(testNode.resourceUri, null);
         expect(updateEncodingSpy).not.toHaveBeenCalled();
-        expect(JobFSProvider.instance.encodingMap[basename]).not.toBeDefined();
+        expect(JobFSProvider.instance.encodingMap[nodePath]).not.toBeDefined();
         expect(testNode.dirty).toEqual(true);
     });
 
@@ -942,7 +941,7 @@ describe("ZoweJobNode unit tests - Function setEncoding", () => {
             spool: createIJobFile(),
             parentNode: testParentNode,
         });
-        const basename = path.posix.basename(testNode.resourceUri.path);
+        const nodePath = testNode.resourceUri.path;
         const updateEncodingSpy = jest.spyOn(testNode, "updateEncodingInMap").mockImplementation();
 
         testNode.dirty = false;
@@ -958,7 +957,7 @@ describe("ZoweJobNode unit tests - Function setEncoding", () => {
         expect(e).not.toBeDefined();
         expect(existsSpy).toHaveBeenCalledWith(testNode.resourceUri);
         expect(setEncodingForFileSpy).toHaveBeenCalledWith(testNode.resourceUri, { kind: "binary" });
-        expect(updateEncodingSpy).toHaveBeenCalledWith(basename, { kind: "binary" });
+        expect(updateEncodingSpy).toHaveBeenCalledWith(nodePath, { kind: "binary" });
         expect(testNode.dirty).toEqual(true);
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
@@ -29,7 +29,6 @@ import { SharedTreeProviders } from "../../../../src/trees/shared/SharedTreeProv
 import { MockedProperty } from "../../../__mocks__/mockUtils";
 import { createIJobFile, createJobSessionNode } from "../../../__mocks__/mockCreators/jobs";
 import { JobFSProvider } from "../../../../src/trees/job/JobFSProvider";
-import * as path from "path";
 
 function createGlobalMocks() {
     const newMocks = {
@@ -556,7 +555,7 @@ describe("Shared utils unit tests - function promptForEncoding", () => {
             spool: createIJobFile(),
             parentNode: jobNode,
         });
-        JobFSProvider.instance.encodingMap[path.posix.basename(spoolNode.resourceUri.path)] = { kind: "text" };
+        JobFSProvider.instance.encodingMap[spoolNode.resourceUri.path] = { kind: "text" };
         blockMocks.getEncodingForFile.mockReturnValueOnce(undefined);
         await SharedUtils.promptForEncoding(spoolNode);
         expect(blockMocks.showQuickPick).toHaveBeenCalled();
@@ -695,7 +694,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(node);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(path.posix.basename(node.resourceUri.path));
+            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri.path);
             expect(response).toEqual(encoding.kind);
         });
 
@@ -721,7 +720,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(node);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(path.posix.basename(node.resourceUri.path));
+            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri.path);
             expect(response).toEqual(encoding.kind);
         });
 
@@ -747,7 +746,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(node);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(path.posix.basename(node.resourceUri.path));
+            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri.path);
             expect(response).toEqual(encoding.codepage);
         });
 
@@ -773,7 +772,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(node);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(path.posix.basename(node.resourceUri.path));
+            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri.path);
             expect(response).toEqual(encoding);
         });
     });

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
@@ -12,7 +12,7 @@
 import * as vscode from "vscode";
 import { createIProfile, createISession, createInstanceOfProfile } from "../../../__mocks__/mockCreators/shared";
 import { createDatasetSessionNode } from "../../../__mocks__/mockCreators/datasets";
-import { createUSSNode } from "../../../__mocks__/mockCreators/uss";
+import { createUSSNode, createUSSSessionNode } from "../../../__mocks__/mockCreators/uss";
 import { UssFSProvider } from "../../../../src/trees/uss/UssFSProvider";
 import { imperative, ProfilesCache, Gui, ZosEncoding, BaseProvider } from "@zowe/zowe-explorer-api";
 import { Constants } from "../../../../src/configuration/Constants";
@@ -21,12 +21,15 @@ import { ZoweLocalStorage } from "../../../../src/tools/ZoweLocalStorage";
 import { ZoweLogger } from "../../../../src/tools/ZoweLogger";
 import { DatasetFSProvider } from "../../../../src/trees/dataset/DatasetFSProvider";
 import { ZoweDatasetNode } from "../../../../src/trees/dataset/ZoweDatasetNode";
-import { ZoweJobNode } from "../../../../src/trees/job/ZoweJobNode";
+import { ZoweJobNode, ZoweSpoolNode } from "../../../../src/trees/job/ZoweJobNode";
 import { SharedUtils } from "../../../../src/trees/shared/SharedUtils";
 import { ZoweUSSNode } from "../../../../src/trees/uss/ZoweUSSNode";
 import { AuthUtils } from "../../../../src/utils/AuthUtils";
 import { SharedTreeProviders } from "../../../../src/trees/shared/SharedTreeProviders";
 import { MockedProperty } from "../../../__mocks__/mockUtils";
+import { createIJobFile, createJobSessionNode } from "../../../__mocks__/mockCreators/jobs";
+import { JobFSProvider } from "../../../../src/trees/job/JobFSProvider";
+import * as path from "path";
 
 function createGlobalMocks() {
     const newMocks = {
@@ -535,6 +538,512 @@ describe("Shared utils unit tests - function promptForEncoding", () => {
         await SharedUtils.promptForEncoding(node);
         expect(blockMocks.showQuickPick).toHaveBeenCalled();
         expect(blockMocks.showQuickPick.mock.calls[0][1]).toEqual(expect.objectContaining({ placeHolder: "Current encoding is IBM-1047" }));
+    });
+
+    it("remembers cached encoding for spool node", async () => {
+        const blockMocks = createBlockMocks();
+        const sessionNode = createJobSessionNode(blockMocks.session, blockMocks.profile);
+        const jobNode = new ZoweJobNode({
+            label: "TESTPS",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            session: blockMocks.session,
+            profile: blockMocks.profile,
+            parentNode: sessionNode,
+        });
+        const spoolNode = new ZoweSpoolNode({
+            label: "SPOOL",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            spool: createIJobFile(),
+            parentNode: jobNode,
+        });
+        JobFSProvider.instance.encodingMap[path.posix.basename(spoolNode.resourceUri.path)] = { kind: "text" };
+        blockMocks.getEncodingForFile.mockReturnValueOnce(undefined);
+        await SharedUtils.promptForEncoding(spoolNode);
+        expect(blockMocks.showQuickPick).toHaveBeenCalled();
+        expect(blockMocks.showQuickPick.mock.calls[0][1]).toEqual(expect.objectContaining({ placeHolder: "Current encoding is EBCDIC" }));
+    });
+
+    it("prompts for text encoding for Spool file", async () => {
+        const blockMocks = createBlockMocks();
+        const sessionNode = createJobSessionNode(blockMocks.session, blockMocks.profile);
+        const jobNode = new ZoweJobNode({
+            label: "TESTPS",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            session: blockMocks.session,
+            profile: blockMocks.profile,
+            parentNode: sessionNode,
+        });
+        const node = new ZoweSpoolNode({
+            label: "testFile",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            session: blockMocks.session,
+            profile: blockMocks.profile,
+            parentNode: jobNode,
+            spool: createIJobFile(),
+        });
+
+        blockMocks.showQuickPick.mockImplementationOnce(async (items) => items[0]);
+        blockMocks.getEncodingForFile.mockReturnValueOnce(undefined);
+        const encoding = await SharedUtils.promptForEncoding(node);
+        expect(blockMocks.showQuickPick).toHaveBeenCalled();
+        expect(encoding).toEqual(textEncoding);
+    });
+
+    it("prompts for binary encoding for Spool file", async () => {
+        const blockMocks = createBlockMocks();
+        const sessionNode = createJobSessionNode(blockMocks.session, blockMocks.profile);
+        const jobNode = new ZoweJobNode({
+            label: "TESTPS",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            session: blockMocks.session,
+            profile: blockMocks.profile,
+            parentNode: sessionNode,
+        });
+        const node = new ZoweSpoolNode({
+            label: "testFile",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            session: blockMocks.session,
+            profile: blockMocks.profile,
+            parentNode: jobNode,
+            spool: createIJobFile(),
+        });
+
+        blockMocks.showQuickPick.mockImplementationOnce(async (items) => items[1]);
+        const encoding = await SharedUtils.promptForEncoding(node);
+        expect(blockMocks.showQuickPick).toHaveBeenCalled();
+        expect(encoding).toEqual(binaryEncoding);
+    });
+
+    it("prompts for other encoding for Spool file and returns codepage", async () => {
+        const blockMocks = createBlockMocks();
+        const sessionNode = createJobSessionNode(blockMocks.session, blockMocks.profile);
+        const jobNode = new ZoweJobNode({
+            label: "TESTPS",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            session: blockMocks.session,
+            profile: blockMocks.profile,
+            parentNode: sessionNode,
+        });
+        const node = new ZoweSpoolNode({
+            label: "testFile",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            session: blockMocks.session,
+            profile: blockMocks.profile,
+            parentNode: jobNode,
+            spool: createIJobFile(),
+        });
+
+        blockMocks.showQuickPick.mockImplementationOnce(async (items) => items[2]);
+        blockMocks.showInputBox.mockResolvedValueOnce("IBM-1047");
+        const encoding = await SharedUtils.promptForEncoding(node);
+        expect(blockMocks.showQuickPick).toHaveBeenCalled();
+        expect(blockMocks.showInputBox).toHaveBeenCalled();
+        expect(encoding).toEqual(otherEncoding);
+    });
+
+    it("prompts for other encoding for Spool file and returns undefined", async () => {
+        const blockMocks = createBlockMocks();
+        const sessionNode = createJobSessionNode(blockMocks.session, blockMocks.profile);
+        const jobNode = new ZoweJobNode({
+            label: "TESTPS",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            session: blockMocks.session,
+            profile: blockMocks.profile,
+            parentNode: sessionNode,
+        });
+        const node = new ZoweSpoolNode({
+            label: "testFile",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            session: blockMocks.session,
+            profile: blockMocks.profile,
+            parentNode: jobNode,
+            spool: createIJobFile(),
+        });
+
+        blockMocks.showQuickPick.mockImplementationOnce(async (items) => items[2]);
+        blockMocks.showInputBox.mockResolvedValueOnce(undefined);
+        const encoding = await SharedUtils.promptForEncoding(node);
+        expect(blockMocks.showQuickPick).toHaveBeenCalled();
+        expect(blockMocks.showInputBox).toHaveBeenCalled();
+        expect(encoding).toBeUndefined();
+    });
+});
+
+describe("Shared utils unit tests - function getCachedEncoding", () => {
+    const mockSession = createISession();
+    const mockProfile = createIProfile();
+    describe("Spool nodes", () => {
+        it("correctly returns the cached encoding for binary", async () => {
+            const sessionNode = createJobSessionNode(mockSession, mockProfile);
+            const jobNode = new ZoweJobNode({
+                label: "TESTPS",
+                collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: sessionNode,
+            });
+            const node = new ZoweSpoolNode({
+                label: "testFile",
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: jobNode,
+                spool: createIJobFile(),
+            });
+            const encoding = { kind: "binary" };
+
+            const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
+            const response = await SharedUtils.getCachedEncoding(node);
+
+            expect(encodingMapSpy).toHaveBeenCalledWith(path.posix.basename(node.resourceUri.path));
+            expect(response).toEqual(encoding.kind);
+        });
+
+        it("correctly returns the cached encoding for text", async () => {
+            const sessionNode = createJobSessionNode(mockSession, mockProfile);
+            const jobNode = new ZoweJobNode({
+                label: "TESTPS",
+                collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: sessionNode,
+            });
+            const node = new ZoweSpoolNode({
+                label: "testFile",
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: jobNode,
+                spool: createIJobFile(),
+            });
+            const encoding = { kind: "text" };
+
+            const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
+            const response = await SharedUtils.getCachedEncoding(node);
+
+            expect(encodingMapSpy).toHaveBeenCalledWith(path.posix.basename(node.resourceUri.path));
+            expect(response).toEqual(encoding.kind);
+        });
+
+        it("correctly returns the cached encoding for other", async () => {
+            const sessionNode = createJobSessionNode(mockSession, mockProfile);
+            const jobNode = new ZoweJobNode({
+                label: "TESTPS",
+                collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: sessionNode,
+            });
+            const node = new ZoweSpoolNode({
+                label: "testFile",
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: jobNode,
+                spool: createIJobFile(),
+            });
+            const encoding = { kind: "other", codepage: "IBM-1147" };
+
+            const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
+            const response = await SharedUtils.getCachedEncoding(node);
+
+            expect(encodingMapSpy).toHaveBeenCalledWith(path.posix.basename(node.resourceUri.path));
+            expect(response).toEqual(encoding.codepage);
+        });
+
+        it("correctly returns the cached encoding for undefined", async () => {
+            const sessionNode = createJobSessionNode(mockSession, mockProfile);
+            const jobNode = new ZoweJobNode({
+                label: "TESTPS",
+                collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: sessionNode,
+            });
+            const node = new ZoweSpoolNode({
+                label: "testFile",
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: jobNode,
+                spool: createIJobFile(),
+            });
+            const encoding = undefined;
+
+            const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
+            const response = await SharedUtils.getCachedEncoding(node);
+
+            expect(encodingMapSpy).toHaveBeenCalledWith(path.posix.basename(node.resourceUri.path));
+            expect(response).toEqual(encoding);
+        });
+    });
+
+    describe("USS nodes", () => {
+        it("correctly returns the cached encoding for binary", async () => {
+            const sessionNode = createUSSSessionNode(mockSession, mockProfile);
+            const ussNode = new ZoweUSSNode({
+                label: "TEST.PS",
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                contextOverride: Constants.USS_BINARY_FILE_CONTEXT,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: sessionNode,
+            });
+            const encoding = { kind: "binary" };
+
+            const encodingMapSpy = jest.spyOn(ussNode, "getEncodingInMap").mockResolvedValue(encoding);
+            const response = await SharedUtils.getCachedEncoding(ussNode);
+
+            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.fullPath);
+            expect(response).toEqual(encoding.kind);
+        });
+
+        it("correctly returns the cached encoding for text", async () => {
+            const sessionNode = createUSSSessionNode(mockSession, mockProfile);
+            const ussNode = new ZoweUSSNode({
+                label: "TEST.PS",
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                contextOverride: Constants.USS_TEXT_FILE_CONTEXT,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: sessionNode,
+            });
+            const encoding = { kind: "text" };
+
+            const encodingMapSpy = jest.spyOn(ussNode, "getEncodingInMap").mockResolvedValue(encoding);
+            const response = await SharedUtils.getCachedEncoding(ussNode);
+
+            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.fullPath);
+            expect(response).toEqual(encoding.kind);
+        });
+
+        it("correctly returns the cached encoding for other", async () => {
+            const sessionNode = createUSSSessionNode(mockSession, mockProfile);
+            const ussNode = new ZoweUSSNode({
+                label: "TEST.PS",
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                contextOverride: Constants.USS_TEXT_FILE_CONTEXT,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: sessionNode,
+            });
+            const encoding = { kind: "other", codepage: "IBM-1147" };
+
+            const encodingMapSpy = jest.spyOn(ussNode, "getEncodingInMap").mockResolvedValue(encoding);
+            const response = await SharedUtils.getCachedEncoding(ussNode);
+
+            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.fullPath);
+            expect(response).toEqual(encoding.codepage);
+        });
+
+        it("correctly returns the cached encoding for undefined", async () => {
+            const sessionNode = createUSSSessionNode(mockSession, mockProfile);
+            const ussNode = new ZoweUSSNode({
+                label: "TEST.PS",
+                collapsibleState: vscode.TreeItemCollapsibleState.None,
+                contextOverride: Constants.USS_TEXT_FILE_CONTEXT,
+                session: mockSession,
+                profile: mockProfile,
+                parentNode: sessionNode,
+            });
+            const encoding = undefined;
+
+            const encodingMapSpy = jest.spyOn(ussNode, "getEncodingInMap").mockResolvedValue(encoding);
+            const response = await SharedUtils.getCachedEncoding(ussNode);
+
+            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.fullPath);
+            expect(response).toEqual(encoding);
+        });
+    });
+
+    describe("Dataset nodes", () => {
+        describe("Sequential", () => {
+            it("correctly returns the cached encoding for binary", async () => {
+                const sessionNode = createDatasetSessionNode(mockSession, mockProfile);
+                const dsNode = new ZoweDatasetNode({
+                    label: "TEST.PS",
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    contextOverride: Constants.DS_DS_BINARY_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: sessionNode,
+                });
+                const encoding = { kind: "binary" };
+
+                const encodingMapSpy = jest.spyOn(dsNode, "getEncodingInMap").mockResolvedValue(encoding);
+                const response = await SharedUtils.getCachedEncoding(dsNode);
+
+                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.label);
+                expect(response).toEqual(encoding.kind);
+            });
+
+            it("correctly returns the cached encoding for text", async () => {
+                const sessionNode = createDatasetSessionNode(mockSession, mockProfile);
+                const dsNode = new ZoweDatasetNode({
+                    label: "TEST.PS",
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    contextOverride: Constants.DS_DS_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: sessionNode,
+                });
+                const encoding = { kind: "test" };
+
+                const encodingMapSpy = jest.spyOn(dsNode, "getEncodingInMap").mockResolvedValue(encoding);
+                const response = await SharedUtils.getCachedEncoding(dsNode);
+
+                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.label);
+                expect(response).toEqual(encoding.kind);
+            });
+
+            it("correctly returns the cached encoding for other", async () => {
+                const sessionNode = createDatasetSessionNode(mockSession, mockProfile);
+                const dsNode = new ZoweDatasetNode({
+                    label: "TEST.PS",
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    contextOverride: Constants.DS_DS_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: sessionNode,
+                });
+                const encoding = { kind: "other", codepage: "IBM-1147" };
+
+                const encodingMapSpy = jest.spyOn(dsNode, "getEncodingInMap").mockResolvedValue(encoding);
+                const response = await SharedUtils.getCachedEncoding(dsNode);
+
+                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.label);
+                expect(response).toEqual(encoding.codepage);
+            });
+
+            it("correctly returns the cached encoding for undefined", async () => {
+                const sessionNode = createDatasetSessionNode(mockSession, mockProfile);
+                const dsNode = new ZoweDatasetNode({
+                    label: "TEST.PS",
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    contextOverride: Constants.DS_DS_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: sessionNode,
+                });
+                const encoding = undefined;
+
+                const encodingMapSpy = jest.spyOn(dsNode, "getEncodingInMap").mockResolvedValue(encoding);
+                const response = await SharedUtils.getCachedEncoding(dsNode);
+
+                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.label);
+                expect(response).toEqual(encoding);
+            });
+        });
+
+        describe("Partitioned", () => {
+            it("correctly returns the cached encoding for binary", async () => {
+                const sessionNode = createDatasetSessionNode(mockSession, mockProfile);
+                const dsNode = new ZoweDatasetNode({
+                    label: "TEST.PDS",
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    contextOverride: Constants.DS_PDS_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: sessionNode,
+                });
+                const memNode = new ZoweDatasetNode({
+                    label: "TESTMEM",
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    contextOverride: Constants.DS_MEMBER_BINARY_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: dsNode,
+                });
+                const encoding = { kind: "binary" };
+
+                const encodingMapSpy = jest.spyOn(memNode, "getEncodingInMap").mockResolvedValue(encoding);
+                const response = await SharedUtils.getCachedEncoding(memNode);
+
+                expect(encodingMapSpy).toHaveBeenCalledWith(`${dsNode.label as string}(${memNode.label as string})`);
+                expect(response).toEqual(encoding.kind);
+            });
+
+            it("correctly returns the cached encoding for text", async () => {
+                const sessionNode = createDatasetSessionNode(mockSession, mockProfile);
+                const dsNode = new ZoweDatasetNode({
+                    label: "TEST.PDS",
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    contextOverride: Constants.DS_PDS_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: sessionNode,
+                });
+                const memNode = new ZoweDatasetNode({
+                    label: "TESTMEM",
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    contextOverride: Constants.DS_MEMBER_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: dsNode,
+                });
+                const encoding = { kind: "text" };
+
+                const encodingMapSpy = jest.spyOn(memNode, "getEncodingInMap").mockResolvedValue(encoding);
+                const response = await SharedUtils.getCachedEncoding(memNode);
+
+                expect(encodingMapSpy).toHaveBeenCalledWith(`${dsNode.label as string}(${memNode.label as string})`);
+                expect(response).toEqual(encoding.kind);
+            });
+
+            it("correctly returns the cached encoding for other", async () => {
+                const sessionNode = createDatasetSessionNode(mockSession, mockProfile);
+                const dsNode = new ZoweDatasetNode({
+                    label: "TEST.PDS",
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    contextOverride: Constants.DS_PDS_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: sessionNode,
+                });
+                const memNode = new ZoweDatasetNode({
+                    label: "TESTMEM",
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    contextOverride: Constants.DS_MEMBER_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: dsNode,
+                });
+                const encoding = { kind: "other", codepage: "IBM-1147" };
+
+                const encodingMapSpy = jest.spyOn(memNode, "getEncodingInMap").mockResolvedValue(encoding);
+                const response = await SharedUtils.getCachedEncoding(memNode);
+
+                expect(encodingMapSpy).toHaveBeenCalledWith(`${dsNode.label as string}(${memNode.label as string})`);
+                expect(response).toEqual(encoding.codepage);
+            });
+
+            it("correctly returns the cached encoding for undefined", async () => {
+                const sessionNode = createDatasetSessionNode(mockSession, mockProfile);
+                const dsNode = new ZoweDatasetNode({
+                    label: "TEST.PDS",
+                    collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+                    contextOverride: Constants.DS_PDS_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: sessionNode,
+                });
+                const memNode = new ZoweDatasetNode({
+                    label: "TESTMEM",
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    contextOverride: Constants.DS_MEMBER_CONTEXT,
+                    session: mockSession,
+                    profile: mockProfile,
+                    parentNode: dsNode,
+                });
+                const encoding = undefined;
+
+                const encodingMapSpy = jest.spyOn(memNode, "getEncodingInMap").mockResolvedValue(encoding);
+                const response = await SharedUtils.getCachedEncoding(memNode);
+
+                expect(encodingMapSpy).toHaveBeenCalledWith(`${dsNode.label as string}(${memNode.label as string})`);
+                expect(response).toEqual(encoding);
+            });
+        });
     });
 });
 

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1205,6 +1205,11 @@
           "group": "000_zowe_jobsMainframeInteraction@3"
         },
         {
+          "when": "view == zowe.jobs.explorer && viewItem =~ /^(spool.*)/",
+          "command": "zowe.openWithEncoding",
+          "group": "000_zowe_jobsMainframeInteraction@4"
+        },
+        {
           "when": "view == zowe.jobs.explorer && viewItem =~ /^(?!.*_fav.*)job.*/",
           "command": "zowe.jobs.refreshJob",
           "group": "000_zowe_jobsMainframeInteraction@0"

--- a/packages/zowe-explorer/src/trees/job/JobTree.ts
+++ b/packages/zowe-explorer/src/trees/job/JobTree.ts
@@ -1183,7 +1183,7 @@ export class JobTree extends ZoweTreeProvider<IZoweJobTreeNode> implements Types
         encoding ??= await SharedUtils.promptForEncoding(node);
         if (encoding !== undefined) {
             // Set the encoding, fetch the new contents with the encoding, and open the spool file.
-            node.setEncoding(encoding);
+            await node.setEncoding(encoding);
             await JobFSProvider.instance.fetchSpoolAtUri(node.resourceUri);
             await vscode.commands.executeCommand("vscode.open", node.resourceUri);
         }

--- a/packages/zowe-explorer/src/trees/job/JobTree.ts
+++ b/packages/zowe-explorer/src/trees/job/JobTree.ts
@@ -12,7 +12,18 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import { IJob } from "@zowe/zos-jobs-for-zowe-sdk";
-import { Gui, Validation, imperative, IZoweJobTreeNode, PersistenceSchemaEnum, Poller, Types, ZoweExplorerApiType } from "@zowe/zowe-explorer-api";
+import {
+    Gui,
+    Validation,
+    imperative,
+    IZoweJobTreeNode,
+    PersistenceSchemaEnum,
+    Poller,
+    Types,
+    ZoweExplorerApiType,
+    ZosEncoding,
+    FsAbstractUtils,
+} from "@zowe/zowe-explorer-api";
 import { ZoweJobNode } from "./ZoweJobNode";
 import { JobFSProvider } from "./JobFSProvider";
 import { JobUtils } from "./JobUtils";
@@ -1161,6 +1172,17 @@ export class JobTree extends ZoweTreeProvider<IZoweJobTreeNode> implements Types
         });
         inputBox.show();
         return inputBox;
+    }
+
+    public async openWithEncoding(node: IZoweJobTreeNode, encoding?: ZosEncoding): Promise<void> {
+        encoding ??= await SharedUtils.promptForEncoding(node);
+        if (encoding !== undefined) {
+            if (!(await FsAbstractUtils.confirmForUnsavedDoc(node.resourceUri))) {
+                return;
+            }
+            node.setEncoding(encoding);
+            await vscode.commands.executeCommand("vscode.open", node.resourceUri);
+        }
     }
 }
 

--- a/packages/zowe-explorer/src/trees/job/JobTree.ts
+++ b/packages/zowe-explorer/src/trees/job/JobTree.ts
@@ -22,7 +22,6 @@ import {
     Types,
     ZoweExplorerApiType,
     ZosEncoding,
-    FsAbstractUtils,
 } from "@zowe/zowe-explorer-api";
 import { ZoweJobNode } from "./ZoweJobNode";
 import { JobFSProvider } from "./JobFSProvider";
@@ -1174,13 +1173,18 @@ export class JobTree extends ZoweTreeProvider<IZoweJobTreeNode> implements Types
         return inputBox;
     }
 
+    /**
+     * Opens the spool file with a particular encoding
+     * @param {IZoweJobTreeNode} node The Job Tree Node to open with encoding
+     * @param {ZosEncoding} encoding The encoding to use to open the Job Tree Node
+     */
+
     public async openWithEncoding(node: IZoweJobTreeNode, encoding?: ZosEncoding): Promise<void> {
         encoding ??= await SharedUtils.promptForEncoding(node);
         if (encoding !== undefined) {
-            if (!(await FsAbstractUtils.confirmForUnsavedDoc(node.resourceUri))) {
-                return;
-            }
+            // Set the encoding, fetch the new contents with the encoding, and open the spool file.
             node.setEncoding(encoding);
+            await JobFSProvider.instance.fetchSpoolAtUri(node.resourceUri);
             await vscode.commands.executeCommand("vscode.open", node.resourceUri);
         }
     }

--- a/packages/zowe-explorer/src/trees/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/trees/job/ZoweJobNode.ts
@@ -314,18 +314,36 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
         return this.session ? this : this.getParent()?.getSessionNode() ?? this;
     }
 
+    /**
+     * Get the encoding from the JobFSProvider encoding map for a URI
+     * @param {string} uriPath The URI to look up in the encoding map
+     * @returns {ZosEncoding}
+     */
     public getEncodingInMap(uriPath: string): ZosEncoding {
         return JobFSProvider.instance.encodingMap[uriPath];
     }
 
+    /**
+     * Update the encoding for a URI in the JobFSProvider encoding map
+     * @param {string} uriPath The URI to update in the encoding map
+     * @param {ZosEncoding} encoding The encoding to associate with the URI
+     */
     public updateEncodingInMap(uriPath: string, encoding: ZosEncoding): void {
         JobFSProvider.instance.encodingMap[uriPath] = encoding;
     }
 
+    /**
+     * Get the encoding for a particular Job node
+     * @returns {ZosEncoding}
+     */
     public getEncoding(): ZosEncoding {
         return JobFSProvider.instance.getEncodingForFile(this.resourceUri);
     }
 
+    /**
+     * Update the encoding for a particular Job node
+     * @param {ZosEncoding} encoding The encoding to use for the Job node
+     */
     public setEncoding(encoding: ZosEncoding): void {
         ZoweLogger.trace("ZoweJobNode.setEncoding called.");
         if (!this.contextValue.startsWith(Constants.JOBS_SPOOL_CONTEXT)) {

--- a/packages/zowe-explorer/src/trees/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/trees/job/ZoweJobNode.ts
@@ -356,11 +356,10 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
             throw new Error(`Cannot set encoding for non-existent node`);
         }
 
-        const fullPath = path.posix.basename(this.resourceUri.path);
         if (encoding != null) {
-            this.updateEncodingInMap(fullPath, encoding);
+            this.updateEncodingInMap(this.resourceUri.path, encoding);
         } else {
-            delete JobFSProvider.instance.encodingMap[fullPath];
+            delete JobFSProvider.instance.encodingMap[this.resourceUri.path];
         }
 
         this.dirty = true;

--- a/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
@@ -190,7 +190,10 @@ export class SharedUtils {
             .filter(Boolean);
     }
 
-    public static async promptForEncoding(node: IZoweDatasetTreeNode | IZoweUSSTreeNode, taggedEncoding?: string): Promise<ZosEncoding | undefined> {
+    public static async promptForEncoding(
+        node: IZoweDatasetTreeNode | IZoweUSSTreeNode | IZoweJobTreeNode,
+        taggedEncoding?: string
+    ): Promise<ZosEncoding | undefined> {
         const ebcdicItem: vscode.QuickPickItem = {
             label: vscode.l10n.t("EBCDIC"),
             description: vscode.l10n.t("z/OS default codepage"),

--- a/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
@@ -145,7 +145,7 @@ export class SharedUtils {
         if (SharedUtils.isZoweUSSTreeNode(node)) {
             cachedEncoding = await node.getEncodingInMap(node.fullPath);
         } else if (SharedUtils.isZoweJobTreeNode(node)) {
-            cachedEncoding = await node.getEncodingInMap(path.posix.basename(node.resourceUri.path));
+            cachedEncoding = await node.getEncodingInMap(node.resourceUri.path);
         } else {
             const isMemberNode = node.contextValue.startsWith(Constants.DS_MEMBER_CONTEXT);
             const dsKey = isMemberNode ? `${node.getParent().label as string}(${node.label as string})` : (node.label as string);

--- a/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
@@ -144,6 +144,8 @@ export class SharedUtils {
         let cachedEncoding: ZosEncoding;
         if (SharedUtils.isZoweUSSTreeNode(node)) {
             cachedEncoding = await node.getEncodingInMap(node.fullPath);
+        } else if (SharedUtils.isZoweJobTreeNode(node)) {
+            cachedEncoding = await node.getEncodingInMap(path.posix.basename(node.resourceUri.path));
         } else {
             const isMemberNode = node.contextValue.startsWith(Constants.DS_MEMBER_CONTEXT);
             const dsKey = isMemberNode ? `${node.getParent().label as string}(${node.label as string})` : (node.label as string);


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Adds the ability to open a job spool file with an encoding as described in #1941 

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.1.0

Changelog: 
- Added `Open with Encoding` to the context menu of Job Spool files. [#1941](https://github.com/zowe/zowe-explorer-vscode/issues/1941)
- Added optional `setEncoding`, `getEncoding`, and `getEncodingInMap` functions to the `IZoweJobTreeNode` interface. [#3361](https://github.com/zowe/zowe-explorer-vscode/pull/3361)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->

![2024-12-13-13-39-00](https://github.com/user-attachments/assets/2994b50b-e8b8-499f-8a6e-90f572ff564e)

