### PR TITLE
fix(tests): Use different method in integration test to access ZE settings

### DIFF
--- a/packages/zowe-explorer/__tests__/__integration__/bdd/step_definitions/Settings.steps.ts
+++ b/packages/zowe-explorer/__tests__/__integration__/bdd/step_definitions/Settings.steps.ts
@@ -10,6 +10,7 @@
  */
 
 import { Then, When } from "@cucumber/cucumber";
+import { SettingsEditor } from "wdio-vscode-service";
 
 //
 // Scenario: User can locate Zowe Explorer settings
@@ -20,6 +21,19 @@ When("a user navigates to VS Code Settings", async function () {
     await this.settingsEditor.wait();
 });
 Then("the user can access the Zowe Explorer settings section", async function () {
-    const zeSettings = await this.settingsEditor.findSetting("Secure Credentials Enabled", "Zowe", "Security");
-    await expect(zeSettings).toBeDefined();
+    const settingsEditor = (await this.settingsEditor) as SettingsEditor;
+    const settingsTableOfContents = await (await settingsEditor.elem).$("div[aria-label='Settings'][role='navigation']");
+
+    const extensionsGroup = await settingsTableOfContents.$("div[aria-label='Extensions, group']");
+    await extensionsGroup.click();
+
+    const zeGroup = await settingsTableOfContents.$(
+        ".monaco-list > .monaco-scrollable-element > .monaco-list-rows > div[aria-label='Zowe Explorer, group']"
+    );
+    await zeGroup.click();
+
+    const monacoList = await $(".settings-tree-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows");
+    await expect(monacoList).toExist();
+    const zeHeader = await monacoList.$("div[aria-label='Zowe Explorer']");
+    await expect(zeHeader).toExist();
 });


### PR DESCRIPTION
## Proposed changes

Recently the selectors broke for interacting with the input box of the settings editor. We used this to locate one of the Zowe Explorer settings to make sure the settings were accessible.

I've updated the method to look in the groups in the Settings editor, selecting "Extensions" -> "Zowe Explorer" and then verifying that the header is present in the Settings editor to pass the test.

## Release Notes

Milestone: N/A

Changelog: N/A (test change)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [x] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):