### PR TITLE
fix(ds): inconsistent filtering w/ complex patterns

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where the USS tree collapsed down to the top level set from the initial filter.[#3932](https://github.com/zowe/zowe-explorer-vscode/issues/3932)
 - Fixed an issue where the editor tab remained open after deleting a sequential data set. The editor now automatically closes when the data set is deleted. [#4050](https://github.com/zowe/zowe-explorer-vscode/issues/4050)
 - Fixed extended to include PDS members and USS files. [#4050](https://github.com/zowe/zowe-explorer-vscode/issues/4050)
+- Fixed an issue where complex data set filters with member patterns (such as `HLQ.A(MEM*),HLQ.B(MEM2)`) produced incorrect results: member filters could be applied to the wrong PDS, multiple filters targeting the same PDS were not combined, and unrelated prefix-matched data sets returned by the MVS API leaked into the tree. [#3424](https://github.com/zowe/zowe-explorer-vscode/issues/3424)
 
 ## `3.4.2`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
@@ -6934,6 +6934,32 @@ describe("Dataset Tree Unit Tests - Function applyPatternsToChildren", () => {
             withProfileMock.mockRestore();
         });
 
+        it("ignores whitespace after commas in the user filter input", () => {
+            const testTree = new DatasetTree();
+            const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+            const fakeChildren = [{ label: "Z02589.JCL", contextValue: Constants.DS_PDS_CONTEXT }];
+            // Spaces after commas previously leaked into the captured dsn and broke strict matching.
+            const patterns = testTree.extractPatterns("Z02589.JCL(BLAH*), Z02589.JCL(TEST*)");
+            testTree.applyPatternsToChildren(fakeChildren as any[], patterns);
+
+            expect(fakeChildren).toHaveLength(1);
+            expect((fakeChildren[0] as any).memberPattern).toBe("BLAH*,TEST*");
+            withProfileMock.mockRestore();
+        });
+
+        it("matches PDSs containing single-character qualifiers", () => {
+            const testTree = new DatasetTree();
+            const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+            // `checkFilterPattern` only matches non-wildcard qualifiers >= 3 chars; the fix must compare these directly.
+            const fakeChildren = [{ label: "HLQ.A.SOURCE", contextValue: Constants.DS_PDS_CONTEXT }];
+            const patterns = testTree.extractPatterns("HLQ.A.SOURCE(MEM*)");
+            testTree.applyPatternsToChildren(fakeChildren as any[], patterns);
+
+            expect(fakeChildren).toHaveLength(1);
+            expect((fakeChildren[0] as any).memberPattern).toBe("MEM*");
+            withProfileMock.mockRestore();
+        });
+
         it("skips NavigationTreeItem and 'No data sets found' placeholder children", () => {
             const testTree = new DatasetTree();
             const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
@@ -6851,6 +6851,147 @@ describe("Dataset Tree Unit Tests - Function applyPatternsToChildren", () => {
         expect(fakeChildren[0].contextValue).not.toContain(Constants.FAV_SUFFIX);
         withProfileMock.mockRestore();
     });
+
+    // Regression coverage for https://github.com/zowe/zowe-explorer-vscode/issues/3424
+    describe("issue #3424 - complex member filter scenarios", () => {
+        it("applies the correct member pattern to each PDS when multiple comma-separated filters are provided", () => {
+            const testTree = new DatasetTree();
+            const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+            const fakeChildren = [
+                { label: "HLQ.USERID2.SOURCE", contextValue: Constants.DS_PDS_CONTEXT },
+                { label: "HLQ.USERID1.SOURCE", contextValue: Constants.DS_PDS_CONTEXT },
+            ];
+            const patterns = testTree.extractPatterns("HLQ.USERID2.SOURCE(R80297*),HLQ.USERID1.SOURCE(R80297O1)");
+            testTree.applyPatternsToChildren(fakeChildren as any[], patterns);
+
+            expect(fakeChildren[0].label).toBe("HLQ.USERID2.SOURCE");
+            expect((fakeChildren[0] as any).memberPattern).toBe("R80297*");
+            expect(SharedContext.isFilterFolder(fakeChildren[0])).toBe(true);
+
+            expect(fakeChildren[1].label).toBe("HLQ.USERID1.SOURCE");
+            expect((fakeChildren[1] as any).memberPattern).toBe("R80297O1");
+            expect(SharedContext.isFilterFolder(fakeChildren[1])).toBe(true);
+            withProfileMock.mockRestore();
+        });
+
+        it("removes PDS children that match no user pattern when explicit member filters are provided", () => {
+            const testTree = new DatasetTree();
+            const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+            const fakeChildren = [{ label: "HLQ.USERID1.SOURCE.FINAL", contextValue: Constants.DS_PDS_CONTEXT }];
+            const patterns = testTree.extractPatterns("HLQ.USERID2.SOURCE(R80297*),HLQ.USERID1.SOURCE(R80297O1)");
+            testTree.applyPatternsToChildren(fakeChildren as any[], patterns);
+
+            expect(fakeChildren).toHaveLength(0);
+            withProfileMock.mockRestore();
+        });
+
+        it("merges member patterns when multiple filters target the same PDS", () => {
+            const testTree = new DatasetTree();
+            const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+            const fakeChildren = [
+                { label: "HLQ.USERID2.SOURCE", contextValue: Constants.DS_PDS_CONTEXT },
+                { label: "HLQ.USERID1.SOURCE", contextValue: Constants.DS_PDS_CONTEXT },
+            ];
+            const patterns = testTree.extractPatterns("HLQ.USERID2.SOURCE(R80297B2),HLQ.USERID2.SOURCE(EX1),HLQ.USERID1.SOURCE(R80297O1)");
+            testTree.applyPatternsToChildren(fakeChildren as any[], patterns);
+
+            expect((fakeChildren[0] as any).memberPattern).toBe("R80297B2,EX1");
+            expect((fakeChildren[1] as any).memberPattern).toBe("R80297O1");
+            expect(SharedContext.isFilterFolder(fakeChildren[0])).toBe(true);
+            expect(SharedContext.isFilterFolder(fakeChildren[1])).toBe(true);
+            withProfileMock.mockRestore();
+        });
+
+        it("does not mutate child.pattern as a side effect of pattern matching", () => {
+            const testTree = new DatasetTree();
+            const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+            const fakeChildren = [
+                { label: "HLQ.USERID1.SOURCE", contextValue: Constants.DS_PDS_CONTEXT, pattern: "" },
+                { label: "HLQ.USERID2.SOURCE", contextValue: Constants.DS_PDS_CONTEXT, pattern: "" },
+            ];
+            const patterns = testTree.extractPatterns("HLQ.USERID2.SOURCE(R80297*),HLQ.USERID1.SOURCE(R80297O1)");
+            testTree.applyPatternsToChildren(fakeChildren as any[], patterns);
+
+            expect((fakeChildren[0] as any).pattern).toBe("");
+            expect((fakeChildren[1] as any).pattern).toBe("");
+            expect((fakeChildren[0] as any).memberPattern).toBe("R80297O1");
+            expect((fakeChildren[1] as any).memberPattern).toBe("R80297*");
+            withProfileMock.mockRestore();
+        });
+
+        it("keeps unrelated PDSs when no parenthesized member filters are provided", () => {
+            const testTree = new DatasetTree();
+            const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+            const fakeChildren = [
+                { label: "HLQ.USERID1.SOURCE.FINAL", contextValue: Constants.DS_PDS_CONTEXT },
+                { label: "HLQ.USERID1.OTHER", contextValue: Constants.DS_PDS_CONTEXT },
+            ];
+            testTree.applyPatternsToChildren(fakeChildren as any[], [{ dsn: "HLQ.USERID1.*" }]);
+
+            expect(fakeChildren).toHaveLength(2);
+            expect((fakeChildren[0] as any).memberPattern).toBeUndefined();
+            expect((fakeChildren[1] as any).memberPattern).toBeUndefined();
+            withProfileMock.mockRestore();
+        });
+
+        it("skips NavigationTreeItem and 'No data sets found' placeholder children", () => {
+            const testTree = new DatasetTree();
+            const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+            const navItem = new NavigationTreeItem("Next page", "arrow-right", false, "zowe.dummyCommand", jest.fn());
+            const noDataPlaceholder = { label: vscode.l10n.t("No data sets found"), contextValue: Constants.INFORMATION_CONTEXT };
+            const matchingPds = { label: "HLQ.USERID2.SOURCE", contextValue: Constants.DS_PDS_CONTEXT };
+            const fakeChildren = [navItem, noDataPlaceholder, matchingPds] as any[];
+            const patterns = testTree.extractPatterns("HLQ.USERID2.SOURCE(R80297*)");
+            testTree.applyPatternsToChildren(fakeChildren, patterns);
+
+            // Placeholders are skipped (not removed, no memberPattern set, no contextValue rewrite via withProfile).
+            expect(fakeChildren).toHaveLength(3);
+            expect(fakeChildren[0]).toBe(navItem);
+            expect((noDataPlaceholder as any).memberPattern).toBeUndefined();
+            expect(noDataPlaceholder.contextValue).toBe(Constants.INFORMATION_CONTEXT);
+            // The real PDS still gets its member filter.
+            expect((matchingPds as any).memberPattern).toBe("R80297*");
+            withProfileMock.mockRestore();
+        });
+    });
+});
+
+// `patternAppliesToChild` is private; exercise it through `applyPatternsToChildren` (its only call site).
+describe("Dataset Tree Unit Tests - Function patternAppliesToChild (private)", () => {
+    function applyAndGetMemberPattern(label: string, patternInput: string): string | undefined {
+        const testTree = new DatasetTree();
+        const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+        const fakeChildren = [{ label, contextValue: Constants.DS_PDS_CONTEXT }] as any[];
+        testTree.applyPatternsToChildren(fakeChildren, testTree.extractPatterns(patternInput));
+        withProfileMock.mockRestore();
+        return fakeChildren[0]?.memberPattern;
+    }
+
+    it("matches a PDS with the same number of qualifiers", () => {
+        expect(applyAndGetMemberPattern("HLQ.PROD.SOURCE", "HLQ.PROD.SOURCE(MEM*)")).toBe("MEM*");
+    });
+
+    it("does not match a PDS with extra qualifiers", () => {
+        const testTree = new DatasetTree();
+        const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+        const fakeChildren = [{ label: "HLQ.PROD.SOURCE.FINAL", contextValue: Constants.DS_PDS_CONTEXT }] as any[];
+        testTree.applyPatternsToChildren(fakeChildren, testTree.extractPatterns("HLQ.PROD.SOURCE(MEM*)"));
+        expect(fakeChildren).toHaveLength(0);
+        withProfileMock.mockRestore();
+    });
+
+    it("matches a PDS using qualifier-level wildcards", () => {
+        expect(applyAndGetMemberPattern("HLQ.PROD.SOURCE", "HLQ.*.SOURCE(MEM*)")).toBe("MEM*");
+    });
+
+    it("does not match across mismatched middle qualifiers", () => {
+        const testTree = new DatasetTree();
+        const withProfileMock = jest.spyOn(SharedContext, "withProfile").mockImplementation((child) => String(child.contextValue));
+        const fakeChildren = [{ label: "HLQ.USERID1.SOURCE", contextValue: Constants.DS_PDS_CONTEXT }] as any[];
+        testTree.applyPatternsToChildren(fakeChildren, [{ dsn: "HLQ.USERID2.SOURCE", member: "MEM*" }]);
+        expect(fakeChildren).toHaveLength(0);
+        withProfileMock.mockRestore();
+    });
 });
 
 describe("DataSetTree Unit Tests - Function handleDrag", () => {

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
@@ -1817,43 +1817,67 @@ Would you like to do this now?`,
     }
 
     private patternAppliesToChild(child: IZoweDatasetTreeNode, item: DatasetMatch): boolean {
-        const name = (child.label as string).split(".");
-        let includes = false;
-        if (!child.pattern) {
-            let index = 0;
-            for (const each of item.dsn.split(".")) {
-                includes = this.checkFilterPattern(name[index], each);
-                child.pattern = includes ? item.dsn : "";
-                index++;
-            }
+        // Require the same number of qualifiers so that e.g. `HLQ.PROD.SOURCE` does not match `HLQ.PROD.SOURCE.FINAL`.
+        const childQualifiers = (child.label as string).toUpperCase().split(".");
+        const patternQualifiers = item.dsn.toUpperCase().split(".");
+
+        if (childQualifiers.length !== patternQualifiers.length) {
+            return false;
         }
 
-        return includes;
+        for (let index = 0; index < patternQualifiers.length; index++) {
+            if (!this.checkFilterPattern(childQualifiers[index], patternQualifiers[index])) {
+                return false;
+            }
+        }
+        return true;
     }
 
-    public applyPatternsToChildren(children: IZoweDatasetTreeNode[], patterns: DatasetMatch[]): void {
-        for (const child of children.filter((c) => !(c instanceof NavigationTreeItem) && c.label !== vscode.l10n.t("No data sets found"))) {
-            for (const item of patterns.filter((p) => p.member && this.patternAppliesToChild(child, p))) {
-                // Only apply to PDS that match the given patterns
-                if (SharedContext.isPds(child)) {
-                    child.memberPattern = item.member;
-                    if (!SharedContext.isFilterFolder(child)) {
-                        // Reset to clean context: stripped of _fav and profile suffix
-                        // Filtered PDS must not be favoritable; withProfile re-adds the profile at the end
-                        child.contextValue = Constants.DS_PDS_CONTEXT + Constants.FILTER_SEARCH;
-                    }
-                    let setIcon: IconUtils.IIconItem;
-                    if (child.collapsibleState === vscode.TreeItemCollapsibleState.Collapsed) {
-                        setIcon = IconGenerator.getIconById(IconUtils.IconId.filterFolder);
-                    } else if (child.collapsibleState === vscode.TreeItemCollapsibleState.Expanded) {
-                        setIcon = IconGenerator.getIconById(IconUtils.IconId.filterFolderOpen);
-                    }
-                    if (setIcon) {
-                        child.iconPath = setIcon.path;
-                    }
+    public applyPatternsToChildren(children: IZoweDatasetTreeNode[], patterns: DatasetMatch[], _sessionNode?: IZoweDatasetTreeNode): void {
+        // When the user provides any parenthesized member filter (e.g. `HLQ.PDS(MEM*)`), drop PDS children
+        // that match none of the user-provided patterns. Avoids prefix-matched data sets leaking into the
+        // tree (see https://github.com/zowe/zowe-explorer-vscode/issues/3424).
+        const hasMemberSpecificPattern = patterns.some((p) => Boolean(p.member));
+        const indicesToRemove: number[] = [];
+
+        for (let i = 0; i < children.length; i++) {
+            const child = children[i];
+            if (child instanceof NavigationTreeItem || child.label === vscode.l10n.t("No data sets found")) {
+                continue;
+            }
+
+            const matchingPatterns = patterns.filter((p) => this.patternAppliesToChild(child, p));
+            const matchingMembers = matchingPatterns.filter((p) => Boolean(p.member)).map((p) => p.member);
+
+            if (hasMemberSpecificPattern && matchingPatterns.length === 0 && SharedContext.isPds(child)) {
+                indicesToRemove.push(i);
+                continue;
+            }
+
+            if (matchingMembers.length > 0 && SharedContext.isPds(child)) {
+                const dedupedMembers = [...new Set(matchingMembers)];
+                child.memberPattern = dedupedMembers.join(",");
+                if (!SharedContext.isFilterFolder(child)) {
+                    // Reset to clean context: stripped of _fav and profile suffix
+                    // Filtered PDS must not be favoritable; withProfile re-adds the profile at the end
+                    child.contextValue = Constants.DS_PDS_CONTEXT + Constants.FILTER_SEARCH;
+                }
+                let setIcon: IconUtils.IIconItem;
+                if (child.collapsibleState === vscode.TreeItemCollapsibleState.Collapsed) {
+                    setIcon = IconGenerator.getIconById(IconUtils.IconId.filterFolder);
+                } else if (child.collapsibleState === vscode.TreeItemCollapsibleState.Expanded) {
+                    setIcon = IconGenerator.getIconById(IconUtils.IconId.filterFolderOpen);
+                }
+                if (setIcon) {
+                    child.iconPath = setIcon.path;
                 }
             }
             child.contextValue = SharedContext.withProfile(child);
+        }
+
+        // Splice in reverse so earlier indices remain valid as later items are removed.
+        for (let i = indicesToRemove.length - 1; i >= 0; i--) {
+            children.splice(indicesToRemove[i], 1);
         }
     }
 

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
@@ -1769,19 +1769,22 @@ Would you like to do this now?`,
     public extractPatterns(userInput: string): DatasetMatch[] {
         // Split the user input by comma to handle each pattern.
         return userInput.split(",").map((p) => {
+            // Trim per-segment whitespace first so that user input like `HLQ.A(MEM*), HLQ.B(MEM*)`
+            // does not leak a leading space into the captured dsn
+            const trimmed = p.trim();
             // Check if the pattern contains parentheses with text inside (member wildcard)
-            const match = /((?:.{1,8}){1,4})\((.{0,8})\)/.exec(p);
+            const match = /((?:.{1,8}){1,4})\((.{0,8})\)/.exec(trimmed);
             if (match) {
                 const [, dataSetName, memberName] = match;
                 return {
-                    dsn: dataSetName,
+                    dsn: dataSetName.replace(/\s/g, ""),
                     member: memberName,
                 };
             }
 
             // No member wildcard; remove spaces from dataset name pattern
             return {
-                dsn: p.replace(/\s/g, ""),
+                dsn: trimmed.replace(/\s/g, ""),
             };
         });
     }
@@ -1826,7 +1829,17 @@ Would you like to do this now?`,
         }
 
         for (let index = 0; index < patternQualifiers.length; index++) {
-            if (!this.checkFilterPattern(childQualifiers[index], patternQualifiers[index])) {
+            const patternQualifier = patternQualifiers[index];
+            const childQualifier = childQualifiers[index];
+            // `checkFilterPattern` only handles qualifiers >= 3 chars or those containing wildcards; short, exact-match
+            // qualifiers (e.g. `A`, `JCL`) need a direct comparison fallback to avoid false negatives.
+            if (!patternQualifier.includes("*")) {
+                if (childQualifier !== patternQualifier) {
+                    return false;
+                }
+                continue;
+            }
+            if (!this.checkFilterPattern(childQualifier, patternQualifier)) {
                 return false;
             }
         }


### PR DESCRIPTION
## Proposed changes

Fixes #3424 

## Release Notes

Milestone: 3.5?

Changelog: 

Fixed an issue where complex data set filters with member patterns (such as `HLQ.A(MEM*),HLQ.B(MEM2)`) produced incorrect results: member filters could be applied to the wrong PDS, multiple filters targeting the same PDS were not combined, and unrelated prefix-matched data sets returned by the MVS API leaked into the tree.

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [x] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):