### PR TITLE
fix: store cached encoding by URI path instead of label/short path

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where data set nodes did not update if migrated or recalled outside of Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where listing data sets resulted in an error after opening a data set with an encoding. [#3347](https://github.com/zowe/zowe-explorer-vscode/issues/3347)
 - Fixed an issue where binary USS files were not fetched using the "Pull from Mainframe" context menu option. [#3355](https://github.com/zowe/zowe-explorer-vscode/issues/3355)
-- Fixed an issue where cached encoding was applied for all profiles with the same dataset or USS path in the "Open with Encoding" menu. [#3363](https://github.com/zowe/zowe-explorer-vscode/pull/3363)
+- Fixed an issue where cached encoding was applied for all profiles with the same data set or USS path in the "Open with Encoding" menu. [#3363](https://github.com/zowe/zowe-explorer-vscode/pull/3363)
 
 ## `3.0.3`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where data set nodes did not update if migrated or recalled outside of Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where listing data sets resulted in an error after opening a data set with an encoding. [#3347](https://github.com/zowe/zowe-explorer-vscode/issues/3347)
 - Fixed an issue where binary USS files were not fetched using the "Pull from Mainframe" context menu option. [#3355](https://github.com/zowe/zowe-explorer-vscode/issues/3355)
+- Fixed an issue where cached encoding was applied for all profiles with the same dataset in the "Open with Encoding" menu.
 
 ## `3.0.3`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where data set nodes did not update if migrated or recalled outside of Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where listing data sets resulted in an error after opening a data set with an encoding. [#3347](https://github.com/zowe/zowe-explorer-vscode/issues/3347)
 - Fixed an issue where binary USS files were not fetched using the "Pull from Mainframe" context menu option. [#3355](https://github.com/zowe/zowe-explorer-vscode/issues/3355)
-- Fixed an issue where cached encoding was applied for all profiles with the same dataset in the "Open with Encoding" menu.
+- Fixed an issue where cached encoding was applied for all profiles with the same dataset in the "Open with Encoding" menu. [#3363](https://github.com/zowe/zowe-explorer-vscode/pull/3363)
 
 ## `3.0.3`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -30,7 +30,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where data set nodes did not update if migrated or recalled outside of Zowe Explorer. [#3294](https://github.com/zowe/zowe-explorer-vscode/issues/3294)
 - Fixed an issue where listing data sets resulted in an error after opening a data set with an encoding. [#3347](https://github.com/zowe/zowe-explorer-vscode/issues/3347)
 - Fixed an issue where binary USS files were not fetched using the "Pull from Mainframe" context menu option. [#3355](https://github.com/zowe/zowe-explorer-vscode/issues/3355)
-- Fixed an issue where cached encoding was applied for all profiles with the same dataset in the "Open with Encoding" menu. [#3363](https://github.com/zowe/zowe-explorer-vscode/pull/3363)
+- Fixed an issue where cached encoding was applied for all profiles with the same dataset or USS path in the "Open with Encoding" menu. [#3363](https://github.com/zowe/zowe-explorer-vscode/pull/3363)
 
 ## `3.0.3`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
@@ -507,7 +507,7 @@ describe("Shared utils unit tests - function promptForEncoding", () => {
             profile: blockMocks.profile,
             parentNode: sessionNode,
         });
-        DatasetFSProvider.instance.encodingMap["TEST.PS"] = { kind: "text" };
+        DatasetFSProvider.instance.encodingMap[node.resourceUri.path] = { kind: "text" };
         blockMocks.getEncodingForFile.mockReturnValueOnce(undefined);
         await SharedUtils.promptForEncoding(node);
         expect(blockMocks.showQuickPick).toHaveBeenCalled();

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
@@ -509,7 +509,7 @@ describe("Shared utils unit tests - function promptForEncoding", () => {
             profile: blockMocks.profile,
             parentNode: sessionNode,
         });
-        DatasetFSProvider.instance.encodingMap[node.resourceUri.path] = { kind: "text" };
+        DatasetFSProvider.instance.encodingMap[node.resourceUri?.path] = { kind: "text" };
         blockMocks.getEncodingForFile.mockReturnValueOnce(undefined);
         await SharedUtils.promptForEncoding(node);
         expect(blockMocks.showQuickPick).toHaveBeenCalled();
@@ -555,7 +555,7 @@ describe("Shared utils unit tests - function promptForEncoding", () => {
             spool: createIJobFile(),
             parentNode: jobNode,
         });
-        JobFSProvider.instance.encodingMap[spoolNode.resourceUri.path] = { kind: "text" };
+        JobFSProvider.instance.encodingMap[spoolNode.resourceUri?.path] = { kind: "text" };
         blockMocks.getEncodingForFile.mockReturnValueOnce(undefined);
         await SharedUtils.promptForEncoding(spoolNode);
         expect(blockMocks.showQuickPick).toHaveBeenCalled();
@@ -694,7 +694,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(node);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri.path);
+            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri?.path);
             expect(response).toEqual(encoding.kind);
         });
 
@@ -720,7 +720,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(node);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri.path);
+            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri?.path);
             expect(response).toEqual(encoding.kind);
         });
 
@@ -746,7 +746,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(node);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri.path);
+            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri?.path);
             expect(response).toEqual(encoding.codepage);
         });
 
@@ -772,7 +772,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(node, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(node);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri.path);
+            expect(encodingMapSpy).toHaveBeenCalledWith(node.resourceUri?.path);
             expect(response).toEqual(encoding);
         });
     });
@@ -793,7 +793,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(ussNode, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(ussNode);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.fullPath);
+            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.resourceUri?.path);
             expect(response).toEqual(encoding.kind);
         });
 
@@ -812,7 +812,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(ussNode, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(ussNode);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.fullPath);
+            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.resourceUri?.path);
             expect(response).toEqual(encoding.kind);
         });
 
@@ -831,7 +831,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(ussNode, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(ussNode);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.fullPath);
+            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.resourceUri?.path);
             expect(response).toEqual(encoding.codepage);
         });
 
@@ -850,7 +850,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
             const encodingMapSpy = jest.spyOn(ussNode, "getEncodingInMap").mockResolvedValue(encoding);
             const response = await SharedUtils.getCachedEncoding(ussNode);
 
-            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.fullPath);
+            expect(encodingMapSpy).toHaveBeenCalledWith(ussNode.resourceUri?.path);
             expect(response).toEqual(encoding);
         });
     });
@@ -872,7 +872,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
                 const encodingMapSpy = jest.spyOn(dsNode, "getEncodingInMap").mockResolvedValue(encoding);
                 const response = await SharedUtils.getCachedEncoding(dsNode);
 
-                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.label);
+                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.resourceUri?.path);
                 expect(response).toEqual(encoding.kind);
             });
 
@@ -891,7 +891,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
                 const encodingMapSpy = jest.spyOn(dsNode, "getEncodingInMap").mockResolvedValue(encoding);
                 const response = await SharedUtils.getCachedEncoding(dsNode);
 
-                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.label);
+                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.resourceUri?.path);
                 expect(response).toEqual(encoding.kind);
             });
 
@@ -910,7 +910,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
                 const encodingMapSpy = jest.spyOn(dsNode, "getEncodingInMap").mockResolvedValue(encoding);
                 const response = await SharedUtils.getCachedEncoding(dsNode);
 
-                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.label);
+                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.resourceUri?.path);
                 expect(response).toEqual(encoding.codepage);
             });
 
@@ -929,7 +929,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
                 const encodingMapSpy = jest.spyOn(dsNode, "getEncodingInMap").mockResolvedValue(encoding);
                 const response = await SharedUtils.getCachedEncoding(dsNode);
 
-                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.label);
+                expect(encodingMapSpy).toHaveBeenCalledWith(dsNode.resourceUri?.path);
                 expect(response).toEqual(encoding);
             });
         });
@@ -958,7 +958,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
                 const encodingMapSpy = jest.spyOn(memNode, "getEncodingInMap").mockResolvedValue(encoding);
                 const response = await SharedUtils.getCachedEncoding(memNode);
 
-                expect(encodingMapSpy).toHaveBeenCalledWith(`${dsNode.label as string}(${memNode.label as string})`);
+                expect(encodingMapSpy).toHaveBeenCalledWith(memNode.resourceUri?.path);
                 expect(response).toEqual(encoding.kind);
             });
 
@@ -985,7 +985,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
                 const encodingMapSpy = jest.spyOn(memNode, "getEncodingInMap").mockResolvedValue(encoding);
                 const response = await SharedUtils.getCachedEncoding(memNode);
 
-                expect(encodingMapSpy).toHaveBeenCalledWith(`${dsNode.label as string}(${memNode.label as string})`);
+                expect(encodingMapSpy).toHaveBeenCalledWith(memNode.resourceUri?.path);
                 expect(response).toEqual(encoding.kind);
             });
 
@@ -1012,7 +1012,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
                 const encodingMapSpy = jest.spyOn(memNode, "getEncodingInMap").mockResolvedValue(encoding);
                 const response = await SharedUtils.getCachedEncoding(memNode);
 
-                expect(encodingMapSpy).toHaveBeenCalledWith(`${dsNode.label as string}(${memNode.label as string})`);
+                expect(encodingMapSpy).toHaveBeenCalledWith(memNode.resourceUri?.path);
                 expect(response).toEqual(encoding.codepage);
             });
 
@@ -1039,7 +1039,7 @@ describe("Shared utils unit tests - function getCachedEncoding", () => {
                 const encodingMapSpy = jest.spyOn(memNode, "getEncodingInMap").mockResolvedValue(encoding);
                 const response = await SharedUtils.getCachedEncoding(memNode);
 
-                expect(encodingMapSpy).toHaveBeenCalledWith(`${dsNode.label as string}(${memNode.label as string})`);
+                expect(encodingMapSpy).toHaveBeenCalledWith(memNode.resourceUri?.path);
                 expect(response).toEqual(encoding);
             });
         });

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -715,11 +715,10 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
         } else {
             DatasetFSProvider.instance.makeEmptyDsWithEncoding(this.resourceUri, encoding);
         }
-        const fullPath = isMemberNode ? `${this.getParent().label as string}(${this.label as string})` : (this.label as string);
         if (encoding != null) {
-            this.updateEncodingInMap(fullPath, encoding);
+            this.updateEncodingInMap(this.resourceUri.path, encoding);
         } else {
-            delete DatasetFSProvider.instance.encodingMap[fullPath];
+            delete DatasetFSProvider.instance.encodingMap[this.resourceUri.path];
         }
         if (this.getParent() && this.getParent().contextValue === Constants.FAV_PROFILE_CONTEXT) {
             this.contextValue += Constants.FAV_SUFFIX;

--- a/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
@@ -145,9 +145,7 @@ export class SharedUtils {
         if (SharedUtils.isZoweUSSTreeNode(node)) {
             cachedEncoding = await node.getEncodingInMap(node.fullPath);
         } else {
-            const isMemberNode = node.contextValue.startsWith(Constants.DS_MEMBER_CONTEXT);
-            const dsKey = isMemberNode ? `${node.getParent().label as string}(${node.label as string})` : (node.label as string);
-            cachedEncoding = await (node as IZoweDatasetTreeNode).getEncodingInMap(dsKey);
+            cachedEncoding = await (node as IZoweDatasetTreeNode).getEncodingInMap(node.resourceUri.path);
         }
         return cachedEncoding?.kind === "other" ? cachedEncoding.codepage : cachedEncoding?.kind;
     }

--- a/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
@@ -143,7 +143,7 @@ export class SharedUtils {
     public static async getCachedEncoding(node: IZoweTreeNode): Promise<string | undefined> {
         let cachedEncoding: ZosEncoding;
         if (SharedUtils.isZoweUSSTreeNode(node)) {
-            cachedEncoding = await node.getEncodingInMap(node.fullPath);
+            cachedEncoding = await node.getEncodingInMap(node.resourceUri.path);
         } else {
             cachedEncoding = await (node as IZoweDatasetTreeNode).getEncodingInMap(node.resourceUri.path);
         }

--- a/packages/zowe-explorer/src/trees/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/trees/uss/ZoweUSSNode.ts
@@ -299,9 +299,9 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         }
         UssFSProvider.instance.setEncodingForFile(this.resourceUri, encoding);
         if (encoding != null) {
-            this.updateEncodingInMap(this.fullPath, encoding);
+            this.updateEncodingInMap(this.resourceUri.path, encoding);
         } else {
-            delete UssFSProvider.instance.encodingMap[this.fullPath];
+            delete UssFSProvider.instance.encodingMap[this.resourceUri.path];
         }
         if (this.getParent() && this.getParent().contextValue === Constants.FAV_PROFILE_CONTEXT) {
             this.contextValue =


### PR DESCRIPTION
## Proposed changes

Fixes an issue where two profiles with the same dataset would share the same cached encoding value.

### How to test

- Get 2 LPARs and search for the same data set (`SYS1.PARMLIB`)
- Find a member with the same name in the data set for both LPARs
- Right-click on the member in one LPAR -> "Open with Encoding" -> select "Binary"
- Right-click on the member in the second LPAR. Notice that no encoding is cached, and the default quick pick options for this menu are shown.
- Now right-click on the member under the first LPAR that was opened as binary and select "Open with Encoding." The cached encoding is displayed as the placeholder in the quick pick.

In v3.0.3, right-clicking on the member in the second LPAR causes it to show "binary" as the cached encoding, which should not be the case.

## Release Notes

Milestone: 3.1.0

Changelog:

- Fixed an issue where cached encoding was applied for all profiles with the same dataset in the "Open with Encoding" menu.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have ~added new~ updated test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
