### PR TITLE
fix: Use `initialSort` instead of `sort` in table column definitions

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue seen with outdated profile information in the z/OS tree view data during upload and download of data set and USS files
   [#3457](https://github.com/zowe/zowe-explorer-vscode/issues/3457)
 - Fixed issue where deleting too many nodes at once would cause the confirmation prompt to be oversized. [#3254](https://github.com/zowe/zowe-explorer-vscode/issues/3254)
+- Fixed an issue where selecting items in table views would reset the column sort order. [#3473](https://github.com/zowe/zowe-explorer-vscode/issues/3473)
 
 ## `3.1.1`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
@@ -3868,7 +3868,7 @@ describe("Dataset Actions Unit Tests - function search", () => {
                         field: "name",
                         headerName: vscode.l10n.t("Data Set Name"),
                         filter: true,
-                        sort: "asc",
+                        initialSort: "asc",
                     } as Table.ColumnOpts,
                     {
                         field: "position",
@@ -4006,7 +4006,7 @@ describe("Dataset Actions Unit Tests - function search", () => {
                         field: "name",
                         headerName: vscode.l10n.t("Data Set Name"),
                         filter: true,
-                        sort: "asc",
+                        initialSort: "asc",
                     } as Table.ColumnOpts,
                     {
                         field: "position",
@@ -4120,7 +4120,7 @@ describe("Dataset Actions Unit Tests - function search", () => {
                         field: "name",
                         headerName: vscode.l10n.t("Data Set Name"),
                         filter: true,
-                        sort: "asc",
+                        initialSort: "asc",
                     } as Table.ColumnOpts,
                     {
                         field: "position",
@@ -4260,7 +4260,7 @@ describe("Dataset Actions Unit Tests - function search", () => {
                         field: "name",
                         headerName: vscode.l10n.t("Data Set Name"),
                         filter: true,
-                        sort: "asc",
+                        initialSort: "asc",
                     } as Table.ColumnOpts,
                     {
                         field: "position",

--- a/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
@@ -1933,7 +1933,7 @@ export class DatasetActions {
                         field: "name",
                         headerName: vscode.l10n.t("Data Set Name"),
                         filter: true,
-                        sort: "asc",
+                        initialSort: "asc",
                     } as Table.ColumnOpts,
                     {
                         field: "position",

--- a/packages/zowe-explorer/src/trees/job/JobTableView.ts
+++ b/packages/zowe-explorer/src/trees/job/JobTableView.ts
@@ -73,7 +73,7 @@ export class JobTableView {
         {
             field: "jobname",
             headerName: l10n.t("Name"),
-            sort: "asc",
+            initialSort: "asc",
         } as Table.ColumnOpts,
         {
             field: "class",

--- a/packages/zowe-explorer/src/webviews/src/table-view/types.ts
+++ b/packages/zowe-explorer/src/webviews/src/table-view/types.ts
@@ -39,6 +39,8 @@ export const tableProps = (
     ensureDomOrder: true,
     rowData: tableData.rows,
     columnDefs: tableData.columns?.map((col) => ({
+        sortable: true,
+        sortingOrder: ["asc", "desc", null],
         ...col,
         comparator: col.comparator ? new Function(wrapFn(col.comparator))() : undefined,
         colSpan: col.colSpan ? new Function(wrapFn(col.colSpan))() : undefined,
@@ -66,11 +68,6 @@ export const tableProps = (
     },
     onSelectionChanged: (event) => {
         setSelectionCount(event.api.getSelectedRows().length);
-    },
-    onSortChanged: (event) => {
-        const rows: Table.RowData[] = [];
-        event.api.forEachNodeAfterFilterAndSort((row, _i) => rows.push(row.data));
-        vscodeApi.postMessage({ command: "ondisplaychanged", data: rows });
     },
     ...(tableData.options ?? {}),
 });

--- a/packages/zowe-explorer/src/webviews/src/table-view/types.ts
+++ b/packages/zowe-explorer/src/webviews/src/table-view/types.ts
@@ -69,5 +69,10 @@ export const tableProps = (
     onSelectionChanged: (event) => {
         setSelectionCount(event.api.getSelectedRows().length);
     },
+    onSortChanged: (event) => {
+        const rows: Table.RowData[] = [];
+        event.api.forEachNodeAfterFilterAndSort((row, _i) => rows.push(row.data));
+        vscodeApi.postMessage({ command: "ondisplaychanged", data: rows });
+    },
     ...(tableData.options ?? {}),
 });


### PR DESCRIPTION
## Proposed changes

Fixes #3473 by using the `initialSort` property for the `Name` columns for both the Jobs table and the Data Set search table. The `initialSort` property is only applied when creating a new column, which allows for sort options to persist after row selection and table actions. When the sort is changed on a column by clicking on its header, its definition is updated - however, setting the `sort` property for the columns themselves overrides any updates to the column definitions.

I've also made a small change to column definitions so that they are explicitly marked as sortable. This could be seen as breaking, but this is done by AG Grid by default, so this change just makes our column definition logic explicit.

See [this page on AG grid column options](https://www.ag-grid.com/javascript-data-grid/column-properties/#reference-sort-initialSort) for more info.

## Release Notes

Milestone: 3.1.2

Changelog:

- Fixed an issue where selecting items in table views would reset the column sort order.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [x] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
