### PR TITLE
Fix 4050: Editor UI does not update when sequential dataset is deleted

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where focus was lost on a previously selected tree item after opening a Zowe resource (Data set, USS file, or Job) in the editor and closing it using `Ctrl+W`. Screen readers will now announce when focus is restored. [#4025](https://github.com/zowe/zowe-explorer-vscode/issues/4025)
 - Fixed an issue where loading profiles could wrongly assume token authentication if parent profile defines multiple auth types. [#4105](https://github.com/zowe/zowe-explorer-vscode/issues/4105)
 - Fixed an issue where the USS tree collapsed down to the top level set from the initial filter.[#3932](https://github.com/zowe/zowe-explorer-vscode/issues/3932)
+- Fixed an issue where the editor tab remained open after deleting a sequential data set. The editor now automatically closes when the data set is deleted. [#4050](https://github.com/zowe/zowe-explorer-vscode/issues/4050)
 
 ## `3.4.2`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
@@ -24,6 +24,7 @@ import {
     MainframeInteraction,
 } from "@zowe/zowe-explorer-api";
 import { DatasetFSProvider } from "../../../../src/trees/dataset/DatasetFSProvider";
+import { Workspace } from "../../../../src/configuration/Workspace";
 import { bindMvsApi, createMvsApi } from "../../../__mocks__/mockCreators/api";
 import {
     createSessCfgFromArgs,
@@ -811,6 +812,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks();
         mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        const closeTextFileSpy = jest.spyOn(Workspace, "closeOpenedTextFile").mockResolvedValue(true);
         const node = new ZoweDatasetNode({
             label: "HLQ.TEST.NODE",
             collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -820,6 +822,7 @@ describe("Dataset Actions Unit Tests - Function deleteDataset", () => {
 
         await DatasetActions.deleteDataset(node, blockMocks.testDatasetTree);
         expect(globalMocks.fspDelete).toHaveBeenCalledWith(node.resourceUri, { recursive: false });
+        expect(closeTextFileSpy).toHaveBeenCalledWith(node.resourceUri.path);
     });
     it("Checking common PS dataset deletion with Unverified profile", async () => {
         createGlobalMocks();

--- a/packages/zowe-explorer/src/configuration/Workspace.ts
+++ b/packages/zowe-explorer/src/configuration/Workspace.ts
@@ -84,7 +84,7 @@ export class Workspace {
             selectedEditor = vscode.window.activeTextEditor as IExtTextEditor;
         }
 
-        return openedWindows.some((window) => window.document.fileName === path);
+        return openedWindows.some((window) => window.document.fileName === path || window.document.uri?.path === path);
     }
 
     /**
@@ -114,7 +114,7 @@ export class Workspace {
             await Workspace.openNextTab(Constants.WORKSPACE_UTIL_TAB_SWITCH_DELAY);
             selectedEditor = vscode.window.activeTextEditor as IExtTextEditor;
 
-            if (selectedEditor && selectedEditor.document.fileName === path) {
+            if (selectedEditor && (selectedEditor.document.fileName === path || selectedEditor.document.uri?.path === path)) {
                 const isDirty = selectedEditor.document.isDirty;
                 await vscode.commands.executeCommand("workbench.action.closeActiveEditor");
                 if (isDirty) {

--- a/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
@@ -48,6 +48,7 @@ import { SharedTreeProviders } from "../shared/SharedTreeProviders";
 import { DatasetTree } from "./DatasetTree";
 import { SettingsConfig } from "../../configuration/SettingsConfig";
 import { ZoweLocalStorage } from "../../tools/ZoweLocalStorage";
+import { Workspace } from "../../configuration/Workspace";
 
 type ClipboardItem = {
     profileName: string;
@@ -2086,6 +2087,11 @@ export class DatasetActions {
         }
 
         datasetProvider.refreshElement(node.getSessionNode());
+
+        // Close the editor if the deleted dataset is open
+        if (node.resourceUri) {
+            await Workspace.closeOpenedTextFile(node.resourceUri.path);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix for #4050 Editor UI does not update when sequential dataset is deleted

This pull request improves the handling of dataset deletions in Zowe Explorer, ensuring that any open text editors associated with a deleted dataset are properly closed. It also enhances the logic for detecting open files by considering both file names and URI paths, making the extension more robust in various file access scenarios. The most important changes are grouped below:

**Dataset Deletion and Editor Management:**

* When a dataset is deleted via `DatasetActions.deleteDataset`, the code now ensures that any open text editor for the deleted dataset is closed by calling `Workspace.closeOpenedTextFile` with the dataset's path.

* The `Workspace` class's logic for detecting and closing open editors has been updated to check both `document.fileName` and `document.uri.path`, improving reliability when matching open files to paths. [[1]](diffhunk://#diff-05884e48859eeadfa847e63245cb9c42c5352ae88340d77deb2ea67960e63c23L87-R87) [[2]](diffhunk://#diff-05884e48859eeadfa847e63245cb9c42c5352ae88340d77deb2ea67960e63c23L117-R117)

**Testing Enhancements:**

* Unit tests for dataset deletion now mock and verify that `Workspace.closeOpenedTextFile` is called when a dataset is deleted, ensuring the new behavior is tested. [[1]](diffhunk://#diff-d672f8df98be12e26276a784b19729a0742af92e1b8366c318edaa5bd47bd35aR27) [[2]](diffhunk://#diff-d672f8df98be12e26276a784b19729a0742af92e1b8366c318edaa5bd47bd35aR815) [[3]](diffhunk://#diff-d672f8df98be12e26276a784b19729a0742af92e1b8366c318edaa5bd47bd35aR825)

**Imports and Dependencies:**

* Added necessary imports of `Workspace` in both the implementation and test files to support the new functionality. [[1]](diffhunk://#diff-293ee7a479c1abea85ca2e9a7f9d75b84f34d38ed264a860681587d22775ef7bR51) [[2]](diffhunk://#diff-d672f8df98be12e26276a784b19729a0742af92e1b8366c318edaa5bd47bd35aR27)

![Recording 2026-04-07 165002](https://github.com/user-attachments/assets/60cfdae9-1698-438d-99a7-f93cf5f29b5f)


## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [x] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [x] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
I coded this using AI, kindly review. 
Also, do I need documentation?