### PR TITLE
ui: Use correct copy text for data sets

### DIFF
--- a/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
@@ -1835,7 +1835,7 @@ export class DatasetActions {
                     await Gui.withProgress(
                         {
                             location: vscode.ProgressLocation.Notification,
-                            title: DatasetActions.localizedStrings.copyingMembers,
+                            title: DatasetActions.localizedStrings.copyingDatasets,
                             cancellable: true,
                         },
                         async () => {
@@ -1867,7 +1867,7 @@ export class DatasetActions {
         await Gui.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
-                title: DatasetActions.localizedStrings.copyingMembers,
+                title: DatasetActions.localizedStrings.copyingDatasets,
                 cancellable: true,
             },
             async (_progress, token) => {
@@ -2069,7 +2069,7 @@ export class DatasetActions {
                 await Gui.withProgress(
                     {
                         location: vscode.ProgressLocation.Notification,
-                        title: DatasetActions.localizedStrings.copyingMembers,
+                        title: DatasetActions.localizedStrings.copyingDatasets,
                         cancellable: true,
                     },
                     () => {
@@ -2095,7 +2095,7 @@ export class DatasetActions {
         await Gui.withProgress(
             {
                 location: vscode.ProgressLocation.Notification,
-                title: DatasetActions.localizedStrings.copyingMembers,
+                title: DatasetActions.localizedStrings.copyingDatasets,
                 cancellable: true,
             },
             async (_progress, token) => {


### PR DESCRIPTION
## Proposed changes

Fixes small UI typo where data set copy text does not reflect the data source when copying data sets.
Context: Initially this said "Copying file(s)" but it felt inaccurate, so it was changed to "Copying member(s)". However the same text was being used for sequential data sets so this popped up while doing a manual review after merge.
Now, it says "Copying data set(s)" when copying PDS or sequential data sets, and "Copying member(s)" for member copy.

### How to test

- Copying sequential data sets should say "Copying data set(s)" instead of "Copying member(s)"
- Copying members is the only operation that should say "Copying member(s)"

## Release Notes

Milestone: 3.4.0

Changelog: No changelog since changes have not been released

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [x] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [x] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
