### PR TITLE
fix(uss): Treat profile node as valid for refresh button

### DIFF
--- a/packages/zowe-explorer/src/trees/uss/USSInit.ts
+++ b/packages/zowe-explorer/src/trees/uss/USSInit.ts
@@ -80,7 +80,7 @@ export class USSInit {
         context.subscriptions.push(
             vscode.commands.registerCommand("zowe.uss.refreshDirectory", async (node, nodeList) => {
                 let selectedNodes = SharedUtils.getSelectedNodeList(node, nodeList) as IZoweUSSTreeNode[];
-                selectedNodes = selectedNodes.filter((x) => SharedContext.isUssDirectory(x));
+                selectedNodes = selectedNodes.filter((x) => SharedContext.isUssDirectory(x) || SharedContext.isUssSession(x));
                 for (const item of selectedNodes) {
                     await USSActions.refreshDirectory(item, ussFileProvider);
                 }


### PR DESCRIPTION
## Proposed changes

Fixes a long-standing issue (since at least sometime back in v2) where the profile node is not considered valid criteria for the `zowe.uss.refreshDirectory` command (the inline refresh button beside each profile)

## Release Notes

Milestone: 3.2.2

Changelog:

- Fixed an issue where clicking the refresh icon beside a profile in the Unix System Services (USS) view had no effect.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
