### PR TITLE
fix(v2): Show Attributes not working for VSAM data sets

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed an issue where the attributes were not shown for VSAM data sets when using the Show Attributes feature. [#3545](https://github.com/zowe/zowe-explorer-vscode/issues/3545)
+
 ## `2.18.1`
 
 ### Bug fixes

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/init.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/init.unit.test.ts
@@ -170,6 +170,7 @@ describe("Test src/dataset/extension", () => {
                 name: "zowe.ds.showAttributes",
                 mock: [
                     { spy: jest.spyOn(contextuals, "isDs"), arg: [test.value], ret: false },
+                    { spy: jest.spyOn(contextuals, "isVsam"), arg: [test.value], ret: false },
                     { spy: jest.spyOn(contextuals, "isPds"), arg: [test.value], ret: false },
                     { spy: jest.spyOn(contextuals, "isDsMember"), arg: [test.value], ret: true },
                     { spy: jest.spyOn(dsActions, "showAttributes"), arg: [test.value, dsProvider] },

--- a/packages/zowe-explorer/src/dataset/init.ts
+++ b/packages/zowe-explorer/src/dataset/init.ts
@@ -149,7 +149,7 @@ export async function initDatasetProvider(context: vscode.ExtensionContext): Pro
     context.subscriptions.push(
         vscode.commands.registerCommand("zowe.ds.showAttributes", async (node, nodeList) => {
             const selectedNodes = getSelectedNodeList(node, nodeList).filter(
-                (element) => contextuals.isDs(element) || contextuals.isPds(element) || contextuals.isDsMember(element)
+                (element) => contextuals.isDs(element) || contextuals.isVsam(element) || contextuals.isPds(element) || contextuals.isDsMember(element)
             );
             for (const item of selectedNodes) {
                 await dsActions.showAttributes(item, datasetProvider);


### PR DESCRIPTION
## Proposed changes

Ports #3549 to fix #3545 for `v2-lts`

## Release Notes

Milestone: 2.18.2

Changelog:

- Fixed an issue where the attributes were not shown for VSAM data sets when using the Show Attributes feature.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
