### PR TITLE
Add verify lock file script and package.json script to call

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "clean": "pnpm -r clean",
     "fresh-clone": "pnpm -r --parallel fresh-clone && (rimraf node_modules || true)",
     "prepare": "husky install",
+    "verify:lockfile-config": "node scripts/verifyPnpmLockfileConfig.mjs",
     "lint": "pnpm -r lint",
     "lint:html": "pnpm -r lint:html",
     "madge": "pnpm -r madge",

--- a/scripts/verifyPnpmLockfileConfig.mjs
+++ b/scripts/verifyPnpmLockfileConfig.mjs
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const LOCKFILE_PATH = "pnpm-lock.yaml";
+const PACKAGE_JSON_PATH = "package.json";
+
+function parseSimpleValue(value) {
+  if (value === "true") {
+    return true;
+  }
+
+  if (value === "false") {
+    return false;
+  }
+
+  return value;
+}
+
+function parseLockfileSections(lockfileContent) {
+  const lines = lockfileContent.split(/\r?\n/);
+  const settings = {};
+  const overrides = {};
+  let section = "";
+
+  for (const line of lines) {
+    const topLevelMatch = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*$/);
+    if (topLevelMatch) {
+      section = topLevelMatch[1];
+      if (section === "importers") {
+        break;
+      }
+      continue;
+    }
+
+    if (section === "settings") {
+      const match = line.match(/^  ([^:]+):\s*(.*)$/);
+      if (match) {
+        settings[match[1].trim()] = parseSimpleValue(match[2].trim());
+      }
+      continue;
+    }
+
+    if (section === "overrides") {
+      const match = line.match(/^  ([^:]+):\s*(.*)$/);
+      if (match) {
+        overrides[match[1].trim()] = match[2].trim();
+      }
+    }
+  }
+
+  return { settings, overrides };
+}
+
+function getProjectPnpmConfig() {
+  const output = execFileSync("pnpm", ["config", "list", "--location", "project", "--json"], {
+    encoding: "utf8",
+  });
+
+  return JSON.parse(output);
+}
+
+function readEffectiveBooleanConfig(config, envKey, fallbackValue, keys) {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(config, key) && config[key] !== undefined) {
+      return parseSimpleValue(String(config[key]));
+    }
+  }
+
+  if (process.env[envKey] !== undefined) {
+    return parseSimpleValue(String(process.env[envKey]));
+  }
+
+  const lowercaseEnvKey = envKey.toLowerCase();
+  if (process.env[lowercaseEnvKey] !== undefined) {
+    return parseSimpleValue(String(process.env[lowercaseEnvKey]));
+  }
+
+  return fallbackValue;
+}
+
+function compareOverrides(packageOverrides, lockfileOverrides) {
+  const mismatches = [];
+  const keys = [...new Set([...Object.keys(packageOverrides), ...Object.keys(lockfileOverrides)])].sort();
+
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(packageOverrides, key)) {
+      mismatches.push(`missing in package.json: ${key}=${lockfileOverrides[key]}`);
+      continue;
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(lockfileOverrides, key)) {
+      mismatches.push(`missing in pnpm-lock.yaml: ${key}=${packageOverrides[key]}`);
+      continue;
+    }
+
+    if (String(packageOverrides[key]) !== String(lockfileOverrides[key])) {
+      mismatches.push(
+        `override mismatch ${key}: package.json=${packageOverrides[key]} pnpm-lock.yaml=${lockfileOverrides[key]}`,
+      );
+    }
+  }
+
+  return mismatches;
+}
+
+function main() {
+  const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, "utf8"));
+  const lockfileContent = fs.readFileSync(LOCKFILE_PATH, "utf8");
+  const { settings: lockfileSettings, overrides: lockfileOverrides } = parseLockfileSections(lockfileContent);
+  const packageOverrides = packageJson?.pnpm?.overrides ?? {};
+  const projectConfig = getProjectPnpmConfig();
+
+  const effectiveAutoInstallPeers = readEffectiveBooleanConfig(
+    projectConfig,
+    "NPM_CONFIG_AUTO_INSTALL_PEERS",
+    true,
+    ["auto-install-peers", "autoInstallPeers"],
+  );
+  const effectiveExcludeLinksFromLockfile = readEffectiveBooleanConfig(
+    projectConfig,
+    "NPM_CONFIG_EXCLUDE_LINKS_FROM_LOCKFILE",
+    false,
+    ["exclude-links-from-lockfile", "excludeLinksFromLockfile"],
+  );
+
+  const mismatches = [];
+  mismatches.push(...compareOverrides(packageOverrides, lockfileOverrides));
+
+  if (Object.prototype.hasOwnProperty.call(lockfileSettings, "autoInstallPeers")) {
+    if (Boolean(lockfileSettings.autoInstallPeers) !== Boolean(effectiveAutoInstallPeers)) {
+      mismatches.push(
+        `settings mismatch autoInstallPeers: pnpm-lock.yaml=${lockfileSettings.autoInstallPeers} effective=${effectiveAutoInstallPeers}`,
+      );
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(lockfileSettings, "excludeLinksFromLockfile")) {
+    if (Boolean(lockfileSettings.excludeLinksFromLockfile) !== Boolean(effectiveExcludeLinksFromLockfile)) {
+      mismatches.push(
+        `settings mismatch excludeLinksFromLockfile: pnpm-lock.yaml=${lockfileSettings.excludeLinksFromLockfile} effective=${effectiveExcludeLinksFromLockfile}`,
+      );
+    }
+  }
+
+  console.log(`lockfile override keys: ${Object.keys(lockfileOverrides).length}`);
+  console.log(`package override keys: ${Object.keys(packageOverrides).length}`);
+  console.log(`effective autoInstallPeers: ${effectiveAutoInstallPeers}`);
+  console.log(`effective excludeLinksFromLockfile: ${effectiveExcludeLinksFromLockfile}`);
+
+  if (mismatches.length > 0) {
+    console.error("\nPNPM LOCKFILE CONFIG MISMATCH");
+    console.error(mismatches.join("\n"));
+    process.exit(2);
+  }
+
+  console.log("\npnpm lockfile config OK");
+}
+
+main();


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

Implemented

- Added a reusable verifier script: [verifyPnpmLockfileConfig.mjs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Wired root script in [package.json:77-83](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): verify:lockfile-config → node [verifyPnpmLockfileConfig.mjs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Ran locally on release/3.4: passes with pnpm lockfile config OK.

What it checks

- Compares pnpm.overrides in [package.json:63-70](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) vs overrides in [pnpm-lock.yaml:7-13](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Compares lockfile settings in [pnpm-lock.yaml:3-5](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) against effective project/env config for autoInstallPeers and excludeLinksFromLockfile.
- Exits non-zero with detailed mismatch lines if drift is detected.

CI usage

Add this before install:
- corepack enable
- corepack prepare [pnpm@10.17.1](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) --activate
- pnpm --version (must print 10.17.1)
- pnpm run verify:lockfile-config
- pnpm install --ignore-pnpmfile --ignore-scripts --frozen-lockfile --shamefully-hoist


## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
