### PR TITLE
Debounce credential prompts and check profile locks in more places

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 ### Bug fixes
 
 - Fixes an issue where properties of the `TableViewProvider` class were not accessible when the class was extended by developers. [#3456](https://github.com/zowe/zowe-explorer-vscode/pull/3456)
-- Fixed issue where the `AuthHandler.waitForUnlock` function could hang indefinitely if the profile is never unlocked. Now, the function will return after a 30 second timeout as a safety measure. This function should be used alongside the `AuthHandler.isProfileLocked` function to verify that the profile is unlocked before making API requests. [#3480](https://github.com/zowe/zowe-explorer-vscode/pull/3480)
+- Fixed issue where the `AuthHandler.waitForUnlock` function could hang indefinitely if the profile is never unlocked. Now, as a safety measure, the function returns after a 30-second timeout. This function should be used alongside the `AuthHandler.isProfileLocked` function to verify that the profile is unlocked before making API requests. [#3480](https://github.com/zowe/zowe-explorer-vscode/pull/3480)
 
 ## `3.1.1`
 

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 ### Bug fixes
 
 - Fixes an issue where properties of the `TableViewProvider` class were not accessible when the class was extended by developers. [#3456](https://github.com/zowe/zowe-explorer-vscode/pull/3456)
+- Fixed issue where the `AuthHandler.waitForUnlock` function could hang indefinitely if the profile is never unlocked. Now, the function will return after a 30 second timeout as a safety measure. This function should be used alongside the `AuthHandler.isProfileLocked` function to verify that the profile is unlocked before making API requests. [#3480](https://github.com/zowe/zowe-explorer-vscode/pull/3480)
 
 ## `3.1.1`
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/AuthHandler.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/AuthHandler.unit.test.ts
@@ -36,10 +36,14 @@ describe("AuthHandler.enableLocksForType", () => {
 
 describe("AuthHandler.waitForUnlock", () => {
     it("calls Mutex.waitForUnlock if the profile lock is present", async () => {
+        // Used so that `setTimeout` can be invoked from 30sec timeout promise
+        jest.useFakeTimers();
         const mutex = new Mutex();
-        const waitForUnlockMock = jest.spyOn(mutex, "waitForUnlock");
+        const isLockedMock = jest.spyOn(mutex, "isLocked").mockReturnValueOnce(true);
+        const waitForUnlockMock = jest.spyOn(mutex, "waitForUnlock").mockResolvedValueOnce(undefined);
         (AuthHandler as any).profileLocks.set(TEST_PROFILE_NAME, mutex);
         await AuthHandler.waitForUnlock(TEST_PROFILE_NAME);
+        expect(isLockedMock).toHaveBeenCalled();
         expect(waitForUnlockMock).toHaveBeenCalled();
         (AuthHandler as any).profileLocks.clear();
     });

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/AuthHandler.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/AuthHandler.unit.test.ts
@@ -222,3 +222,12 @@ describe("AuthHandler.unlockProfile", () => {
         expect(reloadWorkspaceMock).toHaveBeenCalledWith(TEST_PROFILE_NAME);
     });
 });
+
+describe("AuthHandler.shouldHandleAuthError", () => {
+    it("returns true if a credential prompt was not yet shown to the user", async () => {
+        await expect(AuthHandler.shouldHandleAuthError(TEST_PROFILE_NAME)).resolves.toBe(true);
+    });
+    it("returns false if the user is currently responding to a credential prompt", async () => {
+        await expect(AuthHandler.shouldHandleAuthError(TEST_PROFILE_NAME)).resolves.toBe(false);
+    });
+});

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/AuthHandler.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/AuthHandler.unit.test.ts
@@ -54,6 +54,23 @@ describe("AuthHandler.waitForUnlock", () => {
     });
 });
 
+describe("AuthHandler.unlockAllProfiles", () => {
+    it("unlocks all profiles in the AuthHandler.profileLocks map", async () => {
+        const mutexAuthPrompt = new Mutex();
+        const mutexProfile = new Mutex();
+        const releaseAuthPromptMutex = jest.spyOn(mutexAuthPrompt, "release");
+        const releaseProfileMutex = jest.spyOn(mutexProfile, "release");
+        (AuthHandler as any).authPromptLocks.set(TEST_PROFILE_NAME, mutexAuthPrompt);
+        (AuthHandler as any).profileLocks.set(TEST_PROFILE_NAME, mutexProfile);
+
+        AuthHandler.unlockAllProfiles();
+        expect(releaseAuthPromptMutex).toHaveBeenCalledTimes(1);
+        expect(releaseProfileMutex).toHaveBeenCalledTimes(1);
+        (AuthHandler as any).authPromptLocks.clear();
+        (AuthHandler as any).profileLocks.clear();
+    });
+});
+
 describe("AuthHandler.isProfileLocked", () => {
     it("returns true if the profile is locked", async () => {
         await AuthHandler.lockProfile(TEST_PROFILE_NAME);

--- a/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
+++ b/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
@@ -246,6 +246,21 @@ export class AuthHandler {
     }
 
     /**
+     * Releases locks for all profiles.
+     * Used for scenarios such as the `onVaultChanged` event, where we don't know what secure values have changed,
+     * but we can't assume that the profile still has invalid credentials.
+     */
+    public static unlockAllProfiles(): void {
+        for (const mutex of this.authPromptLocks.values()) {
+            mutex.release();
+        }
+
+        for (const mutex of this.profileLocks.values()) {
+            mutex.release();
+        }
+    }
+
+    /**
      * Checks whether the given profile has its lock acquired.
      * @param profile The profile to check
      * @returns {boolean} `true` if the given profile is locked, `false` otherwise

--- a/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
+++ b/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
@@ -34,6 +34,8 @@ export type AuthPromptParams = {
     authMethods: IAuthMethods;
     // Error encountered from API call
     imperativeError: imperative.ImperativeError;
+    // Whether to show the dialog as a modal
+    useModal?: boolean;
 };
 
 export type ProfileLike = string | imperative.IProfileLoaded;
@@ -137,7 +139,7 @@ export class AuthHandler {
                 const message = "Log in to Authentication Service";
                 const userResp = await Gui.showMessage(params.errorCorrelation?.message ?? params.imperativeError.message, {
                     items: [message],
-                    vsCodeOpts: { modal: true },
+                    vsCodeOpts: { modal: params.useModal },
                 });
                 if (userResp === message && (await params.authMethods.ssoLogin(null, profileName))) {
                     // Unlock profile so it can be used again
@@ -152,7 +154,7 @@ export class AuthHandler {
         const checkCredsButton = "Update Credentials";
         const creds = await Gui.errorMessage(params.errorCorrelation?.message ?? params.imperativeError.message, {
             items: [checkCredsButton],
-            vsCodeOpts: { modal: true },
+            vsCodeOpts: { modal: params.useModal },
         }).then(async (selection) => {
             if (selection !== checkCredsButton) {
                 return;

--- a/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
+++ b/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
@@ -234,10 +234,6 @@ export class AuthHandler {
 
         try {
             await Promise.race([mutex.waitForUnlock(), timeoutPromise]);
-
-            // Add a small delay after unlock to ensure credentials are fully updated
-            // before allowing multiple requests to proceed
-            await new Promise((resolve) => setTimeout(resolve, 500));
         } catch (error) {
             // If we hit the timeout, log it but don't throw to allow operation to continue
             if (error instanceof Error && error.message.includes("Timeout waiting for profile")) {

--- a/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
+++ b/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
@@ -235,13 +235,10 @@ export class AuthHandler {
         try {
             await Promise.race([mutex.waitForUnlock(), timeoutPromise]);
         } catch (error) {
-            // If we hit the timeout, log it but don't throw to allow operation to continue
-            if (error instanceof Error && error.message.includes("Timeout waiting for profile")) {
-                // Log the timeout but continue - we'll use a no-op since we don't have access to the logger in the API
-                // This is acceptable since this is just a fallback for an edge case where the user did not respond to a credential prompt in time
-            } else {
-                throw error;
-            }
+            // Log the timeout to console since we don't have access to the logger in the API
+            // This is acceptable as this is just a fallback for an edge case where the user did not respond to a credential prompt in time
+            // eslint-disable-next-line no-console
+            console.log(`Timeout waiting for profile ${profileName} to be unlocked`);
         }
     }
 

--- a/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
+++ b/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
@@ -34,8 +34,6 @@ export type AuthPromptParams = {
     authMethods: IAuthMethods;
     // Error encountered from API call
     imperativeError: imperative.ImperativeError;
-    // Whether to show the dialog as a modal
-    useModal?: boolean;
 };
 
 export type ProfileLike = string | imperative.IProfileLoaded;
@@ -138,7 +136,7 @@ export class AuthHandler {
                 const message = "Log in to Authentication Service";
                 const userResp = await Gui.showMessage(params.errorCorrelation?.message ?? params.imperativeError.message, {
                     items: [message],
-                    vsCodeOpts: { modal: params.useModal },
+                    vsCodeOpts: { modal: true },
                 });
                 if (userResp === message && (await params.authMethods.ssoLogin(null, profileName))) {
                     // Unlock profile so it can be used again
@@ -153,7 +151,7 @@ export class AuthHandler {
         const checkCredsButton = "Update Credentials";
         const creds = await Gui.errorMessage(params.errorCorrelation?.message ?? params.imperativeError.message, {
             items: [checkCredsButton],
-            vsCodeOpts: { modal: params.useModal },
+            vsCodeOpts: { modal: true },
         }).then(async (selection) => {
             if (selection !== checkCredsButton) {
                 return;

--- a/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
+++ b/packages/zowe-explorer-api/src/profiles/AuthHandler.ts
@@ -99,6 +99,29 @@ export class AuthHandler {
         }
     }
 
+    private static authErrorTimestamps = new Map<string, number>();
+    private static readonly DEBOUNCE_WINDOW_MS = 2000; // 2 seconds
+
+    /**
+     * Determines whether to handle an authentication error for a given profile.
+     * This debounces authentication errors so we don't spam the user with authentication prompts during parallel requests.
+     * @param profileName The name of the profile to check
+     * @returns {boolean} Whether to handle the authentication error
+     */
+    public static shouldHandleAuthError(profileName: string): boolean {
+        const now = Date.now();
+        const lastErrorTime = this.authErrorTimestamps.get(profileName) || 0;
+
+        // If we've seen an auth error for this profile within the debounce window, don't handle it again
+        if (now - lastErrorTime < this.DEBOUNCE_WINDOW_MS) {
+            return false;
+        }
+
+        // Update the timestamp and allow handling this error
+        this.authErrorTimestamps.set(profileName, now);
+        return true;
+    }
+
     /**
      * Prompts the user to authenticate over SSO or a credential prompt in the event of an error.
      * @param profile The profile to authenticate

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed z/OS Console panel background colour to be in sync with the rest of the VS Code styling. [#3445](https://github.com/zowe/zowe-explorer-vscode/pull/3445)
 - Fixed an issue seen with outdated profile information in the z/OS tree view data during upload and download of data set and USS files [#3457](https://github.com/zowe/zowe-explorer-vscode/issues/3457)
 - Fixed issue where deleting too many nodes at once would cause the confirmation prompt to be oversized. [#3254](https://github.com/zowe/zowe-explorer-vscode/issues/3254)
-- Fixed issue where users were prompted several times when using a profile with invalid credentials in a VS Code workspace. Now, the user is only prompted once per profile, and can enter in new credentials before any further prompts appear. [#3480](https://github.com/zowe/zowe-explorer-vscode/pull/3480)
+- Fixed issue where users were prompted several times when using a profile with invalid credentials in a VS Code workspace. Now, the user is only prompted once per profile, allowing the user to enter in new credentials. [#3480](https://github.com/zowe/zowe-explorer-vscode/pull/3480)
 
 ## `3.1.1`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -20,9 +20,9 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where user is unable to open a renamed sequential data set from the Data Sets tree view.. [#3345](https://github.com/zowe/zowe-explorer-vscode/issues/3345)
 - Fixed missing z/OS Console icon when `Workbench > Panel: Show Labels` is set to false. [#3293](https://github.com/zowe/zowe-explorer-vscode/issues/3293)
 - Fixed z/OS Console panel background colour to be in sync with the rest of the VS Code styling. [#3445](https://github.com/zowe/zowe-explorer-vscode/pull/3445)
-- Fixed an issue seen with outdated profile information in the z/OS tree view data during upload and download of data set and USS files
-  [#3457](https://github.com/zowe/zowe-explorer-vscode/issues/3457)
+- Fixed an issue seen with outdated profile information in the z/OS tree view data during upload and download of data set and USS files [#3457](https://github.com/zowe/zowe-explorer-vscode/issues/3457)
 - Fixed issue where deleting too many nodes at once would cause the confirmation prompt to be oversized. [#3254](https://github.com/zowe/zowe-explorer-vscode/issues/3254)
+- Fixed issue where users were prompted several times when using a profile with invalid credentials in a VS Code workspace. Now, the user is only prompted once per profile, and can enter in new credentials before any further prompts appear. [#3480](https://github.com/zowe/zowe-explorer-vscode/pull/3480)
 
 ## `3.1.1`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
@@ -94,6 +94,19 @@ describe("createDirectory", () => {
 });
 
 describe("readDirectory", () => {
+    let mockedProperty: MockedProperty;
+    beforeEach(() => {
+        mockedProperty = new MockedProperty(Profiles, "getInstance", {
+            value: jest.fn().mockReturnValue({
+                loadNamedProfile: jest.fn().mockReturnValue(testProfile),
+            } as any),
+        });
+    });
+
+    afterAll(() => {
+        mockedProperty[Symbol.dispose]();
+    });
+
     describe("filter entry (session)", () => {
         it("calls dataSetsMatchingPattern when reading directories if it exists", async () => {
             const mockSessionEntry = { ...testEntries.session, filter: {}, metadata: { profile: testProfile, path: "/" } };

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
@@ -316,6 +316,7 @@ describe("fetchEntries", () => {
             expect(listFilesMock).toHaveBeenCalledTimes(1);
             existsMock.mockRestore();
             lookupMock.mockRestore();
+            listFilesMock.mockRestore();
         });
     });
 });
@@ -1527,14 +1528,14 @@ describe("Expected behavior for functions w/ profile locks", () => {
     });
 
     describe("listFiles", () => {
-        xit("returns early without making API calls when profile is locked", async () => {
+        it("returns early without making API calls when profile is locked", async () => {
             isProfileLockedMock.mockReturnValueOnce(true);
             const ussApiMock = {
                 fileList: jest.fn().mockResolvedValueOnce({ success: true, items: [] }),
             } as any;
 
             const getUssApiMock = jest.spyOn(ZoweExplorerApiRegister, "getUssApi").mockReturnValueOnce(ussApiMock);
-            const waitForUnlockMock = jest.spyOn(AuthHandler, "waitForUnlock").mockResolvedValueOnce(undefined);
+            const waitForUnlockMock = jest.spyOn(AuthHandler, "waitForUnlock").mockResolvedValue(undefined);
 
             const result = await UssFSProvider.instance.listFiles(testProfile, testUris.file);
 
@@ -1550,7 +1551,7 @@ describe("Expected behavior for functions w/ profile locks", () => {
             getUssApiMock.mockRestore();
         });
 
-        xit("makes API calls when profile is not locked", async () => {
+        it("makes API calls when profile is not locked", async () => {
             isProfileLockedMock.mockReturnValueOnce(false);
             const ussApiMock = {
                 fileList: jest.fn().mockResolvedValueOnce({

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
@@ -16,6 +16,7 @@ import { createIProfile } from "../../../__mocks__/mockCreators/shared";
 import { ZoweExplorerApiRegister } from "../../../../src/extending/ZoweExplorerApiRegister";
 import { UssFSProvider } from "../../../../src/trees/uss/UssFSProvider";
 import { USSFileStructure } from "../../../../src/trees/uss/USSFileStructure";
+import { MockedProperty } from "../../../__mocks__/mockUtils";
 
 const testProfile = createIProfile();
 
@@ -125,6 +126,19 @@ describe("stat", () => {
 describe("move", () => {
     const getInfoFromUriMock = jest.spyOn((UssFSProvider as any).prototype, "_getInfoFromUri");
     const newUri = testUris.file.with({ path: "/sestest/aFile2.txt" });
+
+    let mockedProperty: MockedProperty;
+    beforeEach(() => {
+        mockedProperty = new MockedProperty(Profiles, "getInstance", {
+            value: jest.fn().mockReturnValue({
+                loadNamedProfile: jest.fn().mockReturnValue(testProfile),
+            } as any),
+        });
+    });
+
+    afterAll(() => {
+        mockedProperty[Symbol.dispose]();
+    });
 
     it("returns true if it successfully moved a valid, old URI to the new URI", async () => {
         getInfoFromUriMock

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -89,19 +89,30 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         }
 
         ZoweLogger.trace(`[DatasetFSProvider] stat is locating resource ${uri.toString()}`);
+        const profile = Profiles.getInstance().loadNamedProfile(uriInfo.profile.name);
 
         // Locate the resource using the profile in the given URI.
         let resp;
         const isPdsMember = !FsDatasetsUtils.isPdsEntry(entry) && (entry as DsEntry).isMember;
         try {
+            // Wait for any ongoing authentication process to complete
+            await AuthHandler.waitForUnlock(uriInfo.profile);
+
+            // Check if the profile is locked (indicating an auth error is being handled)
+            // If it's locked, we should wait and not make additional requests
+            if (AuthHandler.isProfileLocked(uriInfo.profile)) {
+                ZoweLogger.debug(`[DatasetFSProvider] Profile ${uriInfo.profile.name} is locked, waiting for authentication`);
+                return entry;
+            }
+
             if (isPdsMember) {
                 // PDS member
                 const pds = this._lookupParentDirectory(uri);
-                resp = await ZoweExplorerApiRegister.getMvsApi(uriInfo.profile).allMembers(pds.name, { attributes: true });
+                resp = await ZoweExplorerApiRegister.getMvsApi(profile).allMembers(pds.name, { attributes: true });
             } else {
                 // Data Set
                 const dsPath = (entry.metadata as DsEntryMetadata).extensionRemovedFromPath();
-                resp = await ZoweExplorerApiRegister.getMvsApi(uriInfo.profile).dataSet(path.posix.basename(dsPath), {
+                resp = await ZoweExplorerApiRegister.getMvsApi(profile).dataSet(path.posix.basename(dsPath), {
                     attributes: true,
                 });
             }
@@ -109,6 +120,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
             if (err instanceof Error) {
                 ZoweLogger.error(err.message);
             }
+            await AuthUtils.handleProfileAuthOnError(err, profile);
             throw err;
         }
 
@@ -143,7 +155,8 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
             return profileEntry;
         }
 
-        const mvsApi = ZoweExplorerApiRegister.getMvsApi(uriInfo.profile);
+        const profile = Profiles.getInstance().loadNamedProfile(uriInfo.profile.name);
+        const mvsApi = ZoweExplorerApiRegister.getMvsApi(profile);
         const datasetResponses: IZosFilesResponse[] = [];
         const dsPatterns = [
             ...new Set(
@@ -217,7 +230,8 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                 return;
             }
 
-            members = await ZoweExplorerApiRegister.getMvsApi(uriInfo.profile).allMembers(path.posix.basename(uri.path));
+            const profile = Profiles.getInstance().loadNamedProfile(entry.metadata.profile.name);
+            members = await ZoweExplorerApiRegister.getMvsApi(profile).allMembers(path.posix.basename(uri.path));
         } catch (err) {
             await AuthUtils.handleProfileAuthOnError(err, uriInfo.profile);
             throw err;
@@ -266,8 +280,9 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
 
         if (!entryExists) {
             try {
+                const profile = Profiles.getInstance().loadNamedProfile(uriInfo.profile.name);
                 if (pdsMember) {
-                    const resp = await ZoweExplorerApiRegister.getMvsApi(uriInfo.profile).allMembers(uriPath[0]);
+                    const resp = await ZoweExplorerApiRegister.getMvsApi(profile).allMembers(uriPath[0]);
                     entryIsDir = false;
                     const memberName = path.parse(uriPath[1]).name;
                     if (
@@ -278,7 +293,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                         throw vscode.FileSystemError.FileNotFound(uri);
                     }
                 } else {
-                    const resp = await ZoweExplorerApiRegister.getMvsApi(uriInfo.profile).dataSet(uriPath[0], {
+                    const resp = await ZoweExplorerApiRegister.getMvsApi(profile).dataSet(uriPath[0], {
                         attributes: true,
                     });
                     if (resp.success && resp.apiResponse?.items?.length > 0) {
@@ -417,7 +432,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         let dsEntry = this._lookupAsFile(uri, { silent: true }) as DsEntry | undefined;
         const bufBuilder = new BufferBuilder();
         const metadata = dsEntry?.metadata ?? this._getInfoFromUri(uri);
-        const profile = Profiles.getInstance().loadNamedProfile(dsEntry?.metadata.profile.name);
+        const profile = Profiles.getInstance().loadNamedProfile(metadata.profile.name);
         const profileEncoding = dsEntry?.encoding ? null : profile.profile?.encoding; // use profile encoding rather than metadata encoding
         try {
             // Wait for any ongoing authentication process to complete
@@ -430,10 +445,10 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                 return null;
             }
 
-            const resp = await ZoweExplorerApiRegister.getMvsApi(metadata.profile).getContents(metadata.dsName, {
+            const resp = await ZoweExplorerApiRegister.getMvsApi(profile).getContents(metadata.dsName, {
                 binary: dsEntry?.encoding?.kind === "binary",
                 encoding: dsEntry?.encoding?.kind === "other" ? dsEntry?.encoding.codepage : profileEncoding,
-                responseTimeout: metadata.profile.profile?.responseTimeout,
+                responseTimeout: profile.profile?.responseTimeout,
                 returnEtag: true,
                 stream: bufBuilder,
             });

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -101,7 +101,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
             // Check if the profile is locked (indicating an auth error is being handled)
             // If it's locked, we should wait and not make additional requests
             if (AuthHandler.isProfileLocked(uriInfo.profile)) {
-                ZoweLogger.debug(`[DatasetFSProvider] Profile ${uriInfo.profile.name} is locked, waiting for authentication`);
+                ZoweLogger.warn(`[DatasetFSProvider] Profile ${uriInfo.profile.name} is locked, waiting for authentication`);
                 return entry;
             }
 
@@ -151,7 +151,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         // Check if the profile is locked (indicating an auth error is being handled)
         // If it's locked, we should wait and not make additional requests
         if (AuthHandler.isProfileLocked(uriInfo.profile)) {
-            ZoweLogger.debug(`[DatasetFSProvider] Profile ${uriInfo.profile.name} is locked, waiting for authentication`);
+            ZoweLogger.warn(`[DatasetFSProvider] Profile ${uriInfo.profile.name} is locked, waiting for authentication`);
             return profileEntry;
         }
 
@@ -226,7 +226,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
             // Check if the profile is locked (indicating an auth error is being handled)
             // If it's locked, we should wait and not make additional requests
             if (AuthHandler.isProfileLocked(entry.metadata.profile)) {
-                ZoweLogger.debug(`[DatasetFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
+                ZoweLogger.warn(`[DatasetFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
                 return;
             }
 
@@ -271,7 +271,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         // Check if the profile is locked (indicating an auth error is being handled)
         // If it's locked, we should wait and not make additional requests
         if (AuthHandler.isProfileLocked(uriInfo.profile)) {
-            ZoweLogger.debug(`[DatasetFSProvider] Profile ${uriInfo.profile.name} is locked, waiting for authentication`);
+            ZoweLogger.warn(`[DatasetFSProvider] Profile ${uriInfo.profile.name} is locked, waiting for authentication`);
             if (entryExists) {
                 return entry;
             }
@@ -441,7 +441,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
             // Check if the profile is locked (indicating an auth error is being handled)
             // If it's locked, we should wait and not make additional requests
             if (AuthHandler.isProfileLocked(metadata.profile)) {
-                ZoweLogger.debug(`[DatasetFSProvider] Profile ${metadata.profile.name} is locked, waiting for authentication`);
+                ZoweLogger.warn(`[DatasetFSProvider] Profile ${metadata.profile.name} is locked, waiting for authentication`);
                 return null;
             }
 

--- a/packages/zowe-explorer/src/trees/shared/SharedInit.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedInit.ts
@@ -22,6 +22,7 @@ import {
     ZoweScheme,
     ZoweVsCodeExtension,
     imperative,
+    AuthHandler,
 } from "@zowe/zowe-explorer-api";
 import { SharedActions } from "./SharedActions";
 import { SharedHistoryView } from "./SharedHistoryView";
@@ -367,6 +368,7 @@ export class SharedInit {
         try {
             const zoweWatcher = imperative.EventOperator.getWatcher().subscribeUser(imperative.ZoweUserEvents.ON_VAULT_CHANGED, async () => {
                 ZoweLogger.info(vscode.l10n.t("Changes in the credential vault detected, refreshing Zowe Explorer."));
+                AuthHandler.unlockAllProfiles();
                 await ProfilesUtils.readConfigFromDisk();
                 await SharedActions.refreshAll();
                 ZoweExplorerApiRegister.getInstance().onVaultUpdateEmitter.fire(Validation.EventType.UPDATE);

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -336,7 +336,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
             // Check if the profile is locked (indicating an auth error is being handled)
             // If it's locked, we should wait and not make additional requests
             if (AuthHandler.isProfileLocked(file.metadata.profile)) {
-                ZoweLogger.debug(`[UssFSProvider] Profile ${file.metadata.profile.name} is locked, waiting for authentication`);
+                ZoweLogger.warn(`[UssFSProvider] Profile ${file.metadata.profile.name} is locked, waiting for authentication`);
                 return;
             }
 
@@ -391,7 +391,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         // Check if the profile is locked (indicating an auth error is being handled)
         // If it's locked, we should wait and not make additional requests
         if (AuthHandler.isProfileLocked(entry.metadata.profile)) {
-            ZoweLogger.debug(`[UssFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
+            ZoweLogger.warn(`[UssFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
             return;
         }
 
@@ -488,7 +488,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         // If it's locked, we should wait and not make additional requests
         if (AuthHandler.isProfileLocked(entry.metadata.profile)) {
             statusMsg.dispose();
-            ZoweLogger.debug(`[UssFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
+            ZoweLogger.warn(`[UssFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
             throw new Error(`Profile ${entry.metadata.profile.name} is locked due to authentication error`);
         }
         const profile = Profiles.getInstance().loadNamedProfile(entry.metadata.profile.name);
@@ -647,7 +647,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         // Check if the profile is locked (indicating an auth error is being handled)
         // If it's locked, we should wait and not make additional requests
         if (AuthHandler.isProfileLocked(entry.metadata.profile)) {
-            ZoweLogger.debug(`[UssFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
+            ZoweLogger.warn(`[UssFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
             return;
         }
 
@@ -699,7 +699,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         // Check if the profile is locked (indicating an auth error is being handled)
         // If it's locked, we should wait and not make additional requests
         if (AuthHandler.isProfileLocked(parent.metadata.profile)) {
-            ZoweLogger.debug(`[UssFSProvider] Profile ${parent.metadata.profile.name} is locked, waiting for authentication`);
+            ZoweLogger.warn(`[UssFSProvider] Profile ${parent.metadata.profile.name} is locked, waiting for authentication`);
             return;
         }
 
@@ -783,7 +783,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         // Check if the profile is locked (indicating an auth error is being handled)
         // If it's locked, we should wait and not make additional requests
         if (AuthHandler.isProfileLocked(destInfo.profile)) {
-            ZoweLogger.debug(`[UssFSProvider] Profile ${destInfo.profile.name} is locked, waiting for authentication`);
+            ZoweLogger.warn(`[UssFSProvider] Profile ${destInfo.profile.name} is locked, waiting for authentication`);
             return;
         }
 

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -411,6 +411,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
             }
         } catch (err) {
             await AuthUtils.handleProfileAuthOnError(err, entry.metadata.profile);
+            throw err;
         }
     }
 

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -92,7 +92,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
             // Check if the profile is locked (indicating an auth error is being handled)
             // If it's locked, we should wait and not make additional requests
             if (AuthHandler.isProfileLocked(entry.metadata.profile)) {
-                ZoweLogger.debug(`[UssFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
+                ZoweLogger.warn(`[UssFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
                 return entry;
             }
 
@@ -165,7 +165,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         // Check if the profile is locked (indicating an auth error is being handled)
         // If it's locked, we should wait and not make additional requests
         if (AuthHandler.isProfileLocked(profile)) {
-            ZoweLogger.debug(`[UssFSProvider] Profile ${profile.name} is locked, waiting for authentication`);
+            ZoweLogger.warn(`[UssFSProvider] Profile ${profile.name} is locked, waiting for authentication`);
             return {
                 success: false,
                 commandResponse: "Profile is locked due to authentication error",
@@ -207,7 +207,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         // Check if the profile is locked (indicating an auth error is being handled)
         // If it's locked, we should wait and not make additional requests
         if (AuthHandler.isProfileLocked(uriInfo.profile)) {
-            ZoweLogger.debug(`[UssFSProvider] Profile ${uriInfo.profile.name} is locked, waiting for authentication`);
+            ZoweLogger.warn(`[UssFSProvider] Profile ${uriInfo.profile.name} is locked, waiting for authentication`);
             if (entryExists) {
                 return this.lookup(uri, false) as UssDirectory | UssFile;
             }

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -55,7 +55,6 @@ export class AuthUtils {
                 imperativeError: err,
                 isUsingTokenAuth: await AuthUtils.isUsingTokenAuth(profile.name),
                 errorCorrelation,
-                useModal: true,
             };
             // If the profile is already locked, prompt the user to re-authenticate.
             if (AuthHandler.isProfileLocked(profile)) {
@@ -119,7 +118,6 @@ export class AuthUtils {
                     imperativeError,
                     isUsingTokenAuth: await AuthUtils.isUsingTokenAuth(profile.name),
                     errorCorrelation,
-                    useModal: true,
                 });
             }
         }

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -55,7 +55,6 @@ export class AuthUtils {
                 imperativeError: err,
                 isUsingTokenAuth: await AuthUtils.isUsingTokenAuth(profile.name),
                 errorCorrelation,
-                useModal: false,
             };
             // If the profile is already locked, prompt the user to re-authenticate.
             if (AuthHandler.isProfileLocked(profile)) {

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -38,6 +38,11 @@ export class AuthUtils {
             (Number(err.errorCode) === imperative.RestConstants.HTTP_STATUS_401 ||
                 err.message.includes("All configured authentication methods failed"))
         ) {
+            if (!AuthHandler.shouldHandleAuthError(profile.name)) {
+                ZoweLogger.debug(`[AuthUtils] Skipping authentication prompt for profile ${profile.name} due to debouncing`);
+                return;
+            }
+
             // In the case of an authentication error, find a more user-friendly error message if available.
             const errorCorrelation = ErrorCorrelator.getInstance().correlateError(ZoweExplorerApiType.All, err, {
                 templateArgs: {

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -55,6 +55,7 @@ export class AuthUtils {
                 imperativeError: err,
                 isUsingTokenAuth: await AuthUtils.isUsingTokenAuth(profile.name),
                 errorCorrelation,
+                useModal: false,
             };
             // If the profile is already locked, prompt the user to re-authenticate.
             if (AuthHandler.isProfileLocked(profile)) {

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -55,10 +55,11 @@ export class AuthUtils {
                 imperativeError: err,
                 isUsingTokenAuth: await AuthUtils.isUsingTokenAuth(profile.name),
                 errorCorrelation,
+                useModal: true,
             };
             // If the profile is already locked, prompt the user to re-authenticate.
             if (AuthHandler.isProfileLocked(profile)) {
-                await AuthHandler.promptForAuthentication(profile, authOpts);
+                await AuthHandler.waitForUnlock(profile);
             } else {
                 // Lock the profile and prompt the user for authentication by providing login/credential prompt options.
                 await AuthHandler.lockProfile(profile, authOpts);
@@ -118,6 +119,7 @@ export class AuthUtils {
                     imperativeError,
                     isUsingTokenAuth: await AuthUtils.isUsingTokenAuth(profile.name),
                     errorCorrelation,
+                    useModal: true,
                 });
             }
         }

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -38,7 +38,7 @@ export class AuthUtils {
             (Number(err.errorCode) === imperative.RestConstants.HTTP_STATUS_401 ||
                 err.message.includes("All configured authentication methods failed"))
         ) {
-            if (!AuthHandler.shouldHandleAuthError(profile.name)) {
+            if (!(await AuthHandler.shouldHandleAuthError(profile.name))) {
                 ZoweLogger.debug(`[AuthUtils] Skipping authentication prompt for profile ${profile.name} due to debouncing`);
                 return;
             }


### PR DESCRIPTION
## Proposed changes

- Adds a 30 second timeout to `waitForUnlock` to prevent deadlocks when using the function (safety mechanism)
- "Debounces" credential prompts from parallel requests to a mainframe system by only showing one credential prompt, until the user answers that prompt. 
  - **Behavior remains unchanged:** If the user selects "Cancel" or closes the dialog, the profile remains locked. The user can update their profile through the tree views through the "Manage Profile" to unlock the profile in the filesystem.
  - Resolves an issue where the user was spammed with multiple credential prompts when using a virtual workspace with a profile w/ invalid credentials.
- **Eliminated cached profile use in filesystems:** All filesystem requests will get the latest profile object to prevent invalid, cached credentials from being used.
  - The issue still exists in tree views for credential desync in the quick picks. I have filed issue #<TBD> to track/resolve this in the future.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.1.2

Changelog:

- Fixed issue where users were prompted several times when using a profile with invalid credentials in a VS Code workspace. Now, the user is only prompted once per profile, allowing the user to enter in new credentials.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [x] Documentation should be added to Zowe Docs (discussing w/ Ana offline)
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
