### PR TITLE
add fix for undefined optional parameter of options in MvsApi.deleteDataset()

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 ### Bug fixes
 
 - Updated Zowe SDKs to `8.29.9` for technical currency. [#4040](https://github.com/zowe/zowe-explorer-vscode/pull/4040)
+- Fixed an issue seen with z/OSMF MvsApi.deleteDataset() when optional parameter options was undefined. [4039](https://github.com/zowe/zowe-explorer-vscode/issues/4039)
 
 ## `3.4.0`
 

--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
@@ -630,6 +630,29 @@ describe("ZosmfMvsApi", () => {
         expect(copySpy).toHaveBeenCalled();
     });
 
+    describe("deleteDataSet with undefined options", () => {
+        it("should call Delete.dataSet and not throw TypeError when options is undefined", async () => {
+            const mvsApi = new ZoweExplorerZosmf.MvsApi(loadedProfile);
+            const deleteDataSetSpy = jest.spyOn(zosfiles.Delete, "dataSet").mockResolvedValue({ success: true });
+            const deleteVsamSpy = jest.spyOn(zosfiles.Delete, "vsam").mockResolvedValue({ success: true });
+
+            deleteDataSetSpy.mockClear();
+            deleteVsamSpy.mockClear();
+
+            expect(async () => {
+                await mvsApi.deleteDataSet("DATASET.NAME", undefined);
+            }).not.toThrow();
+
+            expect(deleteDataSetSpy).toHaveBeenCalled();
+            expect(deleteVsamSpy).not.toHaveBeenCalled();
+            expect(deleteDataSetSpy).toHaveBeenCalledWith(
+                expect.any(Object), // session
+                "DATASET.NAME",
+                expect.objectContaining({ responseTimeout: 60 })
+            );
+        });
+    });
+
     describe("MvsApi.getCount", () => {
         let mvsApi: ZoweExplorerZosmf.MvsApi;
         let dataSetsMatchingPatternSpy: jest.SpyInstance;

--- a/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
+++ b/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
@@ -353,7 +353,7 @@ import { IDataSetCount } from "../dataset/IDataSetCount";
         }
 
         public deleteDataSet(dataSetName: string, options?: zosfiles.IDeleteDatasetOptions): Promise<zosfiles.IZosFilesResponse> {
-            if (options.volume == "*VSAM*") {
+            if (options?.volume === "*VSAM*") {
                 return zosfiles.Delete.vsam(this.getSession(), dataSetName, {
                     responseTimeout: this.profile?.profile?.responseTimeout,
                     ...options,


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

check for existence of the optional parameter, added test case for undefined options scenario

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.4.1

Changelog: Fixed an issue seen with z/OSMF MvsApi.deleteDataset() when optional parameter options was undefined. [4039](https://github.com/zowe/zowe-explorer-vscode/issues/4039)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
