### PR TITLE
refactor: Move `onProfileUpdated` to API register, preserve access through getters

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 - Updated dependencies for technical currency purposes. [#3576](https://github.com/zowe/zowe-explorer-vscode/pull/3576)
 - Fixed issue where webviews may register their `onDidReceiveMessage` event multiple times in the `resolveForView` function. [#3584](https://github.com/zowe/zowe-explorer-vscode/pull/3584)
 - Fixed an issue where the `BaseProvider._reopenEditorForRelocatedUri` function threw an exception when an open tab did not have a URI on its `input` property. [#3613](https://github.com/zowe/zowe-explorer-vscode/issues/3613)
+- Fixed an issue where the `onProfileUpdated` event emitter was not guaranteed to be the same across Zowe Explorer and extenders, causing some event listeners to not fire when an extender fires the event emitter. Now, the event is exposed through the API register, so that all operations on this event from the `ZoweVsCodeExtension` class are properly routed to the correct emitter. [#3622](https://github.com/zowe/zowe-explorer-vscode/issues/3622)
 
 ## `3.1.2`
 

--- a/packages/zowe-explorer-api/__mocks__/vscode.ts
+++ b/packages/zowe-explorer-api/__mocks__/vscode.ts
@@ -549,13 +549,20 @@ export namespace commands {
         return undefined;
     }
 }
+
 export class Disposable {
     /**
      * Creates a new Disposable calling the provided function
      * on dispose.
      * @param callOnDispose Function that disposes something.
      */
-    constructor() {}
+    constructor(private callOnDispose?: Function) {}
+    /**
+     * Dispose this object.
+     */
+    public dispose(): any {
+        this.callOnDispose?.();
+    }
 }
 
 export function RelativePattern(_base: string, _pattern: string): {} {
@@ -902,10 +909,19 @@ export enum TreeItemCollapsibleState {
  * API to other extensions.
  */
 export class EventEmitter<T> {
+    private subscribers: Function[] = [];
     /**
      * The event listeners can subscribe to.
      */
-    event: Event<T>;
+    event: Event<T> = jest.fn().mockImplementation((listener) => {
+        this.subscribers.push(listener);
+        return new Disposable(() => {
+            const idx = this.subscribers.findIndex((v) => v === listener);
+            if (idx != -1) {
+                this.subscribers.splice(idx, 1);
+            }
+        });
+    });
 
     /**
      * Notify all subscribers of the [event](EventEmitter#event). Failure

--- a/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
@@ -678,9 +678,14 @@ describe("ZoweVsCodeExtension", () => {
         const promptCredsOptions: PromptCredentialsOptions.ComplexOptions = {
             sessionName: "test",
         };
+        const onProfileUpdatedEmitter = new vscode.EventEmitter<imperative.IProfileLoaded>();
 
         it("should update user and password as secure fields", async () => {
             const mockUpdateProperty = jest.fn();
+            jest.spyOn(ZoweVsCodeExtension, "getZoweExplorerApi").mockReturnValueOnce({
+                onProfileUpdated: onProfileUpdatedEmitter.event,
+                onProfileUpdatedEmitter,
+            } as any);
             jest.spyOn(ZoweVsCodeExtension as any, "profilesCache", "get").mockReturnValue({
                 getLoadedProfConfig: jest.fn().mockReturnValue({
                     profile: {},
@@ -707,6 +712,10 @@ describe("ZoweVsCodeExtension", () => {
 
         it("should update user and password as secure fields with rePrompt", async () => {
             const mockUpdateProperty = jest.fn();
+            jest.spyOn(ZoweVsCodeExtension, "getZoweExplorerApi").mockReturnValueOnce({
+                onProfileUpdated: onProfileUpdatedEmitter.event,
+                onProfileUpdatedEmitter,
+            } as any);
             jest.spyOn(ZoweVsCodeExtension as any, "profilesCache", "get").mockReturnValue({
                 getLoadedProfConfig: jest.fn().mockReturnValue({
                     profile: { user: "badUser", password: "badPassword" },
@@ -736,6 +745,10 @@ describe("ZoweVsCodeExtension", () => {
 
         it("should update user and password as plain text if prompt accepted", async () => {
             const mockUpdateProperty = jest.fn();
+            jest.spyOn(ZoweVsCodeExtension, "getZoweExplorerApi").mockReturnValueOnce({
+                onProfileUpdated: onProfileUpdatedEmitter.event,
+                onProfileUpdatedEmitter,
+            } as any);
             jest.spyOn(ZoweVsCodeExtension as any, "profilesCache", "get").mockReturnValue({
                 getLoadedProfConfig: jest.fn().mockReturnValue({
                     profile: {},
@@ -763,6 +776,10 @@ describe("ZoweVsCodeExtension", () => {
 
         it("should not update user and password as plain text if prompt cancelled", async () => {
             const mockUpdateProperty = jest.fn();
+            jest.spyOn(ZoweVsCodeExtension, "getZoweExplorerApi").mockReturnValueOnce({
+                onProfileUpdated: onProfileUpdatedEmitter.event,
+                onProfileUpdatedEmitter,
+            } as any);
             jest.spyOn(ZoweVsCodeExtension as any, "profilesCache", "get").mockReturnValue({
                 getLoadedProfConfig: jest.fn().mockReturnValue({
                     profile: {},

--- a/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
@@ -674,6 +674,28 @@ describe("ZoweVsCodeExtension", () => {
             await expect(fetchBaseProfileSpy.mock.results[0].value).resolves.toBeUndefined();
         });
     });
+    describe("onProfileUpdated", () => {
+        it("returns event defined on API register", () => {
+            const eventEmitter = new vscode.EventEmitter<imperative.IProfileLoaded>();
+            const apiMock = jest.spyOn(ZoweVsCodeExtension, "getZoweExplorerApi").mockReturnValue({
+                onProfileUpdatedEmitter: eventEmitter,
+                onProfileUpdated: eventEmitter.event,
+            } as any);
+            expect(ZoweVsCodeExtension.onProfileUpdated).toBe(ZoweVsCodeExtension.getZoweExplorerApi().onProfileUpdatedEmitter?.event);
+            apiMock.mockRestore();
+        });
+    });
+    describe("onProfileUpdatedEmitter", () => {
+        it("returns instance of an EventEmitter", () => {
+            const eventEmitter = new vscode.EventEmitter<imperative.IProfileLoaded>();
+            const apiMock = jest.spyOn(ZoweVsCodeExtension, "getZoweExplorerApi").mockReturnValue({
+                onProfileUpdatedEmitter: eventEmitter,
+                onProfileUpdated: eventEmitter.event,
+            } as any);
+            expect(ZoweVsCodeExtension.onProfileUpdatedEmitter).toBeInstanceOf(vscode.EventEmitter);
+            apiMock.mockRestore();
+        });
+    });
     describe("updateCredentials", () => {
         const promptCredsOptions: PromptCredentialsOptions.ComplexOptions = {
             sessionName: "test",

--- a/packages/zowe-explorer-api/src/extend/IRegisterClient.ts
+++ b/packages/zowe-explorer-api/src/extend/IRegisterClient.ts
@@ -111,6 +111,12 @@ export interface IRegisterClient {
     onProfilesUpdate?: vscode.Event<Validation.EventType>;
 
     /**
+     * Fires whenever the given profile is updated.
+     */
+    onProfileUpdated?: vscode.Event<imperative.IProfileLoaded>;
+    onProfileUpdatedEmitter?: vscode.EventEmitter<imperative.IProfileLoaded>;
+
+    /**
      * Define events that fire whenever credentials are updated on the client.
      */
     onVaultUpdate?: vscode.Event<Validation.EventType>;

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -30,8 +30,12 @@ export class ZoweVsCodeExtension {
         return vscode.workspace.workspaceFolders?.find((f) => f.uri.scheme === "file");
     }
 
-    public static onProfileUpdatedEmitter: vscode.EventEmitter<imperative.IProfileLoaded> = new vscode.EventEmitter();
-    public static readonly onProfileUpdated = ZoweVsCodeExtension.onProfileUpdatedEmitter.event;
+    public static get onProfileUpdatedEmitter(): vscode.EventEmitter<imperative.IProfileLoaded> {
+        return this.getZoweExplorerApi().onProfileUpdatedEmitter;
+    }
+    public static get onProfileUpdated(): vscode.Event<imperative.IProfileLoaded> {
+        return ZoweVsCodeExtension.onProfileUpdatedEmitter.event;
+    }
 
     /**
      * @internal

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where profiles that were not utilizing tokens were improperly running `checkJwtForProfile()` function within the `ZoweTreeProvider`. [#3575](https://github.com/zowe/zowe-explorer-vscode/pull/3575)
 - Fixed an issue where searching for the root directory (`/`) under a profile caused the profile to show a placeholder rather than a list of the files and folders at that path. [#3603](https://github.com/zowe/zowe-explorer-vscode/pull/3603)
 - Fixed an issue where dragging and dropping a USS file caused an unhandled error while finalizing the drop operation. [#3613](https://github.com/zowe/zowe-explorer-vscode/issues/3613)
+- Fixed an issue where the `onProfileUpdated` event emitter was not guaranteed to be the same across Zowe Explorer and extenders, causing some event listeners to not fire when an extender fires the event emitter. [#3622](https://github.com/zowe/zowe-explorer-vscode/issues/3622)
 
 ## `3.1.2`
 

--- a/packages/zowe-explorer/__tests__/__mocks__/vscode.ts
+++ b/packages/zowe-explorer/__tests__/__mocks__/vscode.ts
@@ -1087,7 +1087,15 @@ export class EventEmitter<T> {
     /**
      * The event listeners can subscribe to.
      */
-    event: Event<T>;
+    event: Event<T> = jest.fn().mockImplementation((listener) => {
+        this.subscribers.push(listener);
+        return new Disposable(() => {
+            const idx = this.subscribers.findIndex((v) => v === listener);
+            if (idx != -1) {
+                this.subscribers.splice(idx, 1);
+            }
+        });
+    });
 
     /**
      * Notify all subscribers of the [event](EventEmitter#event). Failure
@@ -1107,18 +1115,6 @@ export class EventEmitter<T> {
      * Dispose this object and free resources.
      */
     //dispose(): void;
-
-    public constructor() {
-        this.event = jest.fn().mockImplementation((listener) => {
-            this.subscribers.push(listener);
-            return new Disposable(() => {
-                const idx = this.subscribers.findIndex((v) => v === listener);
-                if (idx != -1) {
-                    this.subscribers.splice(idx, 1);
-                }
-            });
-        });
-    }
 }
 
 export enum FilePermission {

--- a/packages/zowe-explorer/__tests__/__unit__/configuration/Profiles.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/configuration/Profiles.unit.test.ts
@@ -101,6 +101,10 @@ function createGlobalMocks(): { [key: string]: any } {
         FileSystemProvider: {
             createDirectory: jest.fn(),
         },
+        mockZoweExplorerApi: jest.spyOn(ZoweVsCodeExtension, "getZoweExplorerApi").mockReturnValue({
+            onProfileUpdatedEmitter: new vscode.EventEmitter<imperative.IProfileLoaded>(),
+            onProfileUpdatedEmitterEvent: jest.fn().mockReturnValue(new vscode.Disposable(jest.fn())),
+        } as any),
     };
     newMocks.mockCreateSessCfgFromArgs.mockReturnValue(newMocks.testSession);
 

--- a/packages/zowe-explorer/__tests__/__unit__/extending/ZoweExplorerApiRegister.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extending/ZoweExplorerApiRegister.unit.test.ts
@@ -275,14 +275,17 @@ describe("ZoweExplorerApiRegister unit testing", () => {
     });
 
     it("provides access to the appropriate event for onResourceChanged", () => {
+        ZoweExplorerApiRegister.addFileSystemEvent(ZoweScheme.DS, DatasetFSProvider.instance.onDidChangeFile);
         expect(ZoweExplorerApiRegister.onResourceChanged(ZoweScheme.DS)).toBe(DatasetFSProvider.instance.onDidChangeFile);
     });
 
     it("provides access to the onUssChanged event", () => {
+        ZoweExplorerApiRegister.addFileSystemEvent(ZoweScheme.USS, UssFSProvider.instance.onDidChangeFile);
         expect(ZoweExplorerApiRegister.onResourceChanged(ZoweScheme.USS)).toBe(UssFSProvider.instance.onDidChangeFile);
     });
 
     it("provides access to the onJobChanged event", () => {
+        ZoweExplorerApiRegister.addFileSystemEvent(ZoweScheme.Jobs, JobFSProvider.instance.onDidChangeFile);
         expect(ZoweExplorerApiRegister.onResourceChanged(ZoweScheme.Jobs)).toBe(JobFSProvider.instance.onDidChangeFile);
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extension.unit.test.ts
@@ -30,8 +30,8 @@ import { ZoweDatasetNode } from "../../src/trees/dataset/ZoweDatasetNode";
 import { USSTree } from "../../src/trees/uss/USSTree";
 import { ProfilesUtils } from "../../src/utils/ProfilesUtils";
 import { JobTree } from "../../src/trees/job/JobTree";
-import { JobFSProvider } from "../../src/trees/job/JobFSProvider";
-import { PaginationCodeLens } from "../../../zowe-explorer-api/src";
+import { MockedProperty } from "../__mocks__/mockUtils";
+import { ZoweExplorerApiRegister } from "../../src/extending/ZoweExplorerApiRegister";
 
 jest.mock("../../src/utils/LoggerUtils");
 jest.mock("../../src/tools/ZoweLogger");
@@ -139,6 +139,12 @@ async function createGlobalMocks() {
             fetchAllProfilesByType: jest.fn().mockResolvedValue([]),
             getProfileInfo: () => createInstanceOfProfileInfo(),
         },
+        mockOnProfileUpdated: new MockedProperty(
+            ZoweExplorerApiRegister,
+            "onProfileUpdated",
+            undefined,
+            jest.fn().mockReturnValue(new vscode.Disposable(jest.fn()))
+        ),
         mockExtension: null,
         appName: vscode.env.appName,
         uriScheme: vscode.env.uriScheme,
@@ -258,7 +264,7 @@ async function createGlobalMocks() {
         ],
     };
 
-    jest.replaceProperty(ZoweVsCodeExtension, "onProfileUpdated", jest.fn());
+    jest.spyOn(ZoweVsCodeExtension as any, "onProfileUpdated", "get").mockReturnValue(jest.fn().mockReturnValue(new vscode.Disposable(jest.fn())));
     Object.defineProperty(fs, "mkdirSync", { value: globalMocks.mockMkdirSync, configurable: true });
     Object.defineProperty(vscode.window, "createTreeView", {
         value: globalMocks.mockCreateTreeView,
@@ -469,6 +475,10 @@ describe("Extension Unit Tests", () => {
             expect(call[1]).toBeInstanceOf(Function);
             allCommands.push({ cmd: call[0], fun: call[1], toMock: jest.fn() });
         });
+    });
+
+    afterAll(() => {
+        globalMocks.mockOnProfileUpdated[Symbol.dispose]();
     });
 
     it("Testing that activate correctly executes", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
@@ -663,7 +663,7 @@ describe("writeFile", () => {
 
 describe("watch", () => {
     it("returns an empty Disposable object", () => {
-        expect(DatasetFSProvider.instance.watch(testUris.pds, { recursive: false, excludes: [] })).toStrictEqual(new Disposable(() => {}));
+        expect(DatasetFSProvider.instance.watch(testUris.pds, { recursive: false, excludes: [] })).toBeInstanceOf(Disposable);
     });
 });
 describe("stat", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/JobFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/JobFSProvider.unit.test.ts
@@ -59,7 +59,7 @@ const testEntries = {
 
 describe("watch", () => {
     it("returns an empty Disposable object", () => {
-        expect(JobFSProvider.instance.watch(testUris.job, { recursive: false, excludes: [] })).toStrictEqual(new Disposable(() => {}));
+        expect(JobFSProvider.instance.watch(testUris.job, { recursive: false, excludes: [] })).toBeInstanceOf(Disposable);
     });
 });
 describe("stat", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
@@ -65,9 +65,8 @@ describe("Test src/shared/extension", () => {
             ssoLogin: jest.fn(),
             ssoLogout: jest.fn(),
         };
-        const onProfileUpdated = jest
-            .spyOn(ZoweExplorerApiRegister.getInstance(), "onProfileUpdated")
-            .mockReturnValue(new vscode.Disposable(jest.fn()));
+        const onProfileUpdated = jest.fn().mockReturnValue(new vscode.Disposable(jest.fn()));
+        const mockOnProfileUpdated = new MockedProperty(ZoweExplorerApiRegister.getInstance(), "onProfileUpdated", undefined, onProfileUpdated);
 
         const commands: IJestIt[] = [
             {
@@ -320,6 +319,7 @@ describe("Test src/shared/extension", () => {
             SharedInit.registerCommonCommands(test.context, test.value.providers);
         });
         afterAll(() => {
+            mockOnProfileUpdated[Symbol.dispose]();
             jest.restoreAllMocks();
         });
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
@@ -325,6 +325,7 @@ describe("Test src/shared/extension", () => {
 
         processSubscriptions(commands, test);
         it("registers an onProfileUpdated event", () => {
+            expect(mockOnProfileUpdated.mock).toHaveBeenCalledTimes(1);
             expect(onProfileUpdated).toHaveBeenCalledTimes(1);
         });
     });

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedInit.unit.test.ts
@@ -52,7 +52,6 @@ describe("Test src/shared/extension", () => {
         };
         const profileMocks = { deleteProfile: jest.fn(), disableValidation: jest.fn(), enableValidation: jest.fn(), refresh: jest.fn() };
         const cmdProviders = { mvs: { issueMvsCommand: jest.fn() }, tso: { issueTsoCommand: jest.fn() }, uss: { issueUnixCommand: jest.fn() } };
-        const onProfileUpdated = jest.fn();
         const treeProvider = {
             addFavorite: jest.fn(),
             deleteSession: jest.fn(),
@@ -66,7 +65,9 @@ describe("Test src/shared/extension", () => {
             ssoLogin: jest.fn(),
             ssoLogout: jest.fn(),
         };
-        jest.replaceProperty(ZoweVsCodeExtension, "onProfileUpdated", onProfileUpdated);
+        const onProfileUpdated = jest
+            .spyOn(ZoweExplorerApiRegister.getInstance(), "onProfileUpdated")
+            .mockReturnValue(new vscode.Disposable(jest.fn()));
 
         const commands: IJestIt[] = [
             {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
@@ -1400,3 +1400,41 @@ describe("Shared utils unit tests - function debounceAsync", () => {
         expect(mockEventHandler).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("SharedUtils.handleProfileChange", () => {
+    it("iterates over tree providers and updates profile on profile nodes", async () => {
+        const profile = createIProfile();
+        const newProfile = { ...profile, profile: { ...profile, user: "newuser", password: "newpass" } };
+        const dsSession = new ZoweDatasetNode({
+            label: "sestest",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            contextOverride: Constants.DS_SESSION_CONTEXT,
+            profile,
+        });
+        const ussSession = new ZoweUSSNode({
+            label: "sestest",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            contextOverride: Constants.USS_SESSION_CONTEXT,
+            profile,
+        });
+        const jobSession = new ZoweJobNode({
+            label: "sestest",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            contextOverride: Constants.JOBS_SESSION_CONTEXT,
+            profile,
+        });
+        const providers = {
+            ds: { getChildren: () => [dsSession] } as any,
+            uss: { getChildren: () => [ussSession] } as any,
+            job: { getChildren: () => [jobSession] } as any,
+        };
+        await SharedUtils.handleProfileChange(providers, newProfile);
+        // verify that nodes were updated with new data
+        expect(dsSession.getProfile().profile?.user).toBe(newProfile.profile.user);
+        expect(dsSession.getProfile().profile?.password).toBe(newProfile.profile.password);
+        expect(ussSession.getProfile().profile?.user).toBe(newProfile.profile.user);
+        expect(ussSession.getProfile().profile?.password).toBe(newProfile.profile.password);
+        expect(jobSession.getProfile().profile?.user).toBe(newProfile.profile.user);
+        expect(jobSession.getProfile().profile?.password).toBe(newProfile.profile.password);
+    });
+});

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
@@ -324,7 +324,11 @@ describe("USSTree Unit Tests - Function initializeFavChildNodeForProfile", () =>
             expectedFavSearchNode.iconPath = targetIcon.path;
         }
         const favSearchNode = await testTree1.initializeFavChildNodeForProfile(label, "ussSession", favProfileNode);
-        expect(favSearchNode).toEqual(expectedFavSearchNode);
+        expect(favSearchNode.label).toEqual(expectedFavSearchNode.label);
+        expect(favSearchNode.collapsibleState).toEqual(expectedFavSearchNode.collapsibleState);
+        expect(favSearchNode.contextValue).toEqual(expectedFavSearchNode.contextValue);
+        expect(favSearchNode.getParent()).toBe(expectedFavSearchNode.getParent());
+        expect(favSearchNode.getProfile()).toBe(expectedFavSearchNode.getProfile());
     });
 });
 
@@ -346,7 +350,11 @@ describe("USSTree Unit Tests - Function createProfileNodeForFavs", () => {
         expectedFavProfileNode.contextValue = Constants.FAV_PROFILE_CONTEXT;
 
         const createdFavProfileNode = await globalMocks.testTree.createProfileNodeForFavs("testProfile");
-        expect(createdFavProfileNode).toEqual(expectedFavProfileNode);
+        expect(createdFavProfileNode.label).toEqual(expectedFavProfileNode.label);
+        expect(createdFavProfileNode.collapsibleState).toEqual(expectedFavProfileNode.collapsibleState);
+        expect(createdFavProfileNode.contextValue).toEqual(expectedFavProfileNode.contextValue);
+        expect(createdFavProfileNode.getParent()).toEqual(expectedFavProfileNode.getParent());
+        expect(createdFavProfileNode.getProfile()).toEqual(expectedFavProfileNode.getProfile());
     });
 
     it("Tests that profile grouping node is created correctly - global profile", async () => {
@@ -363,7 +371,11 @@ describe("USSTree Unit Tests - Function createProfileNodeForFavs", () => {
         expectedFavProfileNode.iconPath = icon.path;
 
         const createdFavProfileNode = await globalMocks.testTree.createProfileNodeForFavs("testProfile");
-        expect(createdFavProfileNode).toEqual(expectedFavProfileNode);
+        expect(createdFavProfileNode.label).toEqual(expectedFavProfileNode.label);
+        expect(createdFavProfileNode.collapsibleState).toEqual(expectedFavProfileNode.collapsibleState);
+        expect(createdFavProfileNode.contextValue).toEqual(expectedFavProfileNode.contextValue);
+        expect(createdFavProfileNode.getParent()).toEqual(expectedFavProfileNode.getParent());
+        expect(createdFavProfileNode.getProfile()).toEqual(expectedFavProfileNode.getProfile());
         expect(isGlobalProfNodeMock).toHaveBeenCalled();
         isGlobalProfNodeMock.mockRestore();
     });
@@ -1432,7 +1444,7 @@ describe("USSTree Unit Tests - Function getChildren", () => {
 
         const rootChildren = await globalMocks.testTree.getChildren();
         // Creating rootNode
-        const sessNode = [
+        const sessNodes = [
             new ZoweUSSNode({
                 label: "Favorites",
                 collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
@@ -1447,10 +1459,13 @@ describe("USSTree Unit Tests - Function getChildren", () => {
             }),
         ];
 
-        sessNode[1].fullPath = "/test";
-
-        expect(sessNode).toEqual(rootChildren);
-        expect(sessNode[0].iconPath).toEqual(Icon.folder.path);
+        // first node should be the favorites node
+        // second node should be the session
+        for (const child of rootChildren) {
+            const expectedChild = sessNodes.find((sesNode) => child.label === sesNode.label);
+            expect(child.label).toBe(expectedChild?.label);
+            expect(child.contextValue).toBe(expectedChild?.contextValue);
+        }
     });
 
     it("Testing that getChildren() returns correct ZoweUSSNodes when passed element of type ZoweUSSNode<session>", async () => {
@@ -1490,15 +1505,15 @@ describe("USSTree Unit Tests - Function getChildren", () => {
             })
         );
         const favChildren = await globalMocks.testTree.getChildren(globalMocks.testTree.mSessionNodes[0]);
-        const sampleChildren: ZoweUSSNode[] = [
-            new ZoweUSSNode({
-                label: "/u/myUser",
-                collapsibleState: vscode.TreeItemCollapsibleState.None,
-                parentNode: globalMocks.testTree.mSessionNodes[0],
-            }),
-        ];
+        const expectedChild = new ZoweUSSNode({
+            label: "/u/myUser",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            parentNode: globalMocks.testTree.mSessionNodes[0],
+        });
 
-        expect(favChildren).toEqual(sampleChildren);
+        expect(favChildren[0].label).toEqual(expectedChild.label);
+        expect(favChildren[0].collapsibleState).toEqual(expectedChild.collapsibleState);
+        expect(favChildren[0].getParent()).toEqual(expectedChild.getParent());
     });
 
     it("Testing that getChildren() returns correct ZoweUSSNodes when passed element of type ZoweUSSNode<directory>", async () => {
@@ -1640,7 +1655,10 @@ describe("USSTree Unit Tests - Function loadProfilesForFavorites", () => {
         await globalMocks.testTree.loadProfilesForFavorites(blockMocks.log, favProfileNode);
         const resultFavDirNode = globalMocks.testTree.mFavorites[0].children[0];
 
-        expect(resultFavDirNode).toEqual(expectedFavDirNode);
+        expect(resultFavDirNode.label).toBe(expectedFavDirNode.label);
+        expect(resultFavDirNode.collapsibleState).toBe(expectedFavDirNode.collapsibleState);
+        expect(resultFavDirNode.getParent()).toBe(expectedFavDirNode.getParent());
+        expect(resultFavDirNode.getProfile()).toBe(expectedFavDirNode.getProfile());
     });
     it("Tests that loaded profile/session from profile node in Favorites gets passed to child favorites without profile/session", async () => {
         const globalMocks = createGlobalMocks();
@@ -1670,7 +1688,10 @@ describe("USSTree Unit Tests - Function loadProfilesForFavorites", () => {
         await globalMocks.testTree.loadProfilesForFavorites(blockMocks.log, favProfileNode);
         const resultFavDirNode = globalMocks.testTree.mFavorites[0].children[0];
 
-        expect(resultFavDirNode).toEqual(expectedFavDirNode);
+        expect(resultFavDirNode.label).toEqual(expectedFavDirNode.label);
+        expect(resultFavDirNode.collapsibleState).toEqual(expectedFavDirNode.collapsibleState);
+        expect(resultFavDirNode.contextValue).toEqual(expectedFavDirNode.contextValue);
+        expect(resultFavDirNode.getProfile()).toEqual(expectedFavDirNode.getProfile());
     });
 });
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
@@ -1497,7 +1497,7 @@ describe("createDirectory", () => {
 
 describe("watch", () => {
     it("returns a new, empty Disposable object", () => {
-        expect(UssFSProvider.instance.watch(testUris.file)).toStrictEqual(new Disposable(() => {}));
+        expect(UssFSProvider.instance.watch(testUris.file)).toBeInstanceOf(Disposable);
     });
 });
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/ZoweUSSNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/ZoweUSSNode.unit.test.ts
@@ -929,7 +929,15 @@ describe("ZoweUSSNode Unit Tests - Function node.getChildren()", () => {
             contextOverride: Constants.INFORMATION_CONTEXT,
         });
 
-        expect(await blockMocks.rootNode.getChildren()).toEqual([expectedNode]);
+        const children = await blockMocks.rootNode.getChildren();
+        // just the information node (search to list USS files)
+        expect(children.length).toBe(1);
+        const infoNode = children[0];
+        expect(infoNode.label).toBe(expectedNode.label);
+        expect(infoNode.collapsibleState).toBe(expectedNode.collapsibleState);
+        expect(infoNode.getParent()).toBe(expectedNode.getParent());
+        expect(infoNode.contextValue).toBe(expectedNode.contextValue);
+        expect(infoNode.command).toStrictEqual(expectedNode.command);
     });
 });
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/__snapshots__/ZoweUSSNode.unit.test.ts.snap
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/__snapshots__/ZoweUSSNode.unit.test.ts.snap
@@ -46,7 +46,10 @@ ZoweUSSNode {
       "id": "uss.sestest",
       "label": "sestest",
       "mParent": undefined,
-      "onUpdateEmitter": EventEmitter {},
+      "onUpdateEmitter": EventEmitter {
+        "event": [MockFunction],
+        "subscribers": [],
+      },
       "parentPath": undefined,
       "profile": {
         "failNotFound": false,
@@ -78,7 +81,10 @@ ZoweUSSNode {
       "tooltip": "Profile: sestest
 Profile Type: zosmf",
     },
-    "onUpdateEmitter": EventEmitter {},
+    "onUpdateEmitter": EventEmitter {
+      "event": [MockFunction],
+      "subscribers": [],
+    },
     "parentPath": "/",
     "profile": {
       "failNotFound": false,
@@ -100,7 +106,10 @@ Profile Type: zosmf",
     "session": undefined,
     "tooltip": "/testDir",
   },
-  "onUpdateEmitter": EventEmitter {},
+  "onUpdateEmitter": EventEmitter {
+    "event": [MockFunction],
+    "subscribers": [],
+  },
   "parentPath": "/testDir",
   "profile": {
     "failNotFound": false,

--- a/packages/zowe-explorer/l10n/poeditor.json
+++ b/packages/zowe-explorer/l10n/poeditor.json
@@ -216,7 +216,7 @@
     "Zowe Explorer": ""
   },
   "zowe.ds.paginate.datasetsPerPage": {
-    "Maximum number of data sets and PDS members to list per page": ""
+    "Maximum number of data sets and PDS members to list per page. 0 disables pagination.": ""
   },
   "zowe.ds.default.binary": {
     "Default values of Binary data set creation": ""
@@ -520,6 +520,9 @@
   },
   "zowe.settings.overrideWithEnvironmentVariables": {
     "Indicates if environment variables should override values stored in Zowe configuration profiles on disk.": ""
+  },
+  "zowe.settings.socketConnectTimeout": {
+    "The amount of time to wait for a connection to be initiated with the server, in milliseconds.": ""
   },
   "Enter command here...": "",
   "Page Size:": "",

--- a/packages/zowe-explorer/src/extending/ZoweExplorerApiRegister.ts
+++ b/packages/zowe-explorer/src/extending/ZoweExplorerApiRegister.ts
@@ -22,6 +22,9 @@ export class ZoweExplorerApiRegister implements Types.IApiRegisterClient {
     public static ZoweExplorerApiRegisterInst: ZoweExplorerApiRegister;
     private static eventMap: Record<ZoweScheme | string, vscode.Event<vscode.FileChangeEvent[]>> = {};
 
+    public onProfileUpdatedEmitter: vscode.EventEmitter<imperative.IProfileLoaded> = new vscode.EventEmitter();
+    public readonly onProfileUpdated = this.onProfileUpdatedEmitter.event;
+
     /**
      * Access the singleton instance.
      * @returns {ZoweExplorerApiRegister} the ZoweExplorerApiRegister singleton instance

--- a/packages/zowe-explorer/src/trees/shared/SharedInit.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedInit.ts
@@ -161,7 +161,7 @@ export class SharedInit {
         );
 
         context.subscriptions.push(
-            ZoweVsCodeExtension.onProfileUpdated(async (profile) => {
+            ZoweExplorerApiRegister.getInstance().onProfileUpdated(async (profile) => {
                 for (const provider of Object.values(providers)) {
                     try {
                         const node = (await provider.getChildren()).find((n) => n.label === profile?.name);

--- a/packages/zowe-explorer/src/trees/shared/SharedInit.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedInit.ts
@@ -161,19 +161,7 @@ export class SharedInit {
         );
 
         context.subscriptions.push(
-            ZoweExplorerApiRegister.getInstance().onProfileUpdated(async (profile) => {
-                for (const provider of Object.values(providers)) {
-                    try {
-                        const node = (await provider.getChildren()).find((n) => n.label === profile?.name);
-                        node?.setProfileToChoice?.(profile);
-                    } catch (err) {
-                        if (err instanceof Error) {
-                            ZoweLogger.error(err.message);
-                        }
-                        return;
-                    }
-                }
-            })
+            ZoweExplorerApiRegister.getInstance().onProfileUpdated((profile) => SharedUtils.handleProfileChange(providers, profile))
         );
 
         if (providers.ds || providers.uss) {

--- a/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
@@ -13,7 +13,17 @@
 
 import * as vscode from "vscode";
 import * as path from "path";
-import { Gui, IZoweTreeNode, IZoweDatasetTreeNode, IZoweUSSTreeNode, IZoweJobTreeNode, Types, ZosEncoding, Sorting } from "@zowe/zowe-explorer-api";
+import {
+    Gui,
+    IZoweTreeNode,
+    IZoweDatasetTreeNode,
+    IZoweUSSTreeNode,
+    IZoweJobTreeNode,
+    Types,
+    ZosEncoding,
+    Sorting,
+    imperative,
+} from "@zowe/zowe-explorer-api";
 import { UssFSProvider } from "../uss/UssFSProvider";
 import { USSUtils } from "../uss/USSUtils";
 import { Constants } from "../../configuration/Constants";
@@ -473,5 +483,19 @@ export class SharedUtils {
             }
         }
         return true;
+    }
+
+    public static async handleProfileChange(treeProviders: Definitions.IZoweProviders, profile: imperative.IProfileLoaded): Promise<void> {
+        for (const provider of Object.values(treeProviders)) {
+            try {
+                const node = (await provider.getChildren()).find((n) => n.label === profile?.name);
+                node?.setProfileToChoice?.(profile);
+            } catch (err) {
+                if (err instanceof Error) {
+                    ZoweLogger.error(err.message);
+                }
+                return;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

Fixes #3622 

### How to test

**Note:** this sample extension may modify credentials for your default z/OSMF profile. You may want to start with a fresh config file (`zowe config init --gc`) before continuing.

1. Checkout this branch locally and run `pnpm install && pnpm build && pnpm package`
2. Clone the sample extension linked in #3622 
3. In its `package.json`, update the `@zowe/zowe-explorer-api` dependency to point to the tarball built from step 1. Change its version from 3.1.0 to:
`file:<path-to-zowe-explorer-repo>/dist/zowe-zowe-explorer-api-3.2.0-refactor_move-onprofileupdated.tgz` 
4. Install dependencies and compile the sample extension: `npm install && npm run compile`
5. Run the command `vsce package`. Answer yes (y) to all prompts.
6. Once the sample extension is packaged, install it from VSIX in your copy of VS Code.
7. Then, go back to the window with this branch. Open `packages/zowe-explorer/src/trees/shared/SharedUtils.ts` in the editor and place a breakpoint on line 489. 
8. Then, run the Dev Host (Run & Debug)
9. Notice that the breakpoint is hit, and if you look at the call stack, you'll see the path for the sample extension, indicating that the event was triggered by the sample extension's activation logic (expected).

When setting the same breakpoint on `main` and following these same steps, this event listener is never triggered by the sample extension's activation logic.

## Release Notes

Milestone: 3.2.0 or 3.2.1

Changelog: 
- Fixed an issue where the `onProfileUpdated` event emitter was not guaranteed to be the same across Zowe Explorer and extenders, causing some event listeners to not fire when an extender fires the event emitter.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
