### PR TITLE
v2: Fix wrong context menu options after deleting members

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed an issue where right-click menu for data set shows wrong options after deleting multiple PDS members. [#3516](https://github.com/zowe/zowe-explorer-vscode/issues/3516)
+
 ## `2.18.1`
 
 ### Bug fixes

--- a/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/dataset/actions.unit.test.ts
@@ -44,6 +44,7 @@ import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 import { mocked } from "../../../__mocks__/mockUtils";
 import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
 import * as workspaceUtils from "../../../src/utils/workspace";
+import { TreeViewUtils } from "../../../src/utils/TreeViewUtils";
 
 // Missing the definition of path module, because I need the original logic for tests
 jest.mock("fs");
@@ -612,6 +613,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
             testMemberNode,
             testFavMemberNode,
             testFavoritedNode,
+            fixMultiSelectMock: jest.spyOn(TreeViewUtils, "fixVsCodeMultiSelect"),
         };
     }
 
@@ -629,6 +631,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         await dsActions.deleteDatasetPrompt(blockMocks.testDatasetTree);
 
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith(`The following 1 item(s) were deleted: ${blockMocks.testDatasetNode.getLabel()}`);
+        expect(blockMocks.fixMultiSelectMock).toHaveBeenCalledWith(blockMocks.testDatasetTree, blockMocks.testDatasetNode.getParent());
     });
 
     it("Should delete one member", async () => {
@@ -645,6 +648,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith(
             `The following 1 item(s) were deleted: ${blockMocks.testMemberNode.getParent().getLabel()}(${blockMocks.testMemberNode.getLabel()})`
         );
+        expect(blockMocks.fixMultiSelectMock).toHaveBeenCalledWith(blockMocks.testDatasetTree, blockMocks.testMemberNode.getParent());
     });
 
     it("Should delete one VSAM", async () => {

--- a/packages/zowe-explorer/src/dataset/actions.ts
+++ b/packages/zowe-explorer/src/dataset/actions.ts
@@ -42,6 +42,7 @@ import { ProfileManagement } from "../utils/ProfileManagement";
 import * as nls from "vscode-nls";
 import { resolveFileConflict } from "../shared/actions";
 import { LocalFileManagement } from "../utils/LocalFileManagement";
+import { TreeViewUtils } from "../utils/TreeViewUtils";
 
 nls.config({
     messageFormat: nls.MessageFormat.bundle,
@@ -407,6 +408,7 @@ export async function deleteDatasetPrompt(datasetProvider: api.IZoweTree<api.IZo
     for (const member of memberParents) {
         datasetProvider.refreshElement(member);
     }
+    await TreeViewUtils.fixVsCodeMultiSelect(datasetProvider, nodes[0].getParent());
 }
 
 /**

--- a/packages/zowe-explorer/src/utils/TreeViewUtils.ts
+++ b/packages/zowe-explorer/src/utils/TreeViewUtils.ts
@@ -32,10 +32,10 @@ export class TreeViewUtils {
      * (where multi-select is still active after deleting the nodes in previous multi-selection)
      * @param treeProvider The tree provider to reset multi-selection for
      */
-    public static async fixVsCodeMultiSelect<T>(treeProvider: IZoweTree<T>): Promise<void> {
+    public static async fixVsCodeMultiSelect<T>(treeProvider: IZoweTree<T>, nodeToRefresh?: IZoweTreeNode): Promise<void> {
         const treeView = treeProvider.getTreeView();
-        await treeView.reveal(treeProvider.mFavoriteSession, { select: true });
-        await treeView.reveal(treeProvider.mFavoriteSession, { select: false });
+        await treeView.reveal(nodeToRefresh ?? treeProvider.mFavoriteSession, { select: true });
+        await treeView.reveal(nodeToRefresh ?? treeProvider.mFavoriteSession, { select: false });
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Ports #3539 to v2-lts branch

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 2.18.2

Changelog: Fixed an issue where right-click menu for data set shows wrong options after deleting multiple PDS members

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
