### PR TITLE
fix(v2): Allow profile node to be refreshed using its refresh action button

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where right-click menu for data set shows wrong options after deleting multiple PDS members. [#3516](https://github.com/zowe/zowe-explorer-vscode/issues/3516)
 - Updated dependencies for technical currency purposes. [#3577](https://github.com/zowe/zowe-explorer-vscode/pull/3577)
 - Fixed an issue where searching for the root directory (`/`) under a profile caused the profile to show a placeholder rather than a list of the files and folders at that path. [#3605](https://github.com/zowe/zowe-explorer-vscode/pull/3605)
+- Fixed an issue where clicking the refresh icon beside a profile in the Unix System Services (USS) view had no effect. [#3693](https://github.com/zowe/zowe-explorer-vscode/issues/3693)
 
 ## `2.18.1`
 

--- a/packages/zowe-explorer/src/uss/init.ts
+++ b/packages/zowe-explorer/src/uss/init.ts
@@ -79,7 +79,7 @@ export async function initUSSProvider(context: vscode.ExtensionContext): Promise
     context.subscriptions.push(
         vscode.commands.registerCommand("zowe.uss.refreshDirectory", async (node, nodeList) => {
             let selectedNodes = getSelectedNodeList(node, nodeList) as IZoweUSSTreeNode[];
-            selectedNodes = selectedNodes.filter((x) => contextuals.isUssDirectory(x));
+            selectedNodes = selectedNodes.filter((x) => contextuals.isUssDirectory(x) || contextuals.isUssSession(x));
             for (const item of selectedNodes) {
                 await ussActions.refreshDirectory(item, ussFileProvider);
             }


### PR DESCRIPTION
## Proposed changes

Fixed an issue where clicking the refresh icon beside a profile in the Unix System Services (USS) view had no effect.

## Release Notes

Milestone: 2.18.2

Changelog:

- Fixed an issue where clicking the refresh icon beside a profile in the Unix System Services (USS) view had no effect.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes
