### PR TITLE
fix: use global event bus to route `onProfileUpdated` event listeners across static contexts

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 - Updated dependencies for technical currency purposes. [#3576](https://github.com/zowe/zowe-explorer-vscode/pull/3576)
 - Fixed issue where webviews may register their `onDidReceiveMessage` event multiple times in the `resolveForView` function. [#3584](https://github.com/zowe/zowe-explorer-vscode/pull/3584)
 - Fixed an issue where the `BaseProvider._reopenEditorForRelocatedUri` function threw an exception when an open tab did not have a URI on its `input` property. [#3613](https://github.com/zowe/zowe-explorer-vscode/issues/3613)
-- Fixed an issue where subscribers to the `ZoweVsCodeExtension.onProfileUpdated` event did not always get notified when Zowe Explorer or an extender fired the event. [#3623](https://github.com/zowe/zowe-explorer-vscode/pull/3623)
+- Fixed an issue where subscribers to the `ZoweVsCodeExtension.onProfileUpdated` event did not always get notified when Zowe Explorer or an extender fired the event. [#3622](https://github.com/zowe/zowe-explorer-vscode/issues/3622)
 
 ## `3.1.2`
 

--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 - Updated dependencies for technical currency purposes. [#3576](https://github.com/zowe/zowe-explorer-vscode/pull/3576)
 - Fixed issue where webviews may register their `onDidReceiveMessage` event multiple times in the `resolveForView` function. [#3584](https://github.com/zowe/zowe-explorer-vscode/pull/3584)
 - Fixed an issue where the `BaseProvider._reopenEditorForRelocatedUri` function threw an exception when an open tab did not have a URI on its `input` property. [#3613](https://github.com/zowe/zowe-explorer-vscode/issues/3613)
+- Fixed an issue where subscribers to the `ZoweVsCodeExtension.onProfileUpdated` event did not always get notified when Zowe Explorer or an extender fired the event. [#3623](https://github.com/zowe/zowe-explorer-vscode/pull/3623)
 
 ## `3.1.2`
 

--- a/packages/zowe-explorer-api/__mocks__/vscode.ts
+++ b/packages/zowe-explorer-api/__mocks__/vscode.ts
@@ -549,14 +549,6 @@ export namespace commands {
         return undefined;
     }
 }
-export class Disposable {
-    /**
-     * Creates a new Disposable calling the provided function
-     * on dispose.
-     * @param callOnDispose Function that disposes something.
-     */
-    constructor() {}
-}
 
 export function RelativePattern(_base: string, _pattern: string): {} {
     return {};
@@ -893,33 +885,7 @@ export enum TreeItemCollapsibleState {
     Expanded = 2,
 }
 
-/**
- * An event emitter can be used to create and manage an [event](#Event) for others
- * to subscribe to. One emitter always owns one event.
- *
- * Use this class if you want to provide event from within your extension, for instance
- * inside a [TextDocumentContentProvider](#TextDocumentContentProvider) or when providing
- * API to other extensions.
- */
-export class EventEmitter<T> {
-    /**
-     * The event listeners can subscribe to.
-     */
-    event: Event<T>;
-
-    /**
-     * Notify all subscribers of the [event](EventEmitter#event). Failure
-     * of one or more listener will not fail this function call.
-     *
-     * @param data The event object.
-     */
-    fire(_data?: T): void {}
-
-    /**
-     * Dispose this object and free resources.
-     */
-    //dispose(): void;
-}
+export const { Disposable, EventEmitter } = require("jest-mock-vscode").createVSCodeMock(jest);
 
 export enum FilePermission {
     /**

--- a/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
@@ -27,6 +27,21 @@ describe("ZoweVsCodeExtension", () => {
         jest.clearAllMocks();
     });
 
+    describe("onProfileUpdatedEmitter", () => {
+        it("returns a valid event instance after successful import", () => {
+            expect(ZoweVsCodeExtension.onProfileUpdatedEmitter).toBeInstanceOf(vscode.EventEmitter);
+        });
+    });
+
+    describe("onProfileUpdated", () => {
+        it("returns a valid event instance", () => {
+            // event is valid and can be subscribed to
+            expect(ZoweVsCodeExtension.onProfileUpdated).not.toBeUndefined();
+            // event returns a disposable to remove the listener from the list of event subscribers
+            expect(ZoweVsCodeExtension.onProfileUpdated(jest.fn())["dispose"]).toBeInstanceOf(Function);
+        });
+    });
+
     it("customLoggingPath should return value if defined in VS Code settings", () => {
         const mockGetConfig = jest.fn().mockReturnValueOnce(__dirname);
         const vscodeMock = {

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -22,6 +22,11 @@ import type { BaseProfileAuthOptions } from "./doc/BaseProfileAuth";
 import { FileManagement } from "../utils";
 import { VscSettings } from "./doc/VscSettings";
 
+const globalEmitterKey = "__zowe_profile_updated_emitter__";
+if (!(globalThis as any)[globalEmitterKey]) {
+    (globalThis as any)[globalEmitterKey] = new vscode.EventEmitter<imperative.IProfileLoaded>();
+}
+
 /**
  * Collection of utility functions for writing Zowe Explorer VS Code extensions.
  */
@@ -30,8 +35,13 @@ export class ZoweVsCodeExtension {
         return vscode.workspace.workspaceFolders?.find((f) => f.uri.scheme === "file");
     }
 
-    public static onProfileUpdatedEmitter: vscode.EventEmitter<imperative.IProfileLoaded> = new vscode.EventEmitter();
-    public static readonly onProfileUpdated = ZoweVsCodeExtension.onProfileUpdatedEmitter.event;
+    public static get onProfileUpdatedEmitter(): vscode.EventEmitter<imperative.IProfileLoaded> {
+        return (globalThis as any)[globalEmitterKey] as vscode.EventEmitter<imperative.IProfileLoaded>;
+    }
+
+    public static get onProfileUpdated(): vscode.Event<imperative.IProfileLoaded> {
+        return ZoweVsCodeExtension.onProfileUpdatedEmitter.event;
+    }
 
     /**
      * @internal

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -30,8 +30,7 @@ import { ZoweDatasetNode } from "../../src/trees/dataset/ZoweDatasetNode";
 import { USSTree } from "../../src/trees/uss/USSTree";
 import { ProfilesUtils } from "../../src/utils/ProfilesUtils";
 import { JobTree } from "../../src/trees/job/JobTree";
-import { JobFSProvider } from "../../src/trees/job/JobFSProvider";
-import { PaginationCodeLens } from "../../../zowe-explorer-api/src";
+import { MockedProperty } from "../__mocks__/mockUtils";
 
 jest.mock("../../src/utils/LoggerUtils");
 jest.mock("../../src/tools/ZoweLogger");
@@ -139,6 +138,12 @@ async function createGlobalMocks() {
             fetchAllProfilesByType: jest.fn().mockResolvedValue([]),
             getProfileInfo: () => createInstanceOfProfileInfo(),
         },
+        mockOnProfileUpdated: new MockedProperty(
+            ZoweVsCodeExtension,
+            "onProfileUpdated",
+            undefined,
+            jest.fn().mockReturnValue(new vscode.Disposable(jest.fn()))
+        ),
         mockExtension: null,
         appName: vscode.env.appName,
         uriScheme: vscode.env.uriScheme,
@@ -257,8 +262,6 @@ async function createGlobalMocks() {
             "zowe.placeholderCommand",
         ],
     };
-
-    jest.replaceProperty(ZoweVsCodeExtension, "onProfileUpdated", jest.fn());
     Object.defineProperty(fs, "mkdirSync", { value: globalMocks.mockMkdirSync, configurable: true });
     Object.defineProperty(vscode.window, "createTreeView", {
         value: globalMocks.mockCreateTreeView,
@@ -433,6 +436,10 @@ async function createGlobalMocks() {
 describe("Extension Unit Tests", () => {
     const allCommands: Array<{ cmd: string; fun: () => void; toMock: () => void }> = [];
     let globalMocks;
+
+    afterAll(() => {
+        globalMocks.mockOnProfileUpdated[Symbol.dispose]();
+    });
     beforeAll(async () => {
         globalMocks = await createGlobalMocks();
         jest.spyOn(fs, "readFileSync").mockReturnValue(Buffer.from(JSON.stringify({ overrides: { credentialManager: "@zowe/cli" } }), "utf-8"));

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
@@ -52,7 +52,7 @@ describe("Test src/shared/extension", () => {
         };
         const profileMocks = { deleteProfile: jest.fn(), disableValidation: jest.fn(), enableValidation: jest.fn(), refresh: jest.fn() };
         const cmdProviders = { mvs: { issueMvsCommand: jest.fn() }, tso: { issueTsoCommand: jest.fn() }, uss: { issueUnixCommand: jest.fn() } };
-        const onProfileUpdated = jest.fn();
+        const onProfileUpdated = jest.fn().mockReturnValue(new vscode.Disposable(jest.fn()));
         const treeProvider = {
             addFavorite: jest.fn(),
             deleteSession: jest.fn(),
@@ -66,7 +66,8 @@ describe("Test src/shared/extension", () => {
             ssoLogin: jest.fn(),
             ssoLogout: jest.fn(),
         };
-        jest.replaceProperty(ZoweVsCodeExtension, "onProfileUpdated", onProfileUpdated);
+
+        const mockOnProfileUpdated = new MockedProperty(ZoweVsCodeExtension, "onProfileUpdated", undefined, onProfileUpdated);
 
         const commands: IJestIt[] = [
             {
@@ -319,6 +320,7 @@ describe("Test src/shared/extension", () => {
             SharedInit.registerCommonCommands(test.context, test.value.providers);
         });
         afterAll(() => {
+            mockOnProfileUpdated[Symbol.dispose]();
             jest.restoreAllMocks();
         });
 


### PR DESCRIPTION
## Proposed changes

Fixes #3622 

This change leverages the `globalThis` module to provide a non-breaking way for extenders to use the `ZoweVsCodeExtension.onProfileUpdated` event while making sure that its fired for all extenders that import `ZoweVsCodeExtension`.

Using the `globalThis` module to store the event provides a few benefits:
- [x] Avoids moving the event as its already exposed in ZE API under a 3.x release (breaking change). Instead, its exposed as a getter, which provides the same functionality as when it was a `vscode.Event` property.
- [x] We want to support the same event access that's already exposed, e.g. `ZoweVsCodeExtension.onProfileUpdated(() => { ... })` should work with the ZE API version from this branch without the extender making any changes to their code
- [x] If an extender happens to import this API before Zowe Explorer initializes (possible if the extender does not directly depend on ZE): Zowe Explorer reuses that event rather than re-introducing this separation between class objects.

Since `globalThis` is guaranteed to be the same across all static contexts in Node.js, it can be used to store "truly-global" properties until we can relocate the event (or refactor the class altogether) in v4.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.1.3, 3.2.0, or 3.2.1? (parking lot 😋)

Changelog: 
- **ZE API:** Fixed an issue where subscribers to the `ZoweVsCodeExtension.onProfileUpdated` event did not always get notified when Zowe Explorer or an extender fired the event.

No changelog for ZE, just test updates to reflect the mocks we had on the `onProfileUpdated` property.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
