### PR TITLE
fix(ds): return empty list to paginator when request fails

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
@@ -1508,6 +1508,21 @@ describe("ZoweDatasetNode Unit Tests - listDatasetsInRange()", () => {
         expect(listDatasetsMock.mock.calls[1][1]).toStrictEqual({ attributes: true, start: undefined, maxLength: 2 });
     });
 
+    it("returns an empty list of items to paginator when an error is encountered", async () => {
+        const sessionNode = new ZoweDatasetNode({
+            label: "sestest",
+            collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+            contextOverride: Constants.DS_SESSION_CONTEXT,
+            profile: createIProfile(),
+            session: createISession(),
+        });
+        jest.spyOn(sessionNode, "listDatasets").mockImplementationOnce(async () => {
+            throw new Error("Simulated error");
+        });
+        const result = await (sessionNode as any).listDatasetsInRange(undefined, 2);
+        expect(result).toStrictEqual({ items: [] });
+    });
+
     it("uses cached data to fetch next page", async () => {
         const sessionNode = new ZoweDatasetNode({
             label: "sestest",
@@ -1592,6 +1607,19 @@ describe("ZoweDatasetNode Unit Tests - listMembersInRange()", () => {
         expect(listMembersMock).toHaveBeenCalledTimes(2);
         expect(listMembersMock.mock.calls[0][1]).toStrictEqual({ attributes: false });
         expect(listMembersMock.mock.calls[1][1]).toStrictEqual({ attributes: true, start: undefined, maxLength: 2 });
+    });
+
+    it("returns an empty list of items to paginator when an error is encountered", async () => {
+        const pdsNode = new ZoweDatasetNode({
+            label: "PDS.ERROR",
+            collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+            contextOverride: Constants.DS_PDS_CONTEXT,
+        });
+        jest.spyOn(pdsNode, "listMembers").mockImplementationOnce(async () => {
+            throw new Error("Simulated error");
+        });
+        const result = await (pdsNode as any).listMembersInRange(undefined, 2);
+        expect(result).toStrictEqual({ items: [] });
     });
 
     it("uses cached data to fetch next page - start param defined", async () => {

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -713,7 +713,9 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                 scenario: vscode.l10n.t("Retrieving response from MVS list API"),
             });
             AuthUtils.syncSessionNode((prof) => ZoweExplorerApiRegister.getMvsApi(prof), this.getSessionNode(), updated && this);
-            return;
+            return {
+                items: [],
+            };
         }
 
         const successfulResponses = responses
@@ -815,7 +817,9 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                 scenario: vscode.l10n.t("Retrieving response from MVS list API"),
             });
             AuthUtils.syncSessionNode((prof) => ZoweExplorerApiRegister.getMvsApi(prof), this.getSessionNode(), updated && this);
-            return;
+            return {
+                items: [],
+            };
         }
 
         const successfulResponses = responses


### PR DESCRIPTION
## Proposed changes

I tried to keep the behavior of returning `undefined` from previous data set logic as part of the paginator. However, the paginator expects items to be defined as part of its type definition.

This changes the behavior of `listDatasetsInRange` and `listMembersInRange` to return an empty list of items once we've caught and handled an error. This prevents undefined behavior by the paginator when an error is encountered while expanding a PDS or a profile. 

## Release Notes

Milestone: 3.2.0

Changelog: No changelog as feature isn't yet available

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):