### PR TITLE
chore: update basic-ftp override to fix new vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
       "@tootallnate/once": "^3.0.1",
       "ajv@6": "^6.14.0",
       "ajv@8": "^8.18.0",
-      "basic-ftp@5": "^5.2.0",
+      "basic-ftp@5": "^5.2.1",
       "diff@5": "^5.2.2",
       "diff@>5": "^8.0.3",
       "fast-xml-parser": "^5.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@tootallnate/once': ^3.0.1
   ajv@6: ^6.14.0
   ajv@8: ^8.18.0
-  basic-ftp@5: ^5.2.0
+  basic-ftp@5: ^5.2.1
   diff@5: ^5.2.2
   diff@>5: ^8.0.3
   fast-xml-parser: ^5.5.7
@@ -271,7 +271,7 @@ importers:
         version: 19.0.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.19.39)(typescript@5.9.3)
+        version: 10.9.2(@types/node@22.15.34)(typescript@5.9.3)
       wdio-vscode-service:
         specifier: ^6.1.3
         version: 6.1.3(webdriverio@8.43.0(encoding@0.1.13))
@@ -1747,9 +1747,6 @@ packages:
   '@types/node@20.19.33':
     resolution: {integrity: sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==}
 
-  '@types/node@20.19.39':
-    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
-
   '@types/node@22.14.0':
     resolution: {integrity: sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==}
 
@@ -2573,8 +2570,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.2.1:
+    resolution: {integrity: sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==}
     engines: {node: '>=10.0.0'}
 
   bcrypt-pbkdf@1.0.2:
@@ -8952,10 +8949,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@20.19.39':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.14.0':
     dependencies:
       undici-types: 6.21.0
@@ -10119,7 +10112,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.2.1: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -11799,7 +11792,7 @@ snapshots:
 
   get-uri@6.0.3:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.2.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
       fs-extra: 11.3.4
@@ -15075,14 +15068,14 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@22.15.34)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.39
+      '@types/node': 22.15.34
       acorn: 8.11.3
       acorn-walk: 8.3.2
       arg: 4.1.3


### PR DESCRIPTION
## Proposed changes

Updates `basic-ftp` override to `5.2.1` to resolve new vulnerability: ["basic-ftp has FTP command injection via CRLF"](https://github.com/zowe/zowe-explorer-vscode/security/dependabot/277)

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Other (please specify above in "Proposed changes" section)