### PR TITLE
fix(jobs): Update getSpoolContentById API to support encoding

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 - Fixes an issue where properties of the `TableViewProvider` class were not accessible when the class was extended by developers. [#3456](https://github.com/zowe/zowe-explorer-vscode/pull/3456)
 - Fixed issue where the `AuthHandler.waitForUnlock` function could hang indefinitely if the profile is never unlocked. Now, as a safety measure, the function returns after a 30-second timeout. This function should be used alongside the `AuthHandler.isProfileLocked` function to verify that the profile is unlocked before making API requests. [#3480](https://github.com/zowe/zowe-explorer-vscode/pull/3480)
+- Added optional `encoding` argument which was missing from the `MainframeInteraction.IJes.getSpoolContentById` method. [#3504](https://github.com/zowe/zowe-explorer-vscode/issues/3504)
 
 ## `3.1.1`
 

--- a/packages/zowe-explorer-api/src/extend/MainframeInteraction.ts
+++ b/packages/zowe-explorer-api/src/extend/MainframeInteraction.ts
@@ -443,9 +443,10 @@ export namespace MainframeInteraction {
          * @param {string} jobname
          * @param {string} jobid
          * @param {number} spoolId
+         * @param {encoding} string
          * @returns {Promise<string>}
          */
-        getSpoolContentById(jobname: string, jobid: string, spoolId: number): Promise<string>;
+        getSpoolContentById(jobname: string, jobid: string, spoolId: number, encoding?: string): Promise<string>;
 
         /**
          * Returns the JCL of a job as a string.

--- a/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
+++ b/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
@@ -430,8 +430,8 @@ export namespace ZoweExplorerZosmf {
             return zosjobs.DownloadJobs.downloadSpoolContentCommon(this.getSession(), parms);
         }
 
-        public getSpoolContentById(jobname: string, jobid: string, spoolId: number): Promise<string> {
-            return zosjobs.GetJobs.getSpoolContentById(this.getSession(), jobname, jobid, spoolId);
+        public getSpoolContentById(jobname: string, jobid: string, spoolId: number, encoding?: string): Promise<string> {
+            return zosjobs.GetJobs.getSpoolContentById(this.getSession(), jobname, jobid, spoolId, encoding);
         }
 
         public getJclForJob(job: zosjobs.IJob): Promise<string> {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/JobFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/JobFSProvider.unit.test.ts
@@ -311,6 +311,27 @@ describe("fetchSpoolAtUri", () => {
         lookupAsFileMock.mockRestore();
     });
 
+    it("fetches the spool contents for a given URI - getSpoolContentById w/ encoding", async () => {
+        const lookupAsFileMock = jest
+            .spyOn(JobFSProvider.instance as any, "_lookupAsFile")
+            .mockReturnValueOnce({ ...testEntries.spool, data: new Uint8Array(), encoding: { kind: "other", codepage: "IBM-1147" } });
+        const lookupParentDirMock = jest.spyOn(JobFSProvider.instance as any, "_lookupParentDirectory").mockReturnValueOnce({ ...testEntries.job });
+        const mockJesApi = {
+            getSpoolContentById: jest.fn((opts) => {
+                return "spool contents";
+            }),
+        };
+        const jesApiMock = jest.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValueOnce(mockJesApi as any);
+        const entry = await JobFSProvider.instance.fetchSpoolAtUri(testUris.spool);
+        expect(lookupAsFileMock).toHaveBeenCalledWith(testUris.spool);
+        expect(lookupParentDirMock).toHaveBeenCalledWith(testUris.spool);
+        expect(mockJesApi.getSpoolContentById).toHaveBeenCalled();
+        expect(mockJesApi.getSpoolContentById.mock.calls[0][3]).toBe("IBM-1147");
+        expect(entry.data.toString()).toStrictEqual("spool contents");
+        jesApiMock.mockRestore();
+        lookupAsFileMock.mockRestore();
+    });
+
     it("calls AuthUtils.promptForAuthError when an error occurs", async () => {
         const lookupAsFileMock = jest
             .spyOn(JobFSProvider.instance as any, "_lookupAsFile")

--- a/packages/zowe-explorer/src/trees/job/JobFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/job/JobFSProvider.ts
@@ -214,18 +214,19 @@ export class JobFSProvider extends BaseProvider implements vscode.FileSystemProv
         const jesApi = ZoweExplorerApiRegister.getJesApi(spoolEntry.metadata.profile);
         await AuthHandler.waitForUnlock(spoolEntry.metadata.profile);
         try {
+            const spoolEncoding = spoolEntry.encoding?.kind === "other" ? spoolEntry.encoding.codepage : profileEncoding;
             if (jesApi.downloadSingleSpool) {
                 const spoolDownloadObject: IDownloadSpoolContentParms = {
                     jobFile: spoolEntry.spool,
                     stream: bufBuilder,
                     binary: spoolEntry.encoding?.kind === "binary",
-                    encoding: spoolEntry.encoding?.kind === "other" ? spoolEntry.encoding.codepage : profileEncoding,
+                    encoding: spoolEncoding,
                 };
 
                 await jesApi.downloadSingleSpool(spoolDownloadObject);
             } else {
                 const jobEntry = this._lookupParentDirectory(uri) as JobEntry;
-                bufBuilder.write(await jesApi.getSpoolContentById(jobEntry.job.jobname, jobEntry.job.jobid, spoolEntry.spool.id));
+                bufBuilder.write(await jesApi.getSpoolContentById(jobEntry.job.jobname, jobEntry.job.jobid, spoolEntry.spool.id, spoolEncoding));
             }
         } catch (err) {
             await AuthUtils.handleProfileAuthOnError(err, spoolEntry.metadata.profile);


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
This is a follow-up to #3507 where I missed that the getSpoolContentById API needed an update to support encoding.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.1.2

Changelog: Added optional `encoding` argument which was missing from the `MainframeInteraction.IJes.getSpoolContentById` method

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
