### PR TITLE
fix(audit): use workaround for pnpm audit in CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,6 +21,7 @@ jobs:
           npm install -g pnpm
           pnpm install
 
+      # https://github.com/pnpm/pnpm/issues/11265#issuecomment-4258309621 Can change back to pnpm audit once pnpm 11.0.0 is released
       - name: Check Vulnerabilities
         run: pnpm dlx --config.minimumReleaseAge=0 pnpm@11.0.0-rc.1 --config.manage-package-manager-versions=false audit --prod
   audit-all:
@@ -36,5 +37,6 @@ jobs:
       - run: |
           npm install -g pnpm
           pnpm install
+      # https://github.com/pnpm/pnpm/issues/11265#issuecomment-4258309621 Can change back to pnpm audit once pnpm 11.0.0 is released
       - name: Check All Vulnerabilities (including dev)
         run: pnpm dlx --config.minimumReleaseAge=0 pnpm@11.0.0-rc.1 --config.manage-package-manager-versions=false audit --audit-level high

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,7 +22,7 @@ jobs:
           pnpm install
 
       - name: Check Vulnerabilities
-        run: pnpm audit --prod
+        run: pnpm dlx --config.minimumReleaseAge=0 pnpm@11.0.0-rc.1 --config.manage-package-manager-versions=false audit --prod
   audit-all:
     runs-on: ubuntu-22.04
     continue-on-error: true
@@ -37,4 +37,4 @@ jobs:
           npm install -g pnpm
           pnpm install
       - name: Check All Vulnerabilities (including dev)
-        run: pnpm audit --audit-level high
+        run: pnpm dlx --config.minimumReleaseAge=0 pnpm@11.0.0-rc.1 --config.manage-package-manager-versions=false audit --audit-level high

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "diff@5": "^5.2.2",
       "diff@>5": "^8.0.3",
       "fast-xml-parser": "^5.5.7",
-      "fastify": "^5.8.1",
+      "fastify": "^5.8.5",
       "file-type": "^21.3.1",
       "flatted": "^3.4.2",
       "js-yaml": "^4.1.1",

--- a/packages/zowe-explorer/src/webviews/package.json
+++ b/packages/zowe-explorer/src/webviews/package.json
@@ -25,7 +25,7 @@
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "ag-grid-community": "^34.0.0",
     "ag-grid-react": "^34.0.0",
-    "dompurify": "^3.3.2",
+    "dompurify": "^3.3.4",
     "es-toolkit": "^1.16.0",
     "marked": "^15.0.11",
     "preact": "^10.16.0",

--- a/packages/zowe-explorer/src/webviews/package.json
+++ b/packages/zowe-explorer/src/webviews/package.json
@@ -25,7 +25,7 @@
     "@vscode/webview-ui-toolkit": "^1.2.2",
     "ag-grid-community": "^34.0.0",
     "ag-grid-react": "^34.0.0",
-    "dompurify": "^3.3.4",
+    "dompurify": "^3.3.2",
     "es-toolkit": "^1.16.0",
     "marked": "^15.0.11",
     "preact": "^10.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   diff@5: ^5.2.2
   diff@>5: ^8.0.3
   fast-xml-parser: ^5.5.7
-  fastify: ^5.8.1
+  fastify: ^5.8.5
   file-type: ^21.3.1
   flatted: ^3.4.2
   js-yaml: ^4.1.1
@@ -3701,8 +3701,8 @@ packages:
   fastify-plugin@4.5.1:
     resolution: {integrity: sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==}
 
-  fastify@5.8.4:
-    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -11449,7 +11449,7 @@ snapshots:
 
   fastify-plugin@4.5.1: {}
 
-  fastify@5.8.4:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0
@@ -15386,7 +15386,7 @@ snapshots:
       '@xhmikosr/downloader': 15.0.1
       clipboardy: 3.0.0
       decamelize: 6.0.0
-      fastify: 5.8.4
+      fastify: 5.8.5
       get-port: 7.0.0
       hpagent: 1.2.0
       slash: 5.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,8 +373,8 @@ importers:
         specifier: ^34.0.0
         version: 34.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       dompurify:
-        specifier: ^3.3.2
-        version: 3.3.3
+        specifier: ^3.3.4
+        version: 3.4.0
       es-toolkit:
         specifier: ^1.16.0
         version: 1.16.0
@@ -3307,8 +3307,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.3:
-    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
@@ -10842,7 +10842,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.3:
+  dompurify@3.4.0:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,8 +373,8 @@ importers:
         specifier: ^34.0.0
         version: 34.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       dompurify:
-        specifier: ^3.3.4
-        version: 3.4.0
+        specifier: ^3.3.2
+        version: 3.3.3
       es-toolkit:
         specifier: ^1.16.0
         version: 1.16.0
@@ -3307,8 +3307,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.0:
-    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
@@ -10842,7 +10842,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.0:
+  dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
## Proposed changes

- Uses workaround suggested in https://github.com/pnpm/pnpm/issues/11265 to allow audit to succeed in CI, without upgrading to pnpm 11 (as its still an RC)
- Fixes dompurify vulnerability by updating expected version range to ^3.3.4

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [x] Other (please specify above in "Proposed changes" section)

## Checklist

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes