### PR TITLE
fix: allow listing root in USS, fix edge case w/ `cd ..`

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where multiple directories with the same name could not be favorited in the USS tree. [#3590](https://github.com/zowe/zowe-explorer-vscode/pull/3590)
 - Fixed an issue where an invalid token in a base configuration profile will take precedence over a plaintext user/password in a service configuration profile. [#3575](https://github.com/zowe/zowe-explorer-vscode/pull/3575)
 - Fixed an issue where profiles that were not utilizing tokens were improperly running `checkJwtForProfile()` function within the `ZoweTreeProvider`. [#3575](https://github.com/zowe/zowe-explorer-vscode/pull/3575)
+- Fixed an issue where searching for the root directory (`/`) under a profile caused the profile to show a placeholder rather than a list of the files and folders at that path. [#3603](https://github.com/zowe/zowe-explorer-vscode/pull/3603)
 
 ## `3.1.2`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
@@ -634,11 +634,11 @@ describe("USSTree Unit Tests - Function cdUp", () => {
     it("Tests that cdUp() handles when current filter set but as a root path", async () => {
         const globalMocks = createGlobalMocks();
 
-        await globalMocks.testTree.filterBy(globalMocks.testTree.mSessionNodes[1], "/u");
-        expect(globalMocks.testTree.mSessionNodes[1].fullPath).toEqual("/u");
+        await globalMocks.testTree.filterBy(globalMocks.testTree.mSessionNodes[1], "/");
+        expect(globalMocks.testTree.mSessionNodes[1].fullPath).toEqual("/");
 
         await globalMocks.testTree.cdUp(globalMocks.testTree.mSessionNodes[1]);
-        expect(globalMocks.testTree.mSessionNodes[1].fullPath).toEqual("/u");
+        expect(globalMocks.testTree.mSessionNodes[1].fullPath).toEqual("/");
 
         expect(globalMocks.showInformationMessage).toHaveBeenCalledWith("You are already at the root directory.", undefined);
     });

--- a/packages/zowe-explorer/src/trees/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/trees/uss/USSTree.ts
@@ -688,7 +688,7 @@ export class USSTree extends ZoweTreeProvider<IZoweUSSTreeNode> implements Types
         ZoweLogger.trace("USSTree.cdUp called.");
 
         // Check if the path is a root path already
-        if (path.posix.dirname(node.fullPath) === "/") {
+        if (node.fullPath === "/") {
             Gui.showMessage(vscode.l10n.t("You are already at the root directory."));
             return;
         }
@@ -705,8 +705,8 @@ export class USSTree extends ZoweTreeProvider<IZoweUSSTreeNode> implements Types
      * @returns {Promise<void>}
      */
     private async updateTreeView(node: IZoweUSSTreeNode, filterPath: string, addHistory: boolean): Promise<void> {
-        AuthUtils.syncSessionNode((profile) => ZoweExplorerApiRegister.getUssApi(profile), node);
-        const sanitizedPath = filterPath.replace(/\/+/g, "/").replace(/(\/*)$/, "");
+        await AuthUtils.syncSessionNode((profile) => ZoweExplorerApiRegister.getUssApi(profile), node);
+        const sanitizedPath = filterPath.replace(/\/{2,}/g, "/").replace(/(.+?)\/*$/, "$1");
         node.fullPath = sanitizedPath;
         const icon = IconGenerator.getIconByNode(node);
         if (icon) {


### PR DESCRIPTION
## Proposed changes

Fixes two issues:

- Searching for the root directory (`/`) under a profile caused the profile to show a placeholder rather than a list of the files and folders at that path
- Edge case for `cd ..` / "Go Up One Level" (blocked by above issue)

### How to test

Issue 1 (searching for root dir):
- Click on the magnifying glass beside a profile in the USS tree
- Enter in the root directory as the directory to search (`/`)
- Notice that the files/folders are listed for the root directory rather than a misleading placeholder.

Issue 2 (cd up):
- Click on the magnifying glass beside a profile in the USS tree
- Enter in a top-level directory as the directory to search (e.g., `/users`)
- Click the Up Arrow / "Go Up One Path" action button to go up a folder
- Notice that the path is updated to `/` and the results are listed. Previously, a misleading info message was shown stating that the user was already at the root directory even though they weren't.

## Release Notes

Milestone: 3.2.0

Changelog: See `packages/zowe-explorer/CHANGELOG.md`

Note that the `cd ..` edge case is not in the changelog as we did not yet release the feature.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [x] These changes may need ported to the appropriate branches (list here): `v2-lts` (for not being able to search the root dir)
