### PR TITLE
refactor(TableViewProvider): make constructor & properties protected

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
+- Fixes an issue where properties of the `TableViewProvider` class were not accessible when the class was extended by developers. [#3456](https://github.com/zowe/zowe-explorer-vscode/pull/3456)
+
 ## `3.1.0`
 
 ### New features and enhancements

--- a/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
+++ b/packages/zowe-explorer-api/src/vscode/ui/TableViewProvider.ts
@@ -37,12 +37,10 @@ import { Table } from "./TableView";
  * the "Zowe Resources" panel and is therefore not supported.
  */
 export class TableViewProvider implements WebviewViewProvider {
-    private view?: WebviewView;
-    private tableView: Table.Instance = null;
+    protected view?: WebviewView;
+    protected tableView: Table.Instance = null;
 
-    private static instance: TableViewProvider;
-
-    private constructor() {}
+    protected static instance: TableViewProvider;
 
     /**
      * Retrieve the singleton instance of the TableViewProvider.


### PR DESCRIPTION
## Proposed changes

Updates access modifier for constructor and properties of `TableViewProvider` so it can be extended by extenders for their own panels.

## Release Notes

Milestone: 3.1.1 (or 3.2.0, no strong preference)

Changelog: No changelog needed as behavior is non-breaking & has no effect on current ZE logic

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
