### PR TITLE
Fix report artifact workflow failing on fork PR

### DIFF
--- a/.github/workflows/merge-by-comments.yml
+++ b/.github/workflows/merge-by-comments.yml
@@ -11,5 +11,6 @@ jobs:
             pull-requests: write
         steps:
             - uses: zowe-actions/shared-actions/merge-by@main
+              continue-on-error: true
               with:
                 operation: "bump-dates"

--- a/.github/workflows/report-artifact-pr.yml
+++ b/.github/workflows/report-artifact-pr.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Report VSIX artifact
         uses: bitonality/PRtifact@v0.1.0
+        continue-on-error: true
         with:
           comment-mode: 'CreateOrUpdate'
           handlebars-template: '.github/resources/artifact-template.hbs'

--- a/.github/workflows/report-artifact-pr.yml
+++ b/.github/workflows/report-artifact-pr.yml
@@ -1,4 +1,4 @@
-name: Report VSIX Artifact in PR
+name: Report VSIX Artifact in PR 
 
 on:
   pull_request:

--- a/.github/workflows/report-artifact-pr.yml
+++ b/.github/workflows/report-artifact-pr.yml
@@ -1,7 +1,7 @@
 name: Report VSIX Artifact in PR
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - packages/zowe-explorer/**
       - packages/zowe-explorer-api/**
@@ -50,6 +50,5 @@ jobs:
         uses: bitonality/PRtifact@v0.1.0
         continue-on-error: true
         with:
-          github-token: ${{ secrets.TEST_ISSUE_UPDATE_TOKEN }}
           comment-mode: 'CreateOrUpdate'
           handlebars-template: '.github/resources/artifact-template.hbs'

--- a/.github/workflows/report-artifact-pr.yml
+++ b/.github/workflows/report-artifact-pr.yml
@@ -1,4 +1,4 @@
-name: Report VSIX Artifact in PR 
+name: Report VSIX Artifact in PR
 
 on:
   pull_request:
@@ -50,5 +50,6 @@ jobs:
         uses: bitonality/PRtifact@v0.1.0
         continue-on-error: true
         with:
+          github-token: ${{ secrets.TEST_ISSUE_UPDATE_TOKEN }}
           comment-mode: 'CreateOrUpdate'
           handlebars-template: '.github/resources/artifact-template.hbs'

--- a/.github/workflows/report-artifact-pr.yml
+++ b/.github/workflows/report-artifact-pr.yml
@@ -1,7 +1,7 @@
 name: Report VSIX Artifact in PR 
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - packages/zowe-explorer/**
       - packages/zowe-explorer-api/**

--- a/.github/workflows/report-artifact-pr.yml
+++ b/.github/workflows/report-artifact-pr.yml
@@ -1,7 +1,7 @@
 name: Report VSIX Artifact in PR 
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - packages/zowe-explorer/**
       - packages/zowe-explorer-api/**

--- a/.github/workflows/report-artifact-pr.yml
+++ b/.github/workflows/report-artifact-pr.yml
@@ -1,7 +1,7 @@
 name: Report VSIX Artifact in PR
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - packages/zowe-explorer/**
       - packages/zowe-explorer-api/**


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Why is the report vsix workflow failing on #3648 but not on #3646? 

This PR tests the theory that somehow opening a PR from a branch on a fork causes it to break.

After workflow run... it does indeed. Same error as the `merge_by` workflow on some of my past PR's.

This is because even though the workflow grants write permissions, the `GITHUB_TOKEN` [only has read permissions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) when running based on the workflow file in the PR's fork branch. 

There's a few different ways to fix this, but only one that would actually work for this use case, and also the others aren't very mindful of security. 

- Create a fine-grained PAT, grant "Read and Write" access to "Pull requests" (and maybe "Issues" too, not sure if PRtifact uses that API or not).
- In zowe explorer repo, go to `settings > secrets and variables > actions`.
- Click `new repository secret` and add the PAT called something sensible.
- Then I can update the workflow to
```yml
- name: Report VSIX artifact
  uses: bitonality/PRtifact@v0.1.0
  with:
    github-token: ${{ secrets.PAT_NAME }}
    comment-mode: 'CreateOrUpdate'
    handlebars-template: '.github/resources/artifact-template.hbs'
```

Downside is if the user who makes the PAT loses access or the PAT is revoked/expires, the workflow will break (not just on forks)

Either the above fix or I edit the workflow step of running PRtifact that if it fails the action will still complete "successfully" so it doesn't give a false sense of failed checks (silent fail):

```yml
 - name: Report VSIX artifact
    uses: bitonality/PRtifact@v0.1.0
    continue-on-error: true
    with:
      comment-mode: 'CreateOrUpdate'
      handlebars-template: '.github/resources/artifact-template.hbs'
```

Thoughts?

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
