### PR TITLE
Fix 401 retry loop and extender init race conditions

### DIFF
--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -816,6 +816,17 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
      * - `overwrite` - Overwrites the content if the data set exists
      */
     public async writeFile(uri: vscode.Uri, content: Uint8Array, options: { readonly create: boolean; readonly overwrite: boolean }): Promise<void> {
+        const uriInfo = FsAbstractUtils.getInfoForUri(uri, Profiles.getInstance());
+        return AuthUtils.retryRequest(uriInfo.profile, async () => {
+            await this.writeFileImplementation(uri, content, options);
+        });
+    }
+
+    private async writeFileImplementation(
+        uri: vscode.Uri,
+        content: Uint8Array,
+        options: { readonly create: boolean; readonly overwrite: boolean }
+    ): Promise<void> {
         const basename = path.posix.basename(uri.path);
         const parent = this.lookupParentDirectory(uri);
         const isPdsMember = FsDatasetsUtils.isPdsEntry(parent);
@@ -898,6 +909,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                         groupedLines.push({ start: line, end: line, text: text as string });
                     }
                 }
+
                 const rangeStrings = groupedLines.map((g) => (g.start === g.end ? `${g.start}` : `${g.start}-${g.end}`));
                 const maxRanges = 5;
                 const linesToReview = rangeStrings.length > maxRanges ? rangeStrings.slice(0, maxRanges).join(", ") + "..." : rangeStrings.join(", ");
@@ -950,6 +962,14 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
     }
 
     public async delete(uri: vscode.Uri, _options: { readonly recursive: boolean }): Promise<void> {
+        const uriInfo = FsAbstractUtils.getInfoForUri(uri, Profiles.getInstance());
+        return AuthUtils.retryRequest(uriInfo.profile, async () => {
+            await this.deleteImplementation(uri, _options);
+        });
+    }
+
+    private async deleteImplementation(uri: vscode.Uri, _options: { readonly recursive: boolean }): Promise<void> {
+        await ProfilesUtils.awaitExtenderType(uri, Profiles.getInstance());
         const entry = this.lookup(uri, false) as DsEntry | PdsEntry;
         const parent = this.lookupParentDirectory(uri);
         let fullName: string = "";

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -669,16 +669,14 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
 
         let resp: IZosFilesResponse;
         try {
-            await AuthUtils.retryRequest(entry.metadata.profile, async () => {
-                await this.autoDetectEncoding(entry);
-                const profileEncoding = entry.encoding ? null : profile.profile?.encoding; // use profile encoding rather than metadata encoding
+            await this.autoDetectEncoding(entry);
+            const profileEncoding = entry.encoding ? null : profile.profile?.encoding; // use profile encoding rather than metadata encoding
 
-                resp = await ussApi.uploadFromBuffer(Buffer.from(content), entry.metadata.path, {
-                    binary: entry.encoding?.kind === "binary",
-                    encoding: entry.encoding?.kind === "other" ? entry.encoding.codepage : profileEncoding,
-                    etag: options?.forceUpload || entry.etag == null ? undefined : entry.etag,
-                    returnEtag: true,
-                });
+            resp = await ussApi.uploadFromBuffer(Buffer.from(content), entry.metadata.path, {
+                binary: entry.encoding?.kind === "binary",
+                encoding: entry.encoding?.kind === "other" ? entry.encoding.codepage : profileEncoding,
+                etag: options?.forceUpload || entry.etag == null ? undefined : entry.etag,
+                returnEtag: true,
             });
         } catch (err) {
             statusMsg.dispose();
@@ -698,6 +696,17 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
      * - `overwrite` - Overwrites the content if the file exists
      */
     public async writeFile(
+        uri: vscode.Uri,
+        content: Uint8Array,
+        options: { create: boolean; overwrite: boolean; noStatusMsg?: boolean }
+    ): Promise<void> {
+        const uriInfo = FsAbstractUtils.getInfoForUri(uri, Profiles.getInstance());
+        return AuthUtils.retryRequest(uriInfo.profile, async () => {
+            await this.writeFileImplementation(uri, content, options);
+        });
+    }
+
+    private async writeFileImplementation(
         uri: vscode.Uri,
         content: Uint8Array,
         options: { create: boolean; overwrite: boolean; noStatusMsg?: boolean }


### PR DESCRIPTION
### Bug Summary

Fixes an issue where file write and delete operations in DatasetFSProvider and UssFSProvider failed to properly recover from expired sessions. When a user’s authentication token expired (HTTP 401), the extension showed a retry prompt but did not trigger re-authentication, causing repeated failures and trapping users in a retry loop. This made it impossible to save changes or manage resources until the extension was reloaded.

### Fix Summary

This PR integrates AuthUtils.retryRequest into write and delete operations to ensure proper authentication recovery. It also ensures extender types are initialized before resolving profile information, preventing race conditions during activation. Additionally, redundant nested retry logic in USS operations has been removed to streamline execution and avoid duplicate prompts.

### Impact

This change restores a reliable save and delete workflow by handling session expiration transparently. Users are now prompted to re-authenticate when needed, and operations automatically retry and complete successfully. This prevents workflow interruptions, eliminates infinite retry loops, and reduces the risk of data loss in enterprise environments.
