### PR TITLE
fix: allow editing existing DS/USS filters

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
@@ -2182,6 +2182,8 @@ describe("Dataset Tree Unit Tests - Function datasetFilterPrompt", () => {
             // Example of existing filter from user history
             const filterItem = { label: "EXISTING.FILTER", description: "" };
             jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(filterItem);
+            // Confirm user selection of existing filter
+            jest.spyOn(Gui, "showInputBox").mockResolvedValueOnce("EXISTING.FILTER");
 
             const testTree = new DatasetTree();
             testTree.mSessionNodes.push(blockMocks.datasetSessionNode);

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
@@ -96,7 +96,7 @@ function createGlobalMocks() {
         testSession: createISession(),
         testResponse: createFileResponse({ items: [] }),
         testUSSNode: null,
-        testTree: null,
+        testTree: null as unknown as USSTree,
         profilesForValidation: { status: "active", name: "fake" },
         mockProfilesCache: new ProfilesCache(imperative.Logger.getAppLogger()),
         mockTreeProviders: createTreeProviders(),
@@ -1061,13 +1061,41 @@ describe("USSTree Unit Tests - Function filterPrompt", () => {
         const historyFilterItem = new FilterItem({ text: historyItem });
         blockMocks.resolveQuickPickHelper.mockResolvedValue(historyFilterItem);
         globalMocks.showInputBox.mockReset();
+        // Simulate user confirming input for history item
+        globalMocks.showInputBox.mockResolvedValueOnce(historyItem);
         await globalMocks.testTree.filterPrompt(globalMocks.testTree.mSessionNodes[1]);
 
-        // Should not call showInputBox
-        expect(globalMocks.showInputBox).not.toHaveBeenCalled();
+        // Should call showInputBox to allow user to confirm/edit existing filter
+        expect(globalMocks.showInputBox).toHaveBeenCalled();
 
         // Should use the selected history item, not the typed value
         expect(globalMocks.testTree.mSessionNodes[1].fullPath).toEqual(historyItem);
+    });
+
+    it("should return early when user selects existing filter but cancels the edit input box", async () => {
+        const globalMocks = createGlobalMocks();
+        const blockMocks = createBlockMocks(globalMocks);
+
+        // Add search history to trigger quick pick
+        const existingFilter = "/u/existing/path";
+        globalMocks.testTree.addSearchHistory(existingFilter);
+
+        const existingFilterItem = new FilterItem({ text: existingFilter });
+        blockMocks.resolveQuickPickHelper.mockResolvedValueOnce(existingFilterItem);
+
+        // Mock the input box to return null (simulate user cancelling)
+        globalMocks.showInputBox.mockResolvedValueOnce(undefined);
+
+        const updateTreeViewSpy = jest.spyOn(globalMocks.testTree as any, "updateTreeView").mockImplementation();
+
+        await globalMocks.testTree.filterPrompt(globalMocks.testTree.mSessionNodes[1]);
+
+        expect(globalMocks.showInputBox).toHaveBeenCalledWith({
+            placeHolder: expect.any(String),
+            value: existingFilter,
+            validateInput: expect.any(Function),
+        });
+        expect(updateTreeViewSpy).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/USSTree.unit.test.ts
@@ -1508,7 +1508,6 @@ describe("USSTree Unit Tests - Function rename", () => {
         globalMocks.showInputBox.mockReturnValueOnce("new name");
         jest.spyOn(UssFSProvider.instance, "rename").mockResolvedValue(undefined);
         await globalMocks.testTree.rename(blockMocks.ussFavNode);
-        console.log(globalMocks.showErrorMessage);
         expect(globalMocks.showErrorMessage.mock.calls.length).toBe(0);
     });
 

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTableView.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTableView.ts
@@ -33,7 +33,6 @@ import { ZoweExplorerApiRegister } from "../../extending/ZoweExplorerApiRegister
 import { AuthUtils } from "../../utils/AuthUtils";
 import * as imperative from "@zowe/imperative";
 import { ZoweExplorerExtender } from "../../extending/ZoweExplorerExtender";
-import { ZoweLogger } from "../../tools/ZoweLogger";
 
 /**
  * Tree-based data source that uses existing tree nodes
@@ -547,7 +546,7 @@ export class DatasetTableView {
         try {
             pinnedRows = await this.table.getPinnedRows();
         } catch (error) {
-            ZoweLogger.warn(`Failed to get pinned rows: ${error}`);
+            console.warn("Failed to get pinned rows:", error);
         }
 
         // Store current table state before navigating
@@ -619,7 +618,7 @@ export class DatasetTableView {
                 try {
                     await this.table.setPinnedRows(this.previousTableData.pinnedRows);
                 } catch (error) {
-                    ZoweLogger.warn(`Failed to restore pinned rows: ${error}`);
+                    console.warn("Failed to restore pinned rows:", error);
                 }
             }
 

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTableView.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTableView.ts
@@ -33,6 +33,7 @@ import { ZoweExplorerApiRegister } from "../../extending/ZoweExplorerApiRegister
 import { AuthUtils } from "../../utils/AuthUtils";
 import * as imperative from "@zowe/imperative";
 import { ZoweExplorerExtender } from "../../extending/ZoweExplorerExtender";
+import { ZoweLogger } from "../../tools/ZoweLogger";
 
 /**
  * Tree-based data source that uses existing tree nodes
@@ -546,7 +547,7 @@ export class DatasetTableView {
         try {
             pinnedRows = await this.table.getPinnedRows();
         } catch (error) {
-            console.warn("Failed to get pinned rows:", error);
+            ZoweLogger.warn(`Failed to get pinned rows: ${error}`);
         }
 
         // Store current table state before navigating
@@ -618,7 +619,7 @@ export class DatasetTableView {
                 try {
                     await this.table.setPinnedRows(this.previousTableData.pinnedRows);
                 } catch (error) {
-                    console.warn("Failed to restore pinned rows:", error);
+                    ZoweLogger.warn(`Failed to restore pinned rows: ${error}`);
                 }
             }
 

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
@@ -1341,7 +1341,16 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
                         }
                     }
                 } else {
-                    pattern = choice.label;
+                    // User selected an existing filter - show input box with the filter pre-filled for editing
+                    const options: vscode.InputBoxOptions = {
+                        prompt: vscode.l10n.t("Search data sets: use a comma to separate multiple patterns"),
+                        value: choice.label, // Pre-fill with the selected filter
+                    };
+                    pattern = await Gui.showInputBox(options);
+                    if (!pattern) {
+                        Gui.showMessage(vscode.l10n.t("You must enter a pattern."));
+                        return;
+                    }
                 }
             } else {
                 // No search history, use input box directly

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
@@ -1336,7 +1336,6 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
                         };
                         pattern = await Gui.showInputBox(options);
                         if (!pattern) {
-                            Gui.showMessage(vscode.l10n.t("You must enter a pattern."));
                             return;
                         }
                     }

--- a/packages/zowe-explorer/src/trees/uss/USSTree.ts
+++ b/packages/zowe-explorer/src/trees/uss/USSTree.ts
@@ -780,7 +780,16 @@ export class USSTree extends ZoweTreeProvider<IZoweUSSTreeNode> implements Types
                             }
                         }
                     } else {
-                        remotepath = choice.label;
+                        // User selected an existing filter - show input box with the filter pre-filled for editing
+                        const options: vscode.InputBoxOptions = {
+                            placeHolder: vscode.l10n.t("New filter"),
+                            value: choice.label, // Pre-fill with the selected filter
+                            validateInput: (input: string) => (input.length > 0 ? null : vscode.l10n.t("Please enter a valid USS path.")),
+                        };
+                        remotepath = await Gui.showInputBox(options);
+                        if (remotepath == null) {
+                            return;
+                        }
                     }
                 } else {
                     // No search history, use input box directly


### PR DESCRIPTION
## Proposed changes

Fixes side effect from #3768 where pre-existing filters no longer show an input box to confirm submission.

### How to test

- Search under a profile in Data Sets or USS tree
- Select an existing pattern
- Notice that you can use this pre-existing pattern as a template for a new pattern. This is currently not the case in `main` - clicking on a pre-existing filter would just submit the filter. I wanted to preserve this UX to avoid any perceived breaking changes.

## Release Notes

Milestone: 3.3.0

Changelog: N/A (new UX hasn't been released yet)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [x] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
