### PR TITLE
Fix edit history does not show the correct information

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Fixed an issue where a TypeError occurred when applying VS Code proxy settings to an invalid session. [#3425](https://github.com/zowe/zowe-explorer-vscode/issues/3425)
 - Fixed issue where the 'Delete' key binding for the USS tree returns a 'contextValue' error. [#2796](https://github.com/zowe/zowe-explorer-vscode/issues/2796)
+- Fixed a bug where edit history does not show the correct information. [#3432](https://github.com/zowe/zowe-explorer-vscode/issues/3432)
 
 ## `3.1.0`
 

--- a/packages/zowe-explorer/src/webviews/src/edit-history/App.tsx
+++ b/packages/zowe-explorer/src/webviews/src/edit-history/App.tsx
@@ -21,8 +21,9 @@ import * as l10n from "@vscode/l10n";
 export function App(): JSXInternal.Element {
   const [timestamp, setTimestamp] = useState<Date | undefined>();
   const [currentTab, setCurrentTab] = useState<{ [key: string]: string }>({});
+
   useEffect(() => {
-    window.addEventListener("message", (event) => {
+    const handleMessage = (event: MessageEvent) => {
       if (!isSecureOrigin(event.origin)) {
         return;
       }
@@ -41,9 +42,15 @@ export function App(): JSXInternal.Element {
           contents: contents,
         });
       }
-    });
+    };
+
+    window.addEventListener("message", handleMessage);
     PersistentVSCodeAPI.getVSCodeAPI().postMessage({ command: "ready" });
     PersistentVSCodeAPI.getVSCodeAPI().postMessage({ command: "GET_LOCALIZATION" });
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
   }, []);
 
   return (

--- a/packages/zowe-explorer/src/webviews/src/edit-history/components/PersistentTable/PersistentDataPanel.tsx
+++ b/packages/zowe-explorer/src/webviews/src/edit-history/components/PersistentTable/PersistentDataPanel.tsx
@@ -51,7 +51,7 @@ export default function PersistentDataPanel({ type }: Readonly<{ type: Readonly<
   };
 
   useEffect(() => {
-    window.addEventListener("message", (event) => {
+    const handleMessage = (event: MessageEvent) => {
       if (!isSecureOrigin(event.origin)) {
         return;
       }
@@ -64,16 +64,20 @@ export default function PersistentDataPanel({ type }: Readonly<{ type: Readonly<
           }));
         }
       }
-    });
-  }, []);
+    };
+
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [type]);
 
   useEffect(() => {
-    setPersistentProp(() => data[type][selection[type]]);
-  }, [data]);
-
-  useEffect(() => {
-    setPersistentProp(() => data[type][selection[type]]);
-  }, [selection]);
+    if (data[type] && selection[type]) {
+      setPersistentProp(() => data[type][selection[type]] || []);
+    }
+  }, [data, selection, type]);
 
   if (type == "cmds") {
     return (


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

There are two parts to this bug:
1. When the edit history webview first opened, the ready message was not being sent so it was no populating the fields
2. When the selection field was being changed, the data inside each tab was not being refreshed

This fixes both of these issues. However, the first part caused a test to fail as the refresh is now happening too fast for the test, meaning that `getHistoryData` would return undefined data. Therefore, I also had to update the `getHistoryData` method to handle the case where a tree provider might not be found.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog: Fixed a bug where edit history does not show the correct information.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
