### PR TITLE
fix deadlock in errorHandling on cancelled authentication

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/utils/AuthUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/utils/AuthUtils.unit.test.ts
@@ -1306,17 +1306,20 @@ describe("AuthUtils", () => {
                 errorCode: "401",
                 additionalDetails: "\nAuth order: token,basic\nAuth type: token\nAvailable creds: token,basic\n",
             });
-            const promptForAuthenticationMock = jest.spyOn(AuthHandler, "promptForAuthentication").mockResolvedValue(true);
+            const getOrCreateAuthFlowMock = jest.spyOn(AuthHandler, "getOrCreateAuthFlow").mockResolvedValue();
+            const wasAuthCancelledMock = jest.spyOn(AuthHandler, "wasAuthCancelled").mockReturnValue(false);
             const moreInfo = {
                 profile: "testProfile",
                 apiType: ZoweExplorerApiType.Mvs,
             };
             await expect(AuthUtils.errorHandling(testError, moreInfo)).resolves.toBe(true);
-            expect(promptForAuthenticationMock.mock.calls[0][1]).toEqual(
+            expect(getOrCreateAuthFlowMock.mock.calls[0][1]).toEqual(
                 expect.objectContaining({
                     imperativeError: testError,
                 })
             );
+            getOrCreateAuthFlowMock.mockRestore();
+            wasAuthCancelledMock.mockRestore();
         });
     });
 });

--- a/packages/zowe-explorer/src/utils/AuthUtils.ts
+++ b/packages/zowe-explorer/src/utils/AuthUtils.ts
@@ -171,9 +171,6 @@ export class AuthUtils {
                 (httpErrorCode === imperative.RestConstants.HTTP_STATUS_401 ||
                     imperativeError.message.includes("All configured authentication methods failed"))
             ) {
-                if (!AuthHandler.isProfileLocked(profile)) {
-                    await AuthHandler.lockProfile(profile);
-                }
                 const addDet = imperativeError.mDetails.additionalDetails;
                 if (addDet?.includes("Auth order:") && addDet?.includes("Auth type:") && addDet?.includes("Available creds:")) {
                     const additionalDetails = [addDet.split("\n")[0]];
@@ -202,7 +199,7 @@ export class AuthUtils {
                 }
 
                 const sessTypeFromProf = AuthHandler.sessTypeFromProfile(profile);
-                return await AuthHandler.promptForAuthentication(profile, {
+                await AuthHandler.getOrCreateAuthFlow(profile, {
                     authMethods: Constants.PROFILES_CACHE,
                     imperativeError,
                     isUsingTokenAuth:
@@ -210,6 +207,7 @@ export class AuthUtils {
                         sessTypeFromProf === imperative.SessConstants.AUTH_TYPE_BEARER,
                     errorCorrelation,
                 });
+                return !AuthHandler.wasAuthCancelled(profile);
             }
         }
         if (errorDetails.toString().includes("Could not find profile")) {


### PR DESCRIPTION

##  Bug Summary

**Title:** Deadlock in profile operations after cancelling authentication prompt

When handling `401 Unauthorized` errors in `errorHandling`, the code manually locks a profile using `AuthHandler.lockProfile(profile)` before triggering the authentication UI via `promptForAuthentication`.

However, if the user cancels the authentication prompt (e.g., presses Escape or dismisses the modal), the function exits early and **never releases the lock**. As a result, all subsequent operations for that profile block indefinitely because they are waiting on `AuthHandler.waitForUnlock(profile)`.

###  Impact

This leads to a **silent, permanent deadlock** for the affected profile within the current VS Code session:

- Dataset refresh, file open, and job views stop working
- UI appears responsive, but operations hang with a loading spinner
- Users must restart VS Code to recover
- Especially severe because it occurs during error handling (critical reliability path)

---

##  Root Cause

The issue stems from **manual lock management without guaranteed release**:

- Lock is acquired before authentication prompt
- Unlock only happens on successful authentication
- Cancellation path skips unlock → leaves profile in locked state

This creates a **state inconsistency and resource leak (lock not released)**.

---

##  Fix Summary

Refactored `errorHandling` to use:

```ts
AuthHandler.getOrCreateAuthFlow(profile, authOpts)