### PR TITLE
`datasets` -> `dataSets`, fix event not being disposed

### DIFF
--- a/packages/zowe-explorer-api/__mocks__/vscode.ts
+++ b/packages/zowe-explorer-api/__mocks__/vscode.ts
@@ -486,17 +486,9 @@ export namespace window {
         return undefined;
     }
 
-    export function createWebviewPanel(
-        viewType: string,
-        title: string,
-        showOptions: ViewColumn | { preserveFocus: boolean; viewColumn: ViewColumn },
-        options?: WebviewPanelOptions & WebviewOptions
-    ): WebviewPanel {
-        return undefined as any;
-    }
-
     const { window: mockWindow } = require("jest-mock-vscode").createVSCodeMock(jest);
     export const showQuickPick = mockWindow.showQuickPick;
+    export const createWebviewPanel = mockWindow.createWebviewPanel;
 
     /**
      * Options to configure the behavior of the message.
@@ -549,14 +541,7 @@ export namespace commands {
         return undefined;
     }
 }
-export class Disposable {
-    /**
-     * Creates a new Disposable calling the provided function
-     * on dispose.
-     * @param callOnDispose Function that disposes something.
-     */
-    constructor() {}
-}
+export const { Disposable } = require("jest-mock-vscode").createVSCodeMock(jest);
 
 export function RelativePattern(_base: string, _pattern: string): {} {
     return {};

--- a/packages/zowe-explorer-api/__tests__/__unit__/vscode/ui/TableView.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/vscode/ui/TableView.unit.test.ts
@@ -675,8 +675,8 @@ describe("Table.Instance", () => {
                     { a: 3, b: 2, c: 1, d: true, e: 6 },
                 ])
                 .addColumns([{ field: "a" }, { field: "b" }, { field: "c" }, { field: "d" }, { field: "e" }]);
+            const disposeMock = jest.spyOn((WebView as any).prototype, "dispose").mockImplementationOnce(jest.fn());
             const instance = builder.build();
-            const disposeMock = jest.spyOn((WebView as any).prototype, "dispose");
             instance.dispose();
             expect(disposeMock).toHaveBeenCalled();
         });

--- a/packages/zowe-explorer-api/__tests__/__unit__/vscode/ui/WebView.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/vscode/ui/WebView.unit.test.ts
@@ -44,13 +44,18 @@ describe("WebView unit tests", () => {
         const createWebviewPanelSpy = jest.spyOn(vscode.window, "createWebviewPanel");
         const renderSpy = jest.spyOn(Mustache, "render");
 
+        const disposeMock = jest.fn();
+        const disposable = new vscode.Disposable(disposeMock);
+
         const testView = new WebView("Test Webview Title", "example-folder", { extensionPath: "test/path" } as vscode.ExtensionContext, {
             onDidReceiveMessage: async (_message: any) => {},
         });
+        (testView as any).disposables = [disposable];
         expect(createWebviewPanelSpy).toHaveBeenCalled();
         expect(renderSpy).toHaveBeenCalled();
         (testView as any).dispose();
         expect(testView.panel).toBeUndefined();
+        expect(disposeMock).toHaveBeenCalledTimes(1);
     });
 
     it("returns HTML content from WebView", () => {

--- a/packages/zowe-explorer-api/src/vscode/ui/WebView.ts
+++ b/packages/zowe-explorer-api/src/vscode/ui/WebView.ts
@@ -111,8 +111,9 @@ export class WebView {
                 title: this.title,
             });
             this.webviewContent = builtHtml;
-            if (opts?.onDidReceiveMessage) {
-                this.panel.webview.onDidReceiveMessage(async (message) => opts.onDidReceiveMessage(message));
+            if (opts?.onDidReceiveMessage && !this.eventsRegistered) {
+                this.disposables.push(this.panel.webview.onDidReceiveMessage(async (message) => opts.onDidReceiveMessage(message)));
+                this.eventsRegistered = true;
             }
             this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
             this.panel.webview.html = this.webviewContent;
@@ -143,7 +144,7 @@ export class WebView {
         });
         this.webviewContent = builtHtml;
         if (this.webviewOpts?.onDidReceiveMessage && !this.eventsRegistered) {
-            webviewView.webview.onDidReceiveMessage(async (message) => this.webviewOpts.onDidReceiveMessage(message));
+            this.disposables.push(webviewView.webview.onDidReceiveMessage(async (message) => this.webviewOpts.onDidReceiveMessage(message)));
             this.eventsRegistered = true;
         }
         webviewView.onDidDispose(() => this.dispose(), null, this.disposables);

--- a/packages/zowe-explorer/l10n/poeditor.json
+++ b/packages/zowe-explorer/l10n/poeditor.json
@@ -215,7 +215,7 @@
   "configuration.title": {
     "Zowe Explorer": ""
   },
-  "zowe.ds.paginate.datasetsPerPage": {
+  "zowe.ds.paginate.dataSetsPerPage": {
     "Maximum number of data sets and PDS members to list per page": ""
   },
   "zowe.ds.default.binary": {

--- a/packages/zowe-explorer/l10n/poeditor.json
+++ b/packages/zowe-explorer/l10n/poeditor.json
@@ -216,7 +216,7 @@
     "Zowe Explorer": ""
   },
   "zowe.ds.paginate.dataSetsPerPage": {
-    "Maximum number of data sets and PDS members to list per page": ""
+    "Maximum number of data sets and PDS members to list per page. 0 disables pagination.": ""
   },
   "zowe.ds.default.binary": {
     "Default values of Binary data set creation": ""
@@ -520,6 +520,9 @@
   },
   "zowe.settings.overrideWithEnvironmentVariables": {
     "Indicates if environment variables should override values stored in Zowe configuration profiles on disk.": ""
+  },
+  "zowe.settings.socketConnectTimeout": {
+    "The amount of time to wait for a connection to be initiated with the server, in milliseconds.": ""
   },
   "Enter command here...": "",
   "Page Size:": "",

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -1658,10 +1658,10 @@
       "type": "object",
       "title": "%configuration.title%",
       "properties": {
-        "zowe.ds.paginate.datasetsPerPage": {
+        "zowe.ds.paginate.dataSetsPerPage": {
           "default": 100,
           "type": "integer",
-          "description": "%zowe.ds.paginate.datasetsPerPage%",
+          "description": "%zowe.ds.paginate.dataSetsPerPage%",
           "scope": "window"
         },
         "zowe.ds.default.binary": {

--- a/packages/zowe-explorer/package.nls.json
+++ b/packages/zowe-explorer/package.nls.json
@@ -71,7 +71,7 @@
   "cancelJobs": "Cancel Job",
   "getJobJcl": "Get JCL",
   "configuration.title": "Zowe Explorer",
-  "zowe.ds.paginate.datasetsPerPage": "Maximum number of data sets and PDS members to list per page. 0 disables pagination.",
+  "zowe.ds.paginate.dataSetsPerPage": "Maximum number of data sets and PDS members to list per page. 0 disables pagination.",
   "zowe.ds.default.binary": "Default values of Binary data set creation",
   "zowe.ds.default.c": "Default values of C data set creation",
   "zowe.ds.default.classic": "Default values of Classic data set creation",

--- a/packages/zowe-explorer/src/configuration/Constants.ts
+++ b/packages/zowe-explorer/src/configuration/Constants.ts
@@ -79,7 +79,7 @@ export class Constants {
     public static readonly SETTINGS_AUTOMATIC_PROFILE_VALIDATION = "zowe.automaticProfileValidation";
     public static readonly SETTINGS_SECURE_CREDENTIALS_ENABLED = "zowe.security.secureCredentialsEnabled";
     public static readonly SETTINGS_CHECK_FOR_CUSTOM_CREDENTIAL_MANAGERS = "zowe.security.checkForCustomCredentialManagers";
-    public static readonly SETTINGS_DATASETS_PER_PAGE = "zowe.ds.paginate.datasetsPerPage";
+    public static readonly SETTINGS_DATASETS_PER_PAGE = "zowe.ds.paginate.dataSetsPerPage";
     public static readonly LOGGER_SETTINGS = "zowe.logger";
     public static readonly SETTINGS_OVERRIDE_WITH_ENV_VAR = "zowe.settings.overrideWithEnvironmentVariables";
     public static EXTENDER_CONFIG: imperative.ICommandProfileTypeConfiguration[] = [];


### PR DESCRIPTION
## Proposed changes

- Renames `zowe.ds.paginate.datasetsPerPage` to `zowe.ds.paginate.dataSetsPerPage` so the right text is shown in the VS Code settings UI: "Data Sets Per Page"
- Follow-up to a recent change I made in an attempt to resolve #3619. Turns out I was missing one step where the disposables for the event listeners need added to the array of disposables, as `dispose` gets called when the view is re-initialized (e.g., table contents change).

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.2.0

Changelog: No changelog as we already have entries for pagination (not yet released) & the WebView change

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):