### PR TITLE
fix: avoid extra prompts when replacing conflicting member on creation

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where expanding a job node to show spool doesn't trigger the **Update Credentials** prompt when credentials are invalid. [#3376](https://github.com/zowe/zowe-explorer-vscode/pull/3376)
 - Fixed data loss when creating a data set member with the same name as an existing member. When creating a new member, the user is now prompted to replace it if the member already exists. [[#3327](https://github.com/zowe/zowe-explorer-vscode/issues/3327)]
 - Fixed an issue where profile encoding is not respected when opening job spool files. [#3504](https://github.com/zowe/zowe-explorer-vscode/issues/3504)
+- Fixed an issue where the user was unnecessary prompting after choosing to replace existing data set members when creating new ones. [#3522](https://github.com/zowe/zowe-explorer-vscode/issues/3522)
 
 ## `2.18.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/Profiles.extended.unit.test.ts
@@ -868,7 +868,7 @@ describe("Profiles Unit Tests - Function createZoweSchema", () => {
                 ? "file:\\globalPath\\.zowe\\zowe.config.json"
                 : "file:/globalPath/.zowe/zowe.config.json".split(path.sep).join(path.posix.sep);
 
-        await expect(Profiles.getInstance().createZoweSchema(blockMocks.testDatasetTree)).resolves.toBe(expectedValue);
+        await expect(Profiles.getInstance().createZoweSchema(blockMocks.testDatasetTree)).resolves.toContain(expectedValue);
     });
 });
 

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -430,13 +430,16 @@ export async function createMember(parent: api.IZoweDatasetTreeNode, datasetProv
         const label = parent.label as string;
         const profile = parent.getProfile();
         let replace: shouldReplace;
+        let newEtag: string;
         const dsMemberName = `${label}(${name})`;
         try {
             replace = await determineReplacement(profile, dsMemberName, "mem");
             if (replace !== "cancel") {
-                await ZoweExplorerApiRegister.getMvsApi(profile).createDataSetMember(dsMemberName, {
+                const response = await ZoweExplorerApiRegister.getMvsApi(profile).createDataSetMember(dsMemberName, {
                     responseTimeout: profile.profile?.responseTimeout,
+                    returnEtag: true,
                 });
+                newEtag = response.apiResponse.etag;
                 if (replace === "replace") {
                     deleteTempFile(dsMemberName, parent);
                 }
@@ -459,6 +462,10 @@ export async function createMember(parent: api.IZoweDatasetTreeNode, datasetProv
         await newNode.openDs(false, true, datasetProvider);
         if (replace === "notFound") {
             parent.children.push(newNode);
+        }
+
+        if (replace !== "cancel") {
+            (parent.children.find((node) => node.label === name) as ZoweDatasetNode)?.setEtag(newEtag);
         }
 
         parent.dirty = true;

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -464,8 +464,9 @@ export async function createMember(parent: api.IZoweDatasetTreeNode, datasetProv
             parent.children.push(newNode);
         }
 
-        if (replace !== "cancel") {
-            (parent.children.find((node) => node.label === name) as ZoweDatasetNode)?.setEtag(newEtag);
+        const child = parent.children.find((node) => node.label === name);
+        if (newEtag && child && child instanceof ZoweDatasetNode) {
+            child.setEtag(newEtag);
         }
 
         parent.dirty = true;


### PR DESCRIPTION
## Proposed changes

Avoid extra prompts when the user already decided to replace the existing member
Fix #3420
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 2.18.1

Changelog: Avoids unnecessary prompting after choosing to replace the existing member

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments


<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
