### PR TITLE
Remove misleading prompt when credentials manager disabled and autoStore is false

### DIFF
--- a/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
@@ -11,7 +11,7 @@
 
 import * as vscode from "vscode";
 import { Gui } from "../../../src/globals/Gui";
-import { PromptCredentialsOptions, ZoweVsCodeExtension, ProfilesCache, Types } from "../../../src";
+import { PromptCredentialsOptions, ZoweVsCodeExtension, ProfilesCache, Types, Profiles } from "../../../src";
 import { Login, Logout } from "@zowe/core-for-zowe-sdk";
 import * as imperative from "@zowe/imperative";
 
@@ -713,6 +713,7 @@ describe("ZoweVsCodeExtension", () => {
                     profile: {},
                 }),
                 getProfileInfo: jest.fn().mockReturnValue({
+                    getTeamConfig: jest.fn().mockReturnValue({ properties: { autoStore: true } }),
                     isSecured: jest.fn().mockReturnValue(true),
                     updateProperty: mockUpdateProperty,
                 }),
@@ -743,6 +744,7 @@ describe("ZoweVsCodeExtension", () => {
                     profile: { user: "badUser", password: "badPassword" },
                 }),
                 getProfileInfo: jest.fn().mockReturnValue({
+                    getTeamConfig: jest.fn().mockReturnValue({ properties: { autoStore: true } }),
                     isSecured: jest.fn().mockReturnValue(true),
                     updateProperty: mockUpdateProperty,
                 }),
@@ -776,6 +778,7 @@ describe("ZoweVsCodeExtension", () => {
                     profile: {},
                 }),
                 getProfileInfo: jest.fn().mockReturnValue({
+                    getTeamConfig: jest.fn().mockReturnValue({ properties: { autoStore: true } }),
                     isSecured: jest.fn().mockReturnValue(false),
                     updateProperty: mockUpdateProperty,
                 }),
@@ -807,6 +810,7 @@ describe("ZoweVsCodeExtension", () => {
                     profile: {},
                 }),
                 getProfileInfo: jest.fn().mockReturnValue({
+                    getTeamConfig: jest.fn().mockReturnValue({ properties: { autoStore: true } }),
                     isSecured: jest.fn().mockReturnValue(false),
                     updateProperty: mockUpdateProperty,
                 }),

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -101,7 +101,8 @@ export class ZoweVsCodeExtension {
             loadProfile.profile.password = loadSession.password = creds[1];
 
             let shouldSave = true;
-            if (!setSecure) {
+            const autoStoreValue = (await this.profilesCache.getProfileInfo()).getTeamConfig().properties.autoStore;
+            if (!setSecure && autoStoreValue) {
                 shouldSave = await ZoweVsCodeExtension.saveCredentials(loadProfile);
             }
 


### PR DESCRIPTION
## Proposed changes

Solves https://github.com/zowe/zowe-explorer-vscode/issues/3557
This PR avoids prompting the user with the dialog of 'save credentials' or 'cancel' when credential manger is disabled and autoStore is set to false.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
