### PR TITLE
Fix wrong error message for file system URI with invalid profile

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 - BugFix: Resolved a bug where extenders adding `ssh` or `base` to `allTypes` on `ProfileCache` will result in duplicate nodes when adding a profile of that type in Zowe Explorer. [#3625](https://github.com/zowe/zowe-explorer-vscode/pull/3625)
 - Fixed error message shown when creating a config file that already exists. [#3647](https://github.com/zowe/zowe-explorer-vscode/issues/3647)
+- Fixed wrong error message when accessing a mainframe resource with a file system URI containing invalid profile name. [#3760](https://github.com/zowe/zowe-explorer-vscode/issues/3760)
 
 ## `3.2.2`
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/fs/utils/abstract.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/fs/utils/abstract.unit.test.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { DirEntry, FileEntry, FilterEntry, ZoweScheme } from "../../../../src";
+import { DirEntry, FileEntry, FilterEntry, ProfilesCache, ZoweScheme, imperative } from "../../../../src";
 import { MockedProperty } from "../../../../__mocks__/mockUtils";
 import * as vscode from "vscode";
 import { FsAbstractUtils } from "../../../../src/fs/utils/FsAbstractUtils";
@@ -33,6 +33,27 @@ describe("getInfoForUri", () => {
             profileName: "test.lpar",
             profile: null,
         });
+    });
+
+    it("returns profile properties for URI with valid profile when profiles cache is provided", () => {
+        const profilesCache = new ProfilesCache(imperative.Logger.getAppLogger());
+        const fakeProfile: Partial<imperative.IProfileLoaded> = {
+            name: "test.lpar",
+            type: "zosmf",
+            profile: { port: 443 },
+        };
+        jest.spyOn(profilesCache, "loadNamedProfile").mockReturnValue(fakeProfile as imperative.IProfileLoaded);
+        expect(FsAbstractUtils.getInfoForUri(fakeUri, profilesCache)).toStrictEqual({
+            isRoot: false,
+            slashAfterProfilePos: fakeUri.path.indexOf("/", 1),
+            profileName: "test.lpar",
+            profile: fakeProfile,
+        });
+    });
+
+    it("throws error for URI with invalid profile when profiles cache is provided", () => {
+        const profilesCache = new ProfilesCache(imperative.Logger.getAppLogger());
+        expect(() => FsAbstractUtils.getInfoForUri(fakeUri, profilesCache)).toThrow("Could not find profile named: test.lpar");
     });
 });
 

--- a/packages/zowe-explorer-api/src/fs/utils/FsAbstractUtils.ts
+++ b/packages/zowe-explorer-api/src/fs/utils/FsAbstractUtils.ts
@@ -31,7 +31,7 @@ export class FsAbstractUtils {
 
         // Load profile that matches the parsed name
         const profileName = uri.path.startsWith("/") ? uri.path.substring(1, startPathPos) : uri.path.substring(0, startPathPos);
-        const profile = profilesCache?.loadNamedProfile ? profilesCache.loadNamedProfile(profileName, undefined, true) : null;
+        const profile = profilesCache?.loadNamedProfile ? profilesCache.loadNamedProfile(profileName) : null;
 
         return {
             isRoot,


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Resolves #3760 to fix regression introduced in 3.2.2

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.3.0

Changelog:
* Fixed wrong error message when accessing a mainframe resource with a file system URI containing invalid profile name

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
