### PR TITLE
port: line overwritten by another port; avoid using cached profiles

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
@@ -1078,7 +1078,7 @@ describe("delete", () => {
 
         await DatasetFSProvider.instance.delete(testUris.ps, { recursive: false });
         expect(mockMvsApi.deleteDataSet).toHaveBeenCalledWith(fakePs.name, { responseTimeout: undefined });
-        expect(_lookupMock).toHaveBeenCalledWith(testUris.ps, false);
+        expect(_lookupMock).toHaveBeenCalledWith(testUris.ps);
         expect(_fireSoonMock).toHaveBeenCalled();
 
         expect(fakeSession.entries.has(fakePs.name)).toBe(false);
@@ -1099,7 +1099,7 @@ describe("delete", () => {
 
         await DatasetFSProvider.instance.delete(testUris.pdsMember, { recursive: false });
         expect(mockMvsApi.deleteDataSet).toHaveBeenCalledWith(`${fakePds.name}(${fakePdsMember.name})`, { responseTimeout: undefined });
-        expect(_lookupMock).toHaveBeenCalledWith(testUris.pdsMember, false);
+        expect(_lookupMock).toHaveBeenCalledWith(testUris.pdsMember);
         expect(_fireSoonMock).toHaveBeenCalled();
 
         expect(fakePds.entries.has(fakePdsMember.name)).toBe(false);
@@ -1119,7 +1119,7 @@ describe("delete", () => {
 
         await DatasetFSProvider.instance.delete(testUris.pds, { recursive: false });
         expect(mockMvsApi.deleteDataSet).toHaveBeenCalledWith(fakePds.name, { responseTimeout: undefined });
-        expect(_lookupMock).toHaveBeenCalledWith(testUris.pds, false);
+        expect(_lookupMock).toHaveBeenCalledWith(testUris.pds);
         expect(_fireSoonMock).toHaveBeenCalled();
 
         mvsApiMock.mockRestore();
@@ -1143,7 +1143,7 @@ describe("delete", () => {
 
         await expect(DatasetFSProvider.instance.delete(testUris.ps, { recursive: false })).rejects.toThrow();
         expect(mockMvsApi.deleteDataSet).toHaveBeenCalledWith(fakePs.name, { responseTimeout: undefined });
-        expect(_lookupMock).toHaveBeenCalledWith(testUris.ps, false);
+        expect(_lookupMock).toHaveBeenCalledWith(testUris.ps);
         expect(_fireSoonMock).toHaveBeenCalled();
         expect(handleErrorMock).toHaveBeenCalledWith(
             sampleError,

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -184,7 +184,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                     args: [uri, uriInfo, pattern],
                 },
                 apiType: ZoweExplorerApiType.Mvs,
-                profileType: profile?.type,
+                profileType: profile.type,
                 templateArgs: { profileName: uriInfo.profileName },
             });
         }
@@ -569,7 +569,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         const statusMsg = Gui.setStatusBarMessage(`$(sync~spin) ${vscode.l10n.t("Saving data set...")}`);
         let resp: IZosFilesResponse;
         try {
-            const profile = Profiles.getInstance().loadNamedProfile(entry?.metadata.profile.name);
+            const profile = Profiles.getInstance().loadNamedProfile(entry.metadata.profile.name);
             const mvsApi = ZoweExplorerApiRegister.getMvsApi(profile);
             const profileEncoding = entry.encoding ? null : profile.profile?.encoding; // use profile encoding rather than metadata encoding
             resp = await mvsApi.uploadFromBuffer(Buffer.from(content), entry.metadata.dsName, {

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -570,7 +570,8 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         let resp: IZosFilesResponse;
         try {
             const mvsApi = ZoweExplorerApiRegister.getMvsApi(entry.metadata.profile);
-            const profileEncoding = entry.encoding ? null : entry.metadata.profile.profile?.encoding;
+            const profile = Profiles.getInstance().loadNamedProfile(entry?.metadata.profile.name);
+            const profileEncoding = entry.encoding ? null : profile.profile?.encoding; // use profile encoding rather than metadata encoding
             resp = await mvsApi.uploadFromBuffer(Buffer.from(content), entry.metadata.dsName, {
                 binary: entry.encoding?.kind === "binary",
                 encoding: entry.encoding?.kind === "other" ? entry.encoding.codepage : profileEncoding,

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -176,7 +176,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                 }
             }
         } catch (err) {
-            await AuthUtils.handleProfileAuthOnError(err, uriInfo.profile);
+            await AuthUtils.handleProfileAuthOnError(err, profile);
             this._handleError(err, {
                 additionalContext: vscode.l10n.t("Failed to list datasets"),
                 retry: {
@@ -184,7 +184,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                     args: [uri, uriInfo, pattern],
                 },
                 apiType: ZoweExplorerApiType.Mvs,
-                profileType: uriInfo.profile?.type,
+                profileType: profile?.type,
                 templateArgs: { profileName: uriInfo.profileName },
             });
         }
@@ -206,7 +206,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                         tempEntry = new DsEntry(name, false);
                     }
                     tempEntry.metadata = new DsEntryMetadata({
-                        ...profileEntry.metadata,
+                        profile,
                         path: path.posix.join(profileEntry.metadata.path, name),
                     });
                     profileEntry.entries.set(name, tempEntry);
@@ -436,12 +436,12 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         const profileEncoding = dsEntry?.encoding ? null : profile.profile?.encoding; // use profile encoding rather than metadata encoding
         try {
             // Wait for any ongoing authentication process to complete
-            await AuthHandler.waitForUnlock(metadata.profile);
+            await AuthHandler.waitForUnlock(profile);
 
             // Check if the profile is locked (indicating an auth error is being handled)
             // If it's locked, we should wait and not make additional requests
-            if (AuthHandler.isProfileLocked(metadata.profile)) {
-                ZoweLogger.warn(`[DatasetFSProvider] Profile ${metadata.profile.name} is locked, waiting for authentication`);
+            if (AuthHandler.isProfileLocked(profile)) {
+                ZoweLogger.warn(`[DatasetFSProvider] Profile ${profile.name} is locked, waiting for authentication`);
                 return null;
             }
 
@@ -490,7 +490,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         } catch (error) {
             //Response will error if the file is not found
             //Callers of fetchDatasetAtUri() do not expect it to throw an error
-            await AuthUtils.handleProfileAuthOnError(error, metadata.profile);
+            await AuthUtils.handleProfileAuthOnError(error, profile);
             return null;
         }
     }
@@ -569,8 +569,8 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         const statusMsg = Gui.setStatusBarMessage(`$(sync~spin) ${vscode.l10n.t("Saving data set...")}`);
         let resp: IZosFilesResponse;
         try {
-            const mvsApi = ZoweExplorerApiRegister.getMvsApi(entry.metadata.profile);
             const profile = Profiles.getInstance().loadNamedProfile(entry?.metadata.profile.name);
+            const mvsApi = ZoweExplorerApiRegister.getMvsApi(profile);
             const profileEncoding = entry.encoding ? null : profile.profile?.encoding; // use profile encoding rather than metadata encoding
             resp = await mvsApi.uploadFromBuffer(Buffer.from(content), entry.metadata.dsName, {
                 binary: entry.encoding?.kind === "binary",
@@ -696,7 +696,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
     }
 
     public async delete(uri: vscode.Uri, _options: { readonly recursive: boolean }): Promise<void> {
-        const entry = this.lookup(uri, false) as DsEntry | PdsEntry;
+        const entry = this.lookup(uri) as DsEntry | PdsEntry;
         const parent = this._lookupParentDirectory(uri);
         let fullName: string = "";
         if (FsDatasetsUtils.isPdsEntry(parent)) {
@@ -708,9 +708,10 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
             fullName = entry.metadata.dsName;
         }
 
+        const profile = Profiles.getInstance().loadNamedProfile(entry.metadata.profile.name);
         try {
-            await ZoweExplorerApiRegister.getMvsApi(entry.metadata.profile).deleteDataSet(fullName, {
-                responseTimeout: entry.metadata.profile.profile?.responseTimeout,
+            await ZoweExplorerApiRegister.getMvsApi(profile).deleteDataSet(fullName, {
+                responseTimeout: profile.profile?.responseTimeout,
             });
         } catch (err) {
             this._handleError(err, {
@@ -720,12 +721,12 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                     comment: ["File path"],
                 }),
                 apiType: ZoweExplorerApiType.Mvs,
-                profileType: entry.metadata.profile?.type,
+                profileType: profile?.type,
                 retry: {
                     fn: this.delete.bind(this),
                     args: [uri, _options],
                 },
-                templateArgs: { profileName: entry.metadata.profile?.name ?? "" },
+                templateArgs: { profileName: profile?.name ?? "" },
             });
             throw err;
         }
@@ -747,17 +748,14 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
 
         const oldName = entry.name;
         const newName = path.posix.basename(newUri.path);
+        const profile = Profiles.getInstance().loadNamedProfile(entry.metadata.profile.name);
 
         try {
             if (FsDatasetsUtils.isPdsEntry(entry) || !entry.isMember) {
-                await ZoweExplorerApiRegister.getMvsApi(entry.metadata.profile).renameDataSet(oldName, newName);
+                await ZoweExplorerApiRegister.getMvsApi(profile).renameDataSet(oldName, newName);
             } else {
                 const pdsName = path.basename(path.posix.join(entry.metadata.path, ".."));
-                await ZoweExplorerApiRegister.getMvsApi(entry.metadata.profile).renameDataSetMember(
-                    pdsName,
-                    path.parse(oldName).name,
-                    path.parse(newName).name
-                );
+                await ZoweExplorerApiRegister.getMvsApi(profile).renameDataSetMember(pdsName, path.parse(oldName).name, path.parse(newName).name);
             }
         } catch (err) {
             this._handleError(err, {
@@ -772,7 +770,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                     fn: this.rename.bind(this),
                     args: [oldUri, newUri, options],
                 },
-                templateArgs: { profileName: entry.metadata.profile?.name ?? "" },
+                templateArgs: { profileName: profile?.name ?? "" },
             });
             throw err;
         }

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -87,16 +87,16 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
 
         try {
             // Wait for any ongoing authentication process to complete
-            await AuthHandler.waitForUnlock(entry.metadata.profile);
+            await AuthHandler.waitForUnlock(uriInfo.profile);
 
             // Check if the profile is locked (indicating an auth error is being handled)
             // If it's locked, we should wait and not make additional requests
-            if (AuthHandler.isProfileLocked(entry.metadata.profile)) {
-                ZoweLogger.warn(`[UssFSProvider] Profile ${entry.metadata.profile.name} is locked, waiting for authentication`);
+            if (AuthHandler.isProfileLocked(uriInfo.profile)) {
+                ZoweLogger.warn(`[UssFSProvider] Profile ${uriInfo.profile?.name} is locked, waiting for authentication`);
                 return entry;
             }
 
-            const fileResp = await this.listFiles(entry.metadata.profile, uri, true);
+            const fileResp = await this.listFiles(uriInfo.profile, uri, true);
             if (fileResp.success) {
                 // Regardless of the resource type, it will be the first item in a successful response.
                 // When listing a folder, the folder's stats will be represented as the "." entry.
@@ -244,7 +244,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
             return parentDir.entries.get(filename) as UssFile;
         }
 
-        const fileList = entryExists ? await this.listFiles(entry.metadata.profile, uri) : resp;
+        const fileList = entryExists ? await this.listFiles(uriInfo.profile, uri) : resp;
         for (const item of fileList.apiResponse?.items ?? []) {
             const itemName = item.name as string;
 


### PR DESCRIPTION
## Proposed changes

In PR #3515 I tried to port the debounce PR and #3457, and in the process I accidentally overwrote a change from my PR that was not yet resolved in the other PR. Although the change is small, this ensures that upload operations still use the latest profile rather than the cached one. 

I also realized that the changes in #3457 did not completely resolve the cached profile issue w/ the data sets & USS providers, as it was still using cached profiles in certain places. This PR refactors those functions so both providers use the latest profile for any operation. I'll make sure these changes are also added to `main` so we do not experience a regression in 3.2.0.

## Release Notes

Milestone: 3.1.2

Changelog: No changelog, changelogs are already present w/ these fixes

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
