### PR TITLE
fix(ds): Do not allow listing data sets while filter prompt is open

### DIFF
--- a/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
+++ b/packages/zowe-explorer-api/src/tree/IZoweTreeNode.ts
@@ -187,6 +187,11 @@ export interface IZoweDatasetTreeNode extends IZoweTreeNode {
     children?: IZoweDatasetTreeNode[];
 
     /**
+     * Whether the node is currently being updated through a filter prompt
+     */
+    inFilterPrompt?: boolean;
+
+    /**
      * Retrieves child nodes of this IZoweDatasetTreeNode
      *
      * @returns {Promise<IZoweDatasetTreeNode[]>}

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where renaming or deleting the team configuration file caused an unhandled exception in Zowe Explorer, causing old, non-existent profiles to remain in the tree views. [#3772](https://github.com/zowe/zowe-explorer-vscode/issues/3772)
 - Fixed a regression with the `AuthUtils.syncSessionNode` function that caused Zowe Explorer logic to stop unexpectedly if a session node did not yet have a rich hover tooltip. [#3795](https://github.com/zowe/zowe-explorer-vscode/pull/3795)
 - Prevented data loss by modifying the save process to handle data sets with records that exceeded the logical record length. [#3791](https://github.com/zowe/zowe-explorer-vscode/issues/3791)
+- Fixed issue where `getChildren` was called repeatedly by VS Code during filter prompt interactions, causing performance issues and excessive requests for listing data sets. [#3807](https://github.com/zowe/zowe-explorer-vscode/issues/3807)
 
 ## `3.2.2`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -38,7 +38,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where renaming or deleting the team configuration file caused an unhandled exception in Zowe Explorer, causing old, non-existent profiles to remain in the tree views. [#3772](https://github.com/zowe/zowe-explorer-vscode/issues/3772)
 - Fixed a regression with the `AuthUtils.syncSessionNode` function that caused Zowe Explorer logic to stop unexpectedly if a session node did not yet have a rich hover tooltip. [#3795](https://github.com/zowe/zowe-explorer-vscode/pull/3795)
 - Prevented data loss by modifying the save process to handle data sets with records that exceeded the logical record length. [#3791](https://github.com/zowe/zowe-explorer-vscode/issues/3791)
-- Fixed issue where `getChildren` was called repeatedly by VS Code during filter prompt interactions, causing performance issues and excessive requests for listing data sets. [#3807](https://github.com/zowe/zowe-explorer-vscode/issues/3807)
+- Fixed issue where the `getChildren` function made requests repeatedly while the data set filter prompt was open, causing repeated authentication prompts and excessive requests for listing data sets. [#3807](https://github.com/zowe/zowe-explorer-vscode/issues/3807)
 
 ## `3.2.2`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
@@ -1914,22 +1914,7 @@ describe("Dataset Tree Unit Tests - Function datasetFilterPrompt", () => {
         expect(errorSpy).not.toHaveBeenCalled();
         errorSpy.mockClear();
     });
-    it("Checking function for return if element.getChildren returns undefined", async () => {
-        const globalMocks = createGlobalMocks();
-        const blockMocks = createBlockMocks(globalMocks);
 
-        mocked(vscode.window.showQuickPick).mockResolvedValueOnce(new FilterDescriptor("\uFF0B " + "Create a new filter"));
-        mocked(vscode.window.showInputBox).mockResolvedValueOnce("HLQ.PROD1.STUFF");
-        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
-        const testTree = new DatasetTree();
-        testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
-        Object.defineProperty(testTree.mSessionNodes[1], "getDatasets", {
-            value: jest.fn().mockResolvedValueOnce(undefined),
-            configurable: true,
-        });
-
-        expect(await testTree.datasetFilterPrompt(testTree.mSessionNodes[1])).not.toBeDefined();
-    });
 
     it("should return early if profile is invalid", async () => {
         const globalMocks = createGlobalMocks();

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
@@ -1892,29 +1892,6 @@ describe("Dataset Tree Unit Tests - Function datasetFilterPrompt", () => {
 
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith("No selection made. Operation cancelled.");
     });
-    it("Checking function for return if getChildren is undefined", async () => {
-        const globalMocks = createGlobalMocks();
-        const blockMocks = createBlockMocks(globalMocks);
-
-        mocked(vscode.window.showQuickPick).mockResolvedValueOnce(new FilterDescriptor("\uFF0B " + "Create a new filter"));
-        mocked(vscode.window.showInputBox).mockResolvedValueOnce("HLQ.PROD1.STUFF");
-        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
-        const testTree = new DatasetTree();
-        testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
-        Object.defineProperty(testTree.mSessionNodes[1], "getChildren", {
-            value: jest.fn(() => {
-                return;
-            }),
-            configurable: true,
-        });
-        const errorSpy = jest.spyOn(AuthUtils, "errorHandling");
-
-        expect(await testTree.datasetFilterPrompt(testTree.mSessionNodes[1])).not.toBeDefined();
-
-        expect(errorSpy).not.toHaveBeenCalled();
-        errorSpy.mockClear();
-    });
-
 
     it("should return early if profile is invalid", async () => {
         const globalMocks = createGlobalMocks();

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
@@ -1892,28 +1892,6 @@ describe("Dataset Tree Unit Tests - Function datasetFilterPrompt", () => {
 
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith("No selection made. Operation cancelled.");
     });
-    it("Checking adding of new filter error is caught on getChildren", async () => {
-        const globalMocks = createGlobalMocks();
-        const blockMocks = createBlockMocks(globalMocks);
-
-        mocked(vscode.window.showQuickPick).mockResolvedValueOnce(new FilterDescriptor("\uFF0B " + "Create a new filter"));
-        mocked(vscode.window.showInputBox).mockResolvedValueOnce("HLQ.PROD1.STUFF");
-        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
-        const testTree = new DatasetTree();
-        testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
-        Object.defineProperty(testTree.mSessionNodes[1], "getChildren", {
-            value: jest.fn(() => {
-                throw new Error("test error");
-            }),
-            configurable: true,
-        });
-        const errorSpy = jest.spyOn(AuthUtils, "errorHandling");
-
-        await testTree.datasetFilterPrompt(testTree.mSessionNodes[1]);
-
-        expect(errorSpy).toHaveBeenCalled();
-        errorSpy.mockClear();
-    });
     it("Checking function for return if getChildren is undefined", async () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks(globalMocks);
@@ -2563,6 +2541,282 @@ describe("Dataset Tree Unit Tests - Function datasetFilterPrompt", () => {
             value: existingFilter,
         });
         expect(filterTreeSpy).not.toHaveBeenCalled();
+    });
+
+    describe("inFilterPrompt flag management", () => {
+        it("should set inFilterPrompt to true when prompt opens and false when user cancels", async () => {
+            const globalMocks = createGlobalMocks();
+            const blockMocks = createBlockMocks(globalMocks);
+            const node = blockMocks.datasetSessionNode;
+
+            // Mock the QuickPick to simulate user cancellation
+            const mockQuickPick = {
+                placeholder: "",
+                ignoreFocusOut: true,
+                items: [],
+                value: "",
+                show: jest.fn(),
+                hide: jest.fn(),
+                onDidChangeValue: jest.fn(),
+            };
+
+            mocked(Gui.createQuickPick).mockReturnValue(mockQuickPick);
+            mocked(Gui.resolveQuickPick).mockResolvedValue(undefined); // User cancels
+
+            // Spy on node.inFilterPrompt changes
+            const originalInFilterPrompt = node.inFilterPrompt;
+            expect(originalInFilterPrompt).toBe(false);
+
+            // Mock search history to trigger QuickPick path
+            jest.spyOn(blockMocks.testTree.mPersistence, "getSearchHistory").mockReturnValue(["HLQ.*"]);
+
+            await blockMocks.testTree.datasetFilterPrompt(node);
+
+            // Verify that inFilterPrompt was set to false after cancellation
+            expect(node.inFilterPrompt).toBe(false);
+            expect(Gui.showMessage).toHaveBeenCalledWith("No selection made. Operation cancelled.");
+        });
+
+        it("should set inFilterPrompt to false when user enters invalid input", async () => {
+            const globalMocks = createGlobalMocks();
+            const blockMocks = createBlockMocks(globalMocks);
+            const node = blockMocks.datasetSessionNode;
+
+            // Mock the QuickPick to simulate user selecting "Create new filter" but providing no input
+            const mockQuickPick = {
+                placeholder: "",
+                ignoreFocusOut: true,
+                items: [],
+                value: "",
+                show: jest.fn(),
+                hide: jest.fn(),
+                onDidChangeValue: jest.fn(),
+            };
+
+            mocked(Gui.createQuickPick).mockReturnValue(mockQuickPick);
+            mocked(Gui.resolveQuickPick).mockResolvedValue(new FilterDescriptor("Create a new filter"));
+            mocked(Gui.showInputBox).mockResolvedValue(undefined); // User provides no input
+
+            // Mock search history to trigger QuickPick path
+            jest.spyOn(blockMocks.testTree.mPersistence, "getSearchHistory").mockReturnValue(["HLQ.*"]);
+
+            await blockMocks.testTree.datasetFilterPrompt(node);
+
+            // Verify that inFilterPrompt was set to false after invalid input
+            expect(node.inFilterPrompt).toBe(false);
+        });
+
+        it("should set inFilterPrompt to false when successful filter is applied", async () => {
+            const globalMocks = createGlobalMocks();
+            const blockMocks = createBlockMocks(globalMocks);
+            const node = blockMocks.datasetSessionNode;
+
+            // Mock the QuickPick to simulate successful filter creation
+            const mockQuickPick = {
+                placeholder: "",
+                ignoreFocusOut: true,
+                items: [],
+                value: "HLQ.TEST.*",
+                show: jest.fn(),
+                hide: jest.fn(),
+                onDidChangeValue: jest.fn(),
+            };
+
+            mocked(Gui.createQuickPick).mockReturnValue(mockQuickPick);
+            mocked(Gui.resolveQuickPick).mockResolvedValue(new FilterDescriptor("Create a new filter"));
+
+            // Mock TreeViewUtils.expandNode to avoid actual tree expansion
+            jest.spyOn(TreeViewUtils, "expandNode").mockResolvedValue();
+            jest.spyOn(blockMocks.testTree, "nodeDataChanged").mockImplementation();
+            jest.spyOn(blockMocks.testTree, "addSearchHistory").mockImplementation();
+
+            // Mock search history to trigger QuickPick path
+            jest.spyOn(blockMocks.testTree.mPersistence, "getSearchHistory").mockReturnValue(["HLQ.*"]);
+
+            const originalInFilterPrompt = node.inFilterPrompt;
+            expect(originalInFilterPrompt).toBe(false);
+
+            await blockMocks.testTree.datasetFilterPrompt(node);
+
+            // Verify that inFilterPrompt was set to false after successful filter application
+            expect(node.inFilterPrompt).toBe(false);
+            expect(node.pattern).toEqual("HLQ.TEST.*");
+        });
+
+        it("should set dirty flag to true and trigger refresh when successful filter is applied", async () => {
+            const globalMocks = createGlobalMocks();
+            const blockMocks = createBlockMocks(globalMocks);
+            const node = blockMocks.datasetSessionNode;
+
+            // Set up successful filter application
+            const mockQuickPick = {
+                placeholder: "",
+                ignoreFocusOut: true,
+                items: [],
+                value: "HLQ.TEST.*",
+                show: jest.fn(),
+                hide: jest.fn(),
+                onDidChangeValue: jest.fn(),
+            };
+
+            mocked(Gui.createQuickPick).mockReturnValue(mockQuickPick);
+            mocked(Gui.resolveQuickPick).mockResolvedValue(new FilterDescriptor("Create a new filter"));
+
+            // Mock TreeViewUtils.expandNode and nodeDataChanged to track calls
+            const expandNodeSpy = jest.spyOn(TreeViewUtils, "expandNode").mockResolvedValue();
+            const nodeDataChangedSpy = jest.spyOn(blockMocks.testTree, "nodeDataChanged").mockImplementation();
+            jest.spyOn(blockMocks.testTree, "addSearchHistory").mockImplementation();
+
+            // Mock search history
+            jest.spyOn(blockMocks.testTree.mPersistence, "getSearchHistory").mockReturnValue(["HLQ.*"]);
+
+            // Set initial state
+            node.dirty = false;
+            node.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+
+            await blockMocks.testTree.datasetFilterPrompt(node);
+
+            // Verify dirty flag was set to true
+            expect(node.dirty).toBe(true);
+            expect(node.inFilterPrompt).toBe(false);
+
+            // Verify refresh was triggered for expanded node
+            expect(nodeDataChangedSpy).toHaveBeenCalledWith(node);
+            expect(expandNodeSpy).not.toHaveBeenCalled(); // Should not expand already expanded node
+        });
+
+        it("should expand node when it's not already expanded after filter application", async () => {
+            const globalMocks = createGlobalMocks();
+            const blockMocks = createBlockMocks(globalMocks);
+            const node = blockMocks.datasetSessionNode;
+
+            // Set up successful filter application
+            const mockQuickPick = {
+                placeholder: "",
+                ignoreFocusOut: true,
+                items: [],
+                value: "HLQ.TEST.*",
+                show: jest.fn(),
+                hide: jest.fn(),
+                onDidChangeValue: jest.fn(),
+            };
+
+            mocked(Gui.createQuickPick).mockReturnValue(mockQuickPick);
+            mocked(Gui.resolveQuickPick).mockResolvedValue(new FilterDescriptor("Create a new filter"));
+
+            // Mock TreeViewUtils.expandNode and nodeDataChanged to track calls
+            const expandNodeSpy = jest.spyOn(TreeViewUtils, "expandNode").mockResolvedValue();
+            const nodeDataChangedSpy = jest.spyOn(blockMocks.testTree, "nodeDataChanged").mockImplementation();
+            jest.spyOn(blockMocks.testTree, "addSearchHistory").mockImplementation();
+
+            // Mock search history
+            jest.spyOn(blockMocks.testTree.mPersistence, "getSearchHistory").mockReturnValue(["HLQ.*"]);
+
+            // Set initial state - node is NOT expanded
+            node.dirty = false;
+            node.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+
+            await blockMocks.testTree.datasetFilterPrompt(node);
+
+            // Verify dirty flag was set to true
+            expect(node.dirty).toBe(true);
+            expect(node.inFilterPrompt).toBe(false);
+
+            // Verify expand was called instead of nodeDataChanged
+            expect(expandNodeSpy).toHaveBeenCalledWith(node, blockMocks.testTree);
+            expect(nodeDataChangedSpy).not.toHaveBeenCalled();
+        });
+
+        it("should not interfere with dirty flag when user cancels filter prompt", async () => {
+            const globalMocks = createGlobalMocks();
+            const blockMocks = createBlockMocks(globalMocks);
+            const node = blockMocks.datasetSessionNode;
+
+            // Mock user cancellation
+            const mockQuickPick = {
+                placeholder: "",
+                ignoreFocusOut: true,
+                items: [],
+                value: "",
+                show: jest.fn(),
+                hide: jest.fn(),
+                onDidChangeValue: jest.fn(),
+            };
+
+            mocked(Gui.createQuickPick).mockReturnValue(mockQuickPick);
+            mocked(Gui.resolveQuickPick).mockResolvedValue(undefined); // User cancels
+
+            // Mock search history
+            jest.spyOn(blockMocks.testTree.mPersistence, "getSearchHistory").mockReturnValue(["HLQ.*"]);
+
+            // Set initial state
+            const originalDirtyState = true;
+            node.dirty = originalDirtyState;
+
+            await blockMocks.testTree.datasetFilterPrompt(node);
+
+            // Verify dirty flag was not modified during cancellation
+            expect(node.dirty).toBe(originalDirtyState);
+            expect(node.inFilterPrompt).toBe(false);
+        });
+
+        it("should return early from getChildren when inFilterPrompt is true", async () => {
+            const globalMocks = createGlobalMocks();
+            const blockMocks = createBlockMocks(globalMocks);
+            const node = blockMocks.datasetSessionNode;
+
+            // Set up node state
+            node.pattern = "HLQ.*";
+            node.dirty = true;
+            node.inFilterPrompt = true; // Simulate being in filter prompt
+            node.children = [
+                new ZoweDatasetNode({
+                    label: "EXISTING.CHILD",
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    parentNode: node,
+                }),
+            ];
+
+            // Mock SharedContext.isSessionNotFav to return true for session node
+            jest.spyOn(SharedContext, "isSessionNotFav").mockReturnValue(true);
+
+            const result = await node.getChildren();
+
+            // Should return existing children without fetching new data
+            expect(result).toBe(node.children);
+            expect(result).toHaveLength(1);
+            expect(result[0].label).toBe("EXISTING.CHILD");
+        });
+
+        it("should reset inFilterPrompt when selecting existing filter but canceling input", async () => {
+            const globalMocks = createGlobalMocks();
+            const blockMocks = createBlockMocks(globalMocks);
+            const node = blockMocks.datasetSessionNode;
+
+            // Mock selecting existing filter from history
+            const mockQuickPick = {
+                placeholder: "",
+                ignoreFocusOut: true,
+                items: [],
+                value: "",
+                show: jest.fn(),
+                hide: jest.fn(),
+                onDidChangeValue: jest.fn(),
+            };
+
+            mocked(Gui.createQuickPick).mockReturnValue(mockQuickPick);
+            mocked(Gui.resolveQuickPick).mockResolvedValue(new FilterItem({ text: "HLQ.EXISTING.*" }));
+            mocked(Gui.showInputBox).mockResolvedValue(undefined); // User cancels input
+
+            // Mock search history
+            jest.spyOn(blockMocks.testTree.mPersistence, "getSearchHistory").mockReturnValue(["HLQ.EXISTING.*"]);
+
+            await blockMocks.testTree.datasetFilterPrompt(node);
+
+            // Verify inFilterPrompt was reset to false
+            expect(node.inFilterPrompt).toBe(false);
+            expect(Gui.showMessage).toHaveBeenCalledWith("You must enter a pattern.");
+        });
     });
 });
 describe("Dataset Tree Unit Tests - Function editSession", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/ZoweDatasetNode.unit.test.ts
@@ -1388,6 +1388,31 @@ describe("ZoweDatasetNode Unit Tests - getChildren() misc scenarios", () => {
         mockProfilesInstance.mockRestore();
         errorHandlingMock[Symbol.dispose]();
     });
+
+    it("returns empty array when getDatasets returns undefined", async () => {
+        const sessionNode = new ZoweDatasetNode({
+            label: "sestest",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            session,
+            profile: profileOne,
+            contextOverride: Constants.DS_SESSION_CONTEXT,
+        });
+        sessionNode.pattern = "TEST.*";
+        sessionNode.dirty = true;
+
+        // Mock getDatasets to return undefined (simulating invalid session scenario)
+        const getDatasetsSpy = jest.spyOn(sessionNode as any, "getDatasets").mockResolvedValueOnce(undefined);
+        const mockProfilesInstance = jest.spyOn(Profiles, "getInstance").mockReturnValue({
+            loadNamedProfile: jest.fn().mockReturnValue(profileOne),
+        } as any);
+
+        const result = await sessionNode.getChildren();
+
+        expect(result).toStrictEqual([]);
+        expect(getDatasetsSpy).toHaveBeenCalledWith(profileOne, undefined);
+        getDatasetsSpy.mockRestore();
+        mockProfilesInstance.mockRestore();
+    });
 });
 
 describe("ZoweDatasetNode Unit Tests - getDatasets()", () => {

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
@@ -1314,6 +1314,7 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
 
         if (SharedContext.isSessionNotFav(node)) {
             ZoweLogger.debug(vscode.l10n.t("Prompting the user for a data set pattern"));
+            node.inFilterPrompt = true;
             if (this.mPersistence.getSearchHistory().length > 0) {
                 const items: vscode.QuickPickItem[] = this.mPersistence.getSearchHistory().map((element) => new FilterItem({ text: element }));
                 const quickpick = Gui.createQuickPick();
@@ -1337,6 +1338,7 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
                 quickpick.hide();
                 if (!choice) {
                     Gui.showMessage(vscode.l10n.t("No selection made. Operation cancelled."));
+                    node.inFilterPrompt = false;
                     return;
                 }
                 if (choice instanceof FilterDescriptor) {
@@ -1350,6 +1352,7 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
                         };
                         pattern = await Gui.showInputBox(options);
                         if (!pattern) {
+                            node.inFilterPrompt = false;
                             return;
                         }
                     }
@@ -1362,6 +1365,7 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
                     pattern = await Gui.showInputBox(options);
                     if (!pattern) {
                         Gui.showMessage(vscode.l10n.t("You must enter a pattern."));
+                        node.inFilterPrompt = false;
                         return;
                     }
                 }
@@ -1373,6 +1377,7 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
                 pattern = await Gui.showInputBox(options);
                 if (!pattern) {
                     Gui.showMessage(vscode.l10n.t("You must enter a pattern."));
+                    node.inFilterPrompt = false;
                     return;
                 }
             }
@@ -1426,6 +1431,7 @@ export class DatasetTree extends ZoweTreeProvider<IZoweDatasetTreeNode> implemen
             node.resourceUri = node.resourceUri.with({ query: `pattern=${pattern}` });
         }
         node.dirty = true;
+        node.inFilterPrompt = false;
 
         if (node.collapsibleState !== vscode.TreeItemCollapsibleState.Expanded) {
             // The node is refreshed when its expanded & marked dirty, no need to call nodeDataChanged

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -292,7 +292,11 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             return [];
         }
 
-        if ((!this.dirty && !paginate) || this.label === "Favorites" || this.inFilterPrompt) {
+        if ((!this.dirty && !paginate) || this.label === "Favorites") {
+            return this.children;
+        }
+
+        if (SharedContext.isSession(this) && this.inFilterPrompt) {
             return this.children;
         }
 

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -946,28 +946,25 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             // to reflect potential changes without changing the page itself.
 
             // If the page fetch fails, reset the paginator data to take the user back to the first page.
-            if (this.dirty && paginate) {
-                try {
-                    await this.paginator.refetchCurrentPage();
-                } catch (error) {
-                    if (error instanceof Error) {
-                        ZoweLogger.error(`[ZoweDatasetNode.getDatasets]: Error refetching current page: ${error.message}`);
-                    }
-                    if (
-                        (error instanceof imperative.ImperativeError &&
-                            Number(error.mDetails.errorCode) === imperative.RestConstants.HTTP_STATUS_401) ||
-                        error.message.includes("All configured authentication methods failed")
-                    ) {
-                        throw error;
-                    }
-                    this.paginatorData = undefined;
-                }
-            }
-
-            if (paginate && this.paginator) {
-                // Ensure paginator is initialized if it hasn't been (first load or invalidated cache)
+            if (paginate) {
                 if (!this.paginator.isInitialized() || this.paginatorData == null) {
                     await this.paginator.initialize();
+                } else {
+                    try {
+                        await this.paginator.refetchCurrentPage();
+                    } catch (error) {
+                        if (error instanceof Error) {
+                            ZoweLogger.error(`[ZoweDatasetNode.getDatasets]: Error refetching current page: ${error.message}`);
+                        }
+                        if (
+                            (error instanceof imperative.ImperativeError &&
+                                Number(error.mDetails.errorCode) === imperative.RestConstants.HTTP_STATUS_401) ||
+                            error.message.includes("All configured authentication methods failed")
+                        ) {
+                            throw error;
+                        }
+                        this.paginatorData = undefined;
+                    }
                 }
                 responses.push(...this.paginator.getCurrentPageItems());
             } else {

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -70,6 +70,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
     public filter?: Sorting.DatasetFilter;
     public resourceUri?: vscode.Uri;
     public persistence = new ZowePersistentFilters(PersistenceSchemaEnum.Dataset);
+    public inFilterPrompt = false;
 
     private paginator?: Paginator<IZosFilesResponse>;
     private paginatorData?: {
@@ -291,7 +292,7 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
             return [];
         }
 
-        if ((!this.dirty && !paginate) || this.label === "Favorites") {
+        if ((!this.dirty && !paginate) || this.label === "Favorites" || this.inFilterPrompt) {
             return this.children;
         }
 

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -937,33 +937,27 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                 this.paginator = this.paginatorData = undefined;
             }
 
-            if ((!this.paginator || this.paginator.getMaxItemsPerPage() !== this.itemsPerPage) && this.itemsPerPage > 0) {
-                // Force paginator and data to be re-initialized if fetch function or page size changes, or if pattern changes
-                this.paginator = new Paginator(this.itemsPerPage, fetchFunction);
-            }
-
-            // If node is dirty and pagination is enabled, refetch the current page's data
+            // If pagination is enabled, refetch the current page's data
             // to reflect potential changes without changing the page itself.
-
-            // If the page fetch fails, reset the paginator data to take the user back to the first page.
             if (paginate) {
+                if ((!this.paginator || this.paginator.getMaxItemsPerPage() !== this.itemsPerPage) && this.itemsPerPage > 0) {
+                    // Force paginator and data to be re-initialized if fetch function or page size changes, or if pattern changes
+                    this.paginator = new Paginator(this.itemsPerPage, fetchFunction);
+                }
+
                 if (!this.paginator.isInitialized() || this.paginatorData == null) {
                     await this.paginator.initialize();
                 } else {
                     try {
                         await this.paginator.refetchCurrentPage();
                     } catch (error) {
+                        // If the page fetch fails, reset the paginator data to take the user back to the first page.
                         if (error instanceof Error) {
                             ZoweLogger.error(`[ZoweDatasetNode.getDatasets]: Error refetching current page: ${error.message}`);
                         }
-                        if (
-                            (error instanceof imperative.ImperativeError &&
-                                Number(error.mDetails.errorCode) === imperative.RestConstants.HTTP_STATUS_401) ||
-                            error.message.includes("All configured authentication methods failed")
-                        ) {
-                            throw error;
-                        }
                         this.paginatorData = undefined;
+                        // Propagate error to outer try/catch block for error handling
+                        throw error;
                     }
                 }
                 responses.push(...this.paginator.getCurrentPageItems());

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -25,7 +25,7 @@ import { Constants } from "../configuration/Constants";
 import { ZoweLogger } from "../tools/ZoweLogger";
 import { SharedTreeProviders } from "../trees/shared/SharedTreeProviders";
 import { SettingsConfig } from "../configuration/SettingsConfig";
-import type { ZoweDatasetNode } from "../trees/dataset/ZoweDatasetNode";
+import { SharedContext } from "../trees/shared/SharedContext";
 
 interface ErrorContext {
     apiType?: ZoweExplorerApiType;
@@ -352,11 +352,11 @@ export class AuthUtils {
         if (nodeToRefresh) {
             nodeToRefresh.dirty = true;
             const shouldPaginate =
-                nodeToRefresh instanceof ZoweDatasetNode &&
+                SharedContext.isDatasetNode(nodeToRefresh) &&
                 SettingsConfig.getDirectValue<number>(Constants.SETTINGS_DATASETS_PER_PAGE, Constants.DEFAULT_ITEMS_PER_PAGE) > 0;
             void nodeToRefresh
                 .getChildren(shouldPaginate)
-                .then(() => SharedTreeProviders.getProviderForNode(nodeToRefresh).nodeDataChanged?.(nodeToRefresh));
+                .then(() => SharedTreeProviders.getProviderForNode(nodeToRefresh).refreshElement(nodeToRefresh));
         }
     }
 

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -25,7 +25,7 @@ import { Constants } from "../configuration/Constants";
 import { ZoweLogger } from "../tools/ZoweLogger";
 import { SharedTreeProviders } from "../trees/shared/SharedTreeProviders";
 import { SettingsConfig } from "../configuration/SettingsConfig";
-import { ZoweDatasetNode } from "../trees/dataset/ZoweDatasetNode";
+import type { ZoweDatasetNode } from "../trees/dataset/ZoweDatasetNode";
 
 interface ErrorContext {
     apiType?: ZoweExplorerApiType;

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -24,6 +24,8 @@ import {
 import { Constants } from "../configuration/Constants";
 import { ZoweLogger } from "../tools/ZoweLogger";
 import { SharedTreeProviders } from "../trees/shared/SharedTreeProviders";
+import { SettingsConfig } from "../configuration/SettingsConfig";
+import { ZoweDatasetNode } from "../trees/dataset/ZoweDatasetNode";
 
 interface ErrorContext {
     apiType?: ZoweExplorerApiType;
@@ -349,7 +351,12 @@ export class AuthUtils {
         }
         if (nodeToRefresh) {
             nodeToRefresh.dirty = true;
-            void nodeToRefresh.getChildren().then(() => SharedTreeProviders.getProviderForNode(nodeToRefresh).refreshElement(nodeToRefresh));
+            const shouldPaginate =
+                nodeToRefresh instanceof ZoweDatasetNode &&
+                SettingsConfig.getDirectValue<number>(Constants.SETTINGS_DATASETS_PER_PAGE, Constants.DEFAULT_ITEMS_PER_PAGE) > 0;
+            void nodeToRefresh
+                .getChildren(shouldPaginate)
+                .then(() => SharedTreeProviders.getProviderForNode(nodeToRefresh).nodeDataChanged?.(nodeToRefresh));
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Fixes #3807  

### How to test

Enable data set list pagination before trying these steps.

#### Invalid credentials, user updates

- Set invalid credentials on a profile
- Enter in a pattern in the data set filter prompt
- Encounter the auth prompt. Respond "Update Credentials" and enter new creds
- The auth prompt disappears and data sets are listed.

#### Invalid credentials, user cancels

- Set invalid credentials on a profile
- Enter in a pattern in the data set filter prompt
- Encounter the auth prompt. Respond "Cancel"
- The auth prompt disappears and the profile shows "No data sets found".
- Refresh this profile and encounter the same prompt. Select "Cancel." 
- The prompt no longer re-appears until the user enters a new filter or refreshes the profile again. 

## Release Notes

Milestone: 3.3.0 hopefully - if not 3.3.1

Changelog:

Fixed issue where the `getChildren` function made requests repeatedly while the data set filter prompt was open, causing repeated authentication prompts and excessive requests for listing data sets. 

No changelog for ZE API as the change has no impact on consumers/users

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [x] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
