### PR TITLE
fix(regression): Handle uncaught exception in `ZoweTreeNode.getProfile`

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 - BugFix: Resolved a bug where extenders adding `ssh` or `base` to `allTypes` on `ProfileCache` will result in duplicate nodes when adding a profile of that type in Zowe Explorer. [#3625](https://github.com/zowe/zowe-explorer-vscode/pull/3625)
 - Fixed error message shown when creating a config file that already exists. [#3647](https://github.com/zowe/zowe-explorer-vscode/issues/3647)
+- Fixed regression with the `ZoweTreeNode.getProfile` function that caused unhandled exceptions to occur when a profile is no longer accessible. [#3772](https://github.com/zowe/zowe-explorer-vscode/issues/3772)
 
 ## `3.2.2`
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/tree/ZoweTreeNode.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/tree/ZoweTreeNode.unit.test.ts
@@ -122,17 +122,6 @@ describe("ZoweTreeNode", () => {
             expect(result).toStrictEqual(fakeProfile);
         });
 
-        it("should return current profile when profilesCache.loadNamedProfile is undefined", () => {
-            const node = makeNode("testNode", vscode.TreeItemCollapsibleState.None, undefined);
-            node.setProfileToChoice(fakeProfile);
-
-            const mockProfilesCache = {} as ProfilesCache;
-
-            const result = node.getProfile(mockProfilesCache);
-
-            expect(result).toStrictEqual(fakeProfile);
-        });
-
         it("should return parent profile when current profile is null and profilesCache throws error", () => {
             const parentNode = makeNode("parentNode", vscode.TreeItemCollapsibleState.None, undefined, undefined, "parentProfile");
             const node = makeNode("testNode", vscode.TreeItemCollapsibleState.None, parentNode);

--- a/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
+++ b/packages/zowe-explorer-api/src/profiles/ProfilesCache.ts
@@ -135,7 +135,7 @@ export class ProfilesCache {
     public updateCachedProfile(
         profileLoaded: imperative.IProfileLoaded,
         profileNode?: Types.IZoweNodeType,
-        zeRegister?: Types.IApiRegisterClient
+        _zeRegister?: Types.IApiRegisterClient
     ): void {
         // Note: When autoStore is disabled, nested profiles within this service profile may not have their credentials updated.
         const profIndex = this.allProfiles.findIndex((profile) => profile.type === profileLoaded.type && profile.name === profileLoaded.name);

--- a/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
@@ -83,7 +83,9 @@ export class ZoweTreeNode extends vscode.TreeItem {
             } catch (err) {
                 // Profile does not exist. Log and return last known profile for backwards compatibility
                 Logger.getAppLogger().error(
-                    `[ZoweTreeNode.getProfile] Profile ${this.profile.name} does not exist for node ${this.label}, returning last known profile`
+                    `[ZoweTreeNode.getProfile] Profile ${
+                        this.profile.name
+                    } does not exist for node ${this.label?.toString()}, returning last known profile`
                 );
             }
         }

--- a/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
@@ -14,6 +14,7 @@ import * as imperative from "@zowe/imperative";
 import { IZoweTreeNode } from "./IZoweTreeNode";
 import type { BaseProvider } from "../fs/BaseProvider";
 import type { ProfilesCache } from "../profiles";
+import { Logger } from "@zowe/imperative";
 
 /**
  * Common implementation of functions and methods associated with the
@@ -77,7 +78,13 @@ export class ZoweTreeNode extends vscode.TreeItem {
      */
     public getProfile(profilesCache?: ProfilesCache): imperative.IProfileLoaded {
         if (this.profile != null && profilesCache?.loadNamedProfile != null) {
-            return profilesCache.loadNamedProfile(this.profile.name);
+            try {
+                return profilesCache.loadNamedProfile(this.profile.name);
+            } catch (err) {
+                // Profile does not exist. Log and return undefined rather than the cached, invalid profile
+                Logger.getAppLogger().error(`Profile ${this.profile.name} does not exist for node ${this.label}`);
+                return undefined;
+            }
         }
         return this.profile ?? (this.getParent() as unknown as ZoweTreeNode)?.getProfile(profilesCache);
     }

--- a/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
@@ -81,7 +81,7 @@ export class ZoweTreeNode extends vscode.TreeItem {
             try {
                 return profilesCache.loadNamedProfile(this.profile.name);
             } catch (err) {
-                // Profile does not exist. Log and return undefined rather than the cached, invalid profile
+                // Profile does not exist. Log and return last known profile for backwards compatibility
                 Logger.getAppLogger().error(
                     `[ZoweTreeNode.getProfile] Profile ${this.profile.name} does not exist for node ${this.label}, returning last known profile`
                 );

--- a/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
@@ -77,7 +77,7 @@ export class ZoweTreeNode extends vscode.TreeItem {
      * @returns {imperative.IProfileLoaded}
      */
     public getProfile(profilesCache?: ProfilesCache): imperative.IProfileLoaded {
-        if (this.profile != null && profilesCache?.loadNamedProfile != null) {
+        if (this.profile != null && profilesCache != null) {
             try {
                 return profilesCache.loadNamedProfile(this.profile.name);
             } catch (err) {

--- a/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/ZoweTreeNode.ts
@@ -82,8 +82,9 @@ export class ZoweTreeNode extends vscode.TreeItem {
                 return profilesCache.loadNamedProfile(this.profile.name);
             } catch (err) {
                 // Profile does not exist. Log and return undefined rather than the cached, invalid profile
-                Logger.getAppLogger().error(`Profile ${this.profile.name} does not exist for node ${this.label}`);
-                return undefined;
+                Logger.getAppLogger().error(
+                    `[ZoweTreeNode.getProfile] Profile ${this.profile.name} does not exist for node ${this.label}, returning last known profile`
+                );
             }
         }
         return this.profile ?? (this.getParent() as unknown as ZoweTreeNode)?.getProfile(profilesCache);

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Improved integrated terminal behavior to match standard terminal functionality. Now, users can smoothly maintain proper cursor position when typing and backspacing. [#3391](https://github.com/zowe/zowe-explorer-vscode/issues/3391)
 - Fixed an issue where cancelling multiple commands in rapid succession could render the terminal unusable. [#3640](https://github.com/zowe/zowe-explorer-vscode/issues/3640)
 - Fixed an issue where a `401 Unauthorized` error is thrown by the FileSystemProvider implementations when the user cancels or closes an authentication prompt. Now, the filesystem throws a more explicit `AuthCancelledError` in this scenario. [#3662](https://github.com/zowe/zowe-explorer-vscode/issues/3662)
+- Fixed an issue where renaming or deleting the team configuration file caused an unhandled exception in Zowe Explorer, causing old, non-existent profiles to remain in the tree views. [#3772](https://github.com/zowe/zowe-explorer-vscode/issues/3772)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer/src/utils/TreeViewUtils.ts
+++ b/packages/zowe-explorer/src/utils/TreeViewUtils.ts
@@ -101,7 +101,7 @@ export class TreeViewUtils {
         await treeProvider.removeFavProfile(profileName, false);
         // Delete from Tree
         treeProvider.mSessionNodes.forEach((sessNode) => {
-            if ((sessNode.getProfileName() ?? sessNode.label) === profileName) {
+            if (sessNode.getProfileName() === profileName) {
                 treeProvider.deleteSession(sessNode);
                 sessNode.dirty = true;
                 treeProvider.refresh();

--- a/packages/zowe-explorer/src/utils/TreeViewUtils.ts
+++ b/packages/zowe-explorer/src/utils/TreeViewUtils.ts
@@ -101,7 +101,7 @@ export class TreeViewUtils {
         await treeProvider.removeFavProfile(profileName, false);
         // Delete from Tree
         treeProvider.mSessionNodes.forEach((sessNode) => {
-            if (sessNode.getProfileName() === profileName) {
+            if ((sessNode.getProfileName() ?? sessNode.label) === profileName) {
                 treeProvider.deleteSession(sessNode);
                 sessNode.dirty = true;
                 treeProvider.refresh();


### PR DESCRIPTION
## Proposed changes

Fixes #3772 and resolves multiple scenarios due to a `ZoweTreeNode.getProfile` regression in the Zowe Explorer API. The `loadNamedProfile` function was called outside of a try/catch block, causing exceptions from the function to be propagated to the caller/API consumer (breaking change).

If the user:
- deletes a profile from their team configuration
- renames a profile in the team configuration
- deletes the team configuration entirely
- renames the team configuration file

The matching profile node is not removed from any of the trees, because the Zowe Explorer core logic abruptly terminated due to the uncaught exception.

## Release Notes

Milestone: 3.3.0

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [x] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
