### PR TITLE
fix: add optional chaining to tab input check

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 - BugFix: Fixed an issue within the `shouldRemoveTokenFromProfile()` function where a the token type check was occurring on a service profile rather than the base profile. [#3575](https://github.com/zowe/zowe-explorer-vscode/pull/3575)
 - Updated dependencies for technical currency purposes. [#3576](https://github.com/zowe/zowe-explorer-vscode/pull/3576)
 - Fixed issue where webviews may register their `onDidReceiveMessage` event multiple times in the `resolveForView` function. [#3584](https://github.com/zowe/zowe-explorer-vscode/pull/3584)
+- Fixed an issue where the `BaseProvider._reopenEditorForRelocatedUri` function threw an exception when an open tab did not have a URI on its `input` property. [#3613](https://github.com/zowe/zowe-explorer-vscode/issues/3613)
 
 ## `3.1.2`
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/fs/BaseProvider.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/fs/BaseProvider.unit.test.ts
@@ -665,6 +665,26 @@ describe("_reopenEditorForRelocatedUri", () => {
         expect(executeCmdMock).toHaveBeenCalled();
         tabGroupsMock[Symbol.dispose]();
     });
+    
+    it("gracefully handles tabs with no input URI", async () => {
+        const tab = {
+            input: null,
+            viewColumn: vscode.ViewColumn.One,
+        };
+        const tabGroupsMock = new MockedProperty(vscode.window.tabGroups, "all", undefined, [
+            {
+                isActive: true,
+                tabs: [tab],
+            },
+        ]);
+        const oldUri = globalMocks.testFileUri;
+        const newUri = globalMocks.testFileUri.with({
+            path: "/file2.txt",
+        });
+        const prov = new (BaseProvider as any)();
+        await expect(prov._reopenEditorForRelocatedUri(oldUri, newUri)).resolves.not.toThrow();
+        tabGroupsMock[Symbol.dispose]();
+    });
 });
 
 describe("onCloseEvent", () => {

--- a/packages/zowe-explorer-api/src/fs/BaseProvider.ts
+++ b/packages/zowe-explorer-api/src/fs/BaseProvider.ts
@@ -224,7 +224,7 @@ export class BaseProvider {
     private async _reopenEditorForRelocatedUri(oldUri: vscode.Uri, newUri: vscode.Uri): Promise<void> {
         const tabGroups = vscode.window.tabGroups.all;
         const allTabs = tabGroups.reduce((acc: vscode.Tab[], group) => acc.concat(group.tabs), []);
-        const tabWithOldUri = allTabs.find((t) => (t.input as any).uri.path === oldUri.path);
+        const tabWithOldUri = allTabs.find((t) => (t.input as any)?.uri?.path === oldUri.path);
         if (tabWithOldUri) {
             const parent = tabGroups.find((g) => g.tabs.find((t) => t === tabWithOldUri));
             const editorCol = parent.viewColumn;

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where multiple directories with the same name could not be favorited in the USS tree. [#3590](https://github.com/zowe/zowe-explorer-vscode/pull/3590)
 - Fixed an issue where an invalid token in a base configuration profile will take precedence over a plaintext user/password in a service configuration profile. [#3575](https://github.com/zowe/zowe-explorer-vscode/pull/3575)
 - Fixed an issue where profiles that were not utilizing tokens were improperly running `checkJwtForProfile()` function within the `ZoweTreeProvider`. [#3575](https://github.com/zowe/zowe-explorer-vscode/pull/3575)
+- Fixed an issue where dragging and dropping a USS file caused an unhandled error while finalizing the drop operation. [#3613](https://github.com/zowe/zowe-explorer-vscode/issues/3613)
 
 ## `3.1.2`
 


### PR DESCRIPTION
## Proposed changes

Fixes #3613 

### How to test

- Try dragging and dropping a USS file from one folder to another while the Settings tab is open
- Notice that the operation succeeds and the node is moved
  - _Previous behavior:_ Operation "succeeds" but uncaught exception occurs while updating node state

## Release Notes

Milestone: 3.2.0

Changelog: 

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):