### PR TITLE
refactor(node/ds): Make recall/migration logic more reliable

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue seen with outdated profile information in the z/OS tree view data during upload and download of data set and USS files
   [#3457](https://github.com/zowe/zowe-explorer-vscode/issues/3457)
 - Fixed issue where deleting too many nodes at once would cause the confirmation prompt to be oversized. [#3254](https://github.com/zowe/zowe-explorer-vscode/issues/3254)
+- Fixed an issue where data set migration status was incorrectly handled when the `migr` attribute was not present in the API response. [#3471](https://github.com/zowe/zowe-explorer-vscode/issues/3471)
 
 ## `3.1.1`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
@@ -30,6 +30,7 @@ import { DatasetFSProvider } from "../../../../src/trees/dataset/DatasetFSProvid
 import { ZoweDatasetNode } from "../../../../src/trees/dataset/ZoweDatasetNode";
 import { IconUtils } from "../../../../src/icons/IconUtils";
 import { IconGenerator } from "../../../../src/icons/IconGenerator";
+import { SharedTreeProviders } from "../../../../src/trees/shared/SharedTreeProviders";
 
 // Missing the definition of path module, because I need the original logic for tests
 jest.mock("fs");
@@ -923,5 +924,112 @@ describe("ZoweDatasetNode Unit Tests - function datasetMigrated", () => {
         });
         dsNode.datasetMigrated();
         expect(dsNode.iconPath).toBe(IconGenerator.getIconById(IconUtils.IconId.migrated).path);
+    });
+});
+
+describe("ZoweDatasetNode Unit Tests - getChildren() migration scenarios", () => {
+    const session = createISession();
+    const profileOne: imperative.IProfileLoaded = createIProfile();
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it("should handle a dataset that was migrated", async () => {
+        const sessionNode = new ZoweDatasetNode({
+            label: "sestest",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            session,
+            profile: profileOne,
+            contextOverride: Constants.DS_SESSION_CONTEXT,
+        });
+
+        const pdsNode = new ZoweDatasetNode({
+            label: "TEST.PDS",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            parentNode: sessionNode,
+            profile: profileOne,
+            contextOverride: Constants.DS_PDS_CONTEXT,
+        });
+
+        sessionNode.pattern = "TEST.*";
+        sessionNode.children = [pdsNode];
+
+        jest.spyOn(SharedTreeProviders, "ds", "get").mockReturnValueOnce({
+            applyPatternsToChildren: jest.fn(),
+        } as any);
+        jest.spyOn(Profiles, "getInstance").mockReturnValueOnce({
+            loadNamedProfile: jest.fn().mockReturnValueOnce(profileOne),
+        } as any);
+        jest.spyOn(sessionNode as any, "getDatasets").mockResolvedValueOnce([
+            {
+                success: true,
+                apiResponse: {
+                    items: [
+                        {
+                            dsname: "TEST.PDS",
+                            migr: "YES",
+                            dsorg: "PO",
+                        },
+                    ],
+                },
+            },
+        ]);
+
+        await sessionNode.getChildren();
+
+        expect(pdsNode.contextValue).toBe(Constants.DS_MIGRATED_FILE_CONTEXT);
+        expect(pdsNode.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
+        expect(pdsNode.resourceUri).toBeUndefined();
+        expect(pdsNode.command).toBeUndefined();
+    });
+
+    it("should handle a dataset that was recalled", async () => {
+        const sessionNode = new ZoweDatasetNode({
+            label: "sestest",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            session,
+            profile: profileOne,
+            contextOverride: Constants.DS_SESSION_CONTEXT,
+        });
+
+        const dsNode = new ZoweDatasetNode({
+            label: "TEST.DS",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            parentNode: sessionNode,
+            profile: profileOne,
+            contextOverride: Constants.DS_MIGRATED_FILE_CONTEXT,
+        });
+
+        sessionNode.pattern = "TEST.*";
+        sessionNode.children = [dsNode];
+
+        jest.spyOn(SharedTreeProviders, "ds", "get").mockReturnValueOnce({
+            applyPatternsToChildren: jest.fn(),
+        } as any);
+        jest.spyOn(Profiles, "getInstance").mockReturnValueOnce({
+            loadNamedProfile: jest.fn().mockReturnValueOnce(profileOne),
+        } as any);
+        jest.spyOn(sessionNode as any, "getDatasets").mockResolvedValueOnce([
+            {
+                success: true,
+                apiResponse: {
+                    items: [
+                        {
+                            dsname: "TEST.DS",
+                            migr: "NO",
+                            dsorg: "PS",
+                        },
+                    ],
+                },
+            },
+        ]);
+
+        await sessionNode.getChildren();
+
+        expect(dsNode.contextValue).toBe(Constants.DS_DS_CONTEXT);
+        expect(dsNode.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
+        expect(dsNode.resourceUri).toBeDefined();
+        expect(dsNode.command).toBeDefined();
     });
 });

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -169,7 +169,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                 let tempEntry = profileEntry.entries.get(ds.dsname);
                 if (tempEntry == null) {
                     let name = ds.dsname;
-                    if (ds.dsorg === "PO" || ds.dsorg === "PO-E") {
+                    if (ds.dsorg?.startsWith("PO")) {
                         // Entry is a PDS
                         tempEntry = new PdsEntry(ds.dsname);
                     } else if (ds.dsorg === "VS") {

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -305,10 +305,13 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                 let dsNode = existingItems[item.dsname ?? item.member];
                 if (dsNode != null) {
                     elementChildren[dsNode.label.toString()] = dsNode;
-                    if (SharedContext.isMigrated(dsNode) && item.migr?.toUpperCase() !== "YES") {
-                        await dsNode.datasetRecalled(item.dsorg === "PO" || item.dsorg === "PO-E");
-                    } else if (!SharedContext.isMigrated(dsNode) && item.migr?.toUpperCase() === "YES") {
-                        dsNode.datasetMigrated();
+                    if (item.migr) {
+                        const migrationStatus = item.migr.toUpperCase();
+                        if (SharedContext.isMigrated(dsNode) && migrationStatus !== "YES") {
+                            await dsNode.datasetRecalled(item.dsorg === "PO" || item.dsorg === "PO-E");
+                        } else if (!SharedContext.isMigrated(dsNode) && migrationStatus === "YES") {
+                            dsNode.datasetMigrated();
+                        }
                     }
                 } else if (item.migr && item.migr.toUpperCase() === "YES") {
                     // Creates a ZoweDatasetNode for a migrated dataset

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -308,7 +308,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                     if (item.migr) {
                         const migrationStatus = item.migr.toUpperCase();
                         if (SharedContext.isMigrated(dsNode) && migrationStatus !== "YES") {
-                            await dsNode.datasetRecalled(item.dsorg === "PO" || item.dsorg === "PO-E");
+                            await dsNode.datasetRecalled(item.dsorg?.startsWith("PO"));
                         } else if (!SharedContext.isMigrated(dsNode) && migrationStatus === "YES") {
                             dsNode.datasetMigrated();
                         }
@@ -323,7 +323,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                         profile: cachedProfile,
                     });
                     elementChildren[dsNode.label.toString()] = dsNode;
-                } else if (item.dsorg === "PO" || item.dsorg === "PO-E") {
+                } else if (item.dsorg?.startsWith("PO")) {
                     // Creates a ZoweDatasetNode for a PDS
                     dsNode = new ZoweDatasetNode({
                         label: item.dsname,


### PR DESCRIPTION
## Proposed changes

Makes recall/refresh logic more reliable by first checking for the presence of the `migr` property.

However, while this does not directly fix #3471, it ensures that our logic is always correct. The refresh logic is working as expected - sometimes the mainframe system does not recall the data set immediately, even if the recall API returned a successful response, but we can only update the node based off of information we receive at the time of the refresh. This varies from system to system based on configuration and the archive tool used. 

Unfortunately, we cannot subscribe to events using z/OSMF REST APIs, so the user might have no other choice than to refresh the tree once they know the data set is recalled.

This also implements #3487

## Release Notes

Milestone: 3.1.2

Changelog:

-  Fixed an issue where data set migration status was incorrectly handled when the `migr` attribute was not present in the API response.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):