### PR TITLE
fix: call Mutex.waitForUnlock instead of locking profile before request

### DIFF
--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/AuthHandler.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/AuthHandler.unit.test.ts
@@ -17,6 +17,22 @@ import { AuthPromptParams } from "@zowe/zowe-explorer-api";
 
 const TEST_PROFILE_NAME = "lpar.zosmf";
 
+describe("AuthHandler.waitForUnlock", () => {
+    it("calls Mutex.waitForUnlock if the profile lock is present", async () => {
+        const mutex = new Mutex();
+        const waitForUnlockMock = jest.spyOn(mutex, "waitForUnlock");
+        (AuthHandler as any).profileLocks.set(TEST_PROFILE_NAME, mutex);
+        await AuthHandler.waitForUnlock(TEST_PROFILE_NAME);
+        expect(waitForUnlockMock).toHaveBeenCalled();
+        (AuthHandler as any).profileLocks.clear();
+    });
+    it("does nothing if the profile lock is not in the profileLocks map", async () => {
+        const waitForUnlockMock = jest.spyOn(Mutex.prototype, "waitForUnlock");
+        await AuthHandler.waitForUnlock(TEST_PROFILE_NAME);
+        expect(waitForUnlockMock).not.toHaveBeenCalled();
+    });
+});
+
 describe("AuthHandler.isProfileLocked", () => {
     it("returns true if the profile is locked", async () => {
         await AuthHandler.lockProfile(TEST_PROFILE_NAME);

--- a/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
+++ b/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
@@ -169,8 +169,10 @@ export class AuthHandler {
     public static async waitForUnlock(profile: ProfileLike): Promise<void> {
         const profileName = AuthHandler.getProfileName(profile);
         if (!this.profileLocks.has(profileName)) {
-            return this.profileLocks.get(profileName)?.waitForUnlock();
+            return;
         }
+
+        return this.profileLocks.get(profileName)?.waitForUnlock();
     }
 
     /**

--- a/packages/zowe-explorer/src/trees/job/JobFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/job/JobFSProvider.ts
@@ -208,7 +208,7 @@ export class JobFSProvider extends BaseProvider implements vscode.FileSystemProv
         const bufBuilder = new BufferBuilder();
 
         const jesApi = ZoweExplorerApiRegister.getJesApi(spoolEntry.metadata.profile);
-        await AuthHandler.lockProfile(spoolEntry.metadata.profile);
+        await AuthHandler.waitForUnlock(spoolEntry.metadata.profile);
         try {
             if (jesApi.downloadSingleSpool) {
                 const spoolDownloadObject: IDownloadSpoolContentParms = {
@@ -232,7 +232,6 @@ export class JobFSProvider extends BaseProvider implements vscode.FileSystemProv
             await AuthUtils.handleProfileAuthOnError(err, spoolEntry.metadata.profile);
             throw err;
         }
-        AuthHandler.unlockProfile(spoolEntry.metadata.profile);
 
         this._fireSoon({ type: vscode.FileChangeType.Changed, uri });
         spoolEntry.data = bufBuilder.read() ?? new Uint8Array();

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -280,7 +280,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         try {
             await this.autoDetectEncoding(file as UssFile);
             const profileEncoding = file.encoding ? null : file.metadata.profile.profile?.encoding;
-            await AuthHandler.lockProfile(metadata.profile);
+            await AuthHandler.waitForUnlock(file.metadata.profile);
             resp = await ZoweExplorerApiRegister.getUssApi(metadata.profile).getContents(filePath, {
                 binary: file.encoding?.kind === "binary",
                 encoding: file.encoding?.kind === "other" ? file.encoding.codepage : profileEncoding,
@@ -288,7 +288,6 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
                 returnEtag: true,
                 stream: bufBuilder,
             });
-            AuthHandler.unlockProfile(metadata.profile);
         } catch (err) {
             if (err instanceof Error) {
                 ZoweLogger.error(err.message);
@@ -324,7 +323,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         if (entry.encoding !== undefined) {
             return;
         }
-        await AuthHandler.lockProfile(entry.metadata.profile);
+        await AuthHandler.waitForUnlock(entry.metadata.profile);
         const ussApi = ZoweExplorerApiRegister.getUssApi(entry.metadata.profile);
         if (ussApi.getTag != null) {
             const taggedEncoding = await ussApi.getTag(entry.metadata.path);
@@ -337,7 +336,6 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
             const isBinary = await ussApi.isFileTagBinOrAscii(entry.metadata.path);
             entry.encoding = isBinary ? { kind: "binary" } : undefined;
         }
-        AuthHandler.unlockProfile(entry.metadata.profile);
     }
 
     public async fetchEncodingForUri(uri: vscode.Uri): Promise<ZosEncoding> {


### PR DESCRIPTION
## Proposed changes

Fixes #3408

Sorry for the oversight @benjamin-t-santos @phaumer - I did not intend to limit extenders to sequential processing, but I had inadvertently done so by forcing the filesystem to acquire the mutex for each request. With these changes, the filesystem only waits for the mutex to be unlocked *after* a 401 error is encountered *and* if the extender explicitly enables their profile type to use locks (using `AuthHandler.enableLocksForType`). This allows extenders to:

- perform their own credential management (detecting your API's credential error, then prompting for credentials), 
- leverage Zowe Explorer's credential prompting/log in functionality as usual (default behavior) without using/waiting for the locks
- or opt-in to the locks, which prevents repeated requests for REST API services w/ invalid credentials

## Release Notes

Milestone: 3.1.0

Changelog: N/A since we have not yet released a new version with the bug

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [x] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
