### PR TITLE
fix: reuse ProfilesCache instance in `ZoweVsCodeExtension` getter

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 - BugFix: Resolved a bug where extenders adding `ssh` or `base` to `allTypes` on `ProfileCache` will result in duplicate nodes when adding a profile of that type in Zowe Explorer. [#3625](https://github.com/zowe/zowe-explorer-vscode/pull/3625)
 - Fixed error message shown when creating a config file that already exists. [#3647](https://github.com/zowe/zowe-explorer-vscode/issues/3647)
+- Fixed an issue where the `ZoweVsCodeExtension.profilesCache` getter was creating new ProfilesCache instances instead of using the existing one from the Zowe Explorer API, which could lead to inconsistencies and synchronization issues.
 
 ## `3.2.1`
 

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -38,11 +38,10 @@ export class ZoweVsCodeExtension {
     }
 
     /**
-     * @internal
+     * @internal This is used to access the profiles cache through the Zowe Explorer API. For internal use only.
      */
     public static get profilesCache(): ProfilesCache {
-        const workspacePath = this.workspaceRoot?.uri.fsPath;
-        return new ProfilesCache(imperative.Logger.getAppLogger(), workspacePath);
+        return this.getZoweExplorerApi()?.getExplorerExtenderApi().getProfilesCache();
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

This fix addresses an issue where the profilesCache getter was creating a new ProfilesCache instance instead of using the existing one from the Zowe Explorer API. This could lead to inconsistencies and potential issues when multiple parts of the code were accessing different instances of the profiles cache.

**Before:** The profilesCache getter was instantiating a new ProfilesCache: `new ProfilesCache(imperative.Logger.getAppLogger(), workspacePath)`

**After**: The getter reuses the existing profiles cache from the Zowe Explorer API using `this.getZoweExplorerApi()?.getExplorerExtenderApi().getProfilesCache()`.

This getter was used in multiple functions in the `ZoweVsCodeExtension` class (listed below), so I anticipate this could resolve some inconsistencies/caching issues surrounding any of these functions:
- `updateCredentials`
- `ssoLogin`
- `ssoLogout`
- `createTeamConfiguration`
- `directConnectLogin`
- `directConnectLogout`
- `getServiceProfile`

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
