### PR TITLE
fix: unexpected VS Code conflicts from too new of `mtime`

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed an issue where saving contents to a data set or USS file could trigger built-in conflict detection, specifically when the API does not include a timestamp for that resource. Now, the modification time of a data set or USS file in Zowe Explorer's filesystem is kept as-is if the API does not provide a timestamp. Users can continue to use the "Pull from Mainframe" context-menu option to fetch the latest contents of a data set or USS file in an opened editor. [#4206](https://github.com/zowe/zowe-explorer-vscode/issues/4206)
 - Updated USS and data set file system providers to generate notifications based on remote system changes rather than local file system cache updates. [#4162](https://github.com/zowe/zowe-explorer-vscode/pull/4162)
 - Fixed an issue where file system calls incorrectly threw a FileNotFound error for existing files, ensuring they are now fetched correctly. [#3554](https://github.com/zowe/zowe-explorer-vscode/issues/3554)
 - Fixed an issue where file system URIs with trailing slashes failed to resolve. [#3904](https://github.com/zowe/zowe-explorer-vscode/issues/3904)

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
@@ -1733,6 +1733,63 @@ describe("DatasetFSProvider", () => {
                 expect(fakePs.wasAccessed).toBe(false);
             });
 
+            it("should not bump mtime when m4date is missing (regression: VS Code FILE_MODIFIED_SINCE)", async () => {
+                // Regression test for https://github.com/zowe/zowe-explorer-vscode/issues/4206:
+                // When the data set has no modification attributes, `stat()` previously updated
+                // `entry.mtime = Date.now()` on every call. This caused VS Code's built-in
+                // `FileService.validateWriteFile` to detect a stale write on save and trigger the
+                // "content of the file is newer" prompt. The provider must keep `mtime` stable
+                // across calls when the API has no time data.
+                const initialMtime = 1000;
+                const fakePs = Object.assign(Object.create(Object.getPrototypeOf(testEntries.ps)), testEntries.ps);
+                fakePs.mtime = initialMtime;
+                fakePs.wasAccessed = true;
+
+                jest.spyOn(DatasetFSProvider.instance as any, "lookup").mockReturnValue(fakePs);
+                jest.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(testEntries.session);
+                jest.spyOn(FsAbstractUtils, "getInfoForUri").mockReturnValue({
+                    isRoot: false,
+                    slashAfterProfilePos: testUris.ps.path.indexOf("/", 1),
+                    profileName: "sestest",
+                    profile: testEntries.ps.metadata.profile,
+                });
+
+                const dataSetMock = jest.fn().mockResolvedValue({
+                    success: true,
+                    apiResponse: {
+                        items: [
+                            {
+                                name: "USER.DATA.PS",
+                                dsorg: "PS",
+                                m4date: undefined,
+                            },
+                        ],
+                    },
+                    commandResponse: "",
+                });
+                jest.spyOn(ZoweExplorerApiRegister, "getMvsApi").mockReturnValue({
+                    dataSet: dataSetMock,
+                } as any);
+
+                const result1 = await DatasetFSProvider.instance.stat(testUris.ps);
+
+                expect(result1.mtime).toBe(initialMtime);
+                expect(fakePs.wasAccessed).toBe(false);
+
+                // Clear the request cache so the next stat actually re-runs and reset wasAccessed
+                // to simulate a subsequent read between save attempts.
+                DatasetFSProvider.instance.requestCache.clear();
+                fakePs.wasAccessed = true;
+
+                const result2 = await DatasetFSProvider.instance.stat(testUris.ps);
+
+                // The mtime returned must be stable across stat calls so VS Code does not
+                // mistakenly think the file has changed externally between the model's resolve
+                // time and the save time.
+                expect(result2.mtime).toBe(initialMtime);
+                expect(fakePs.wasAccessed).toBe(false);
+            });
+
             it("should not update entry when mtime matches the calculated new time", async () => {
                 const expectedTime = dayjs("2024-08-08 12:34:56:123").valueOf();
                 const fakePs = Object.assign(Object.create(Object.getPrototypeOf(testEntries.ps)), testEntries.ps);
@@ -1796,6 +1853,53 @@ describe("DatasetFSProvider", () => {
                 profile: testProfile,
             });
             expect(allMembersMock).toHaveBeenCalled();
+        });
+
+        it("does not bump member mtime when m4date is missing (regression: VS Code FILE_MODIFIED_SINCE)", async () => {
+            // Regression test for https://github.com/zowe/zowe-explorer-vscode/issues/4206:
+            // PDS members created without ISPF stats (e.g., from REXX automation) come back from
+            // `allMembers` without `m4date`. Before the fix, every directory listing reset
+            // `tempEntry.mtime = Date.now()`, which caused VS Code's stale-write detection to
+            // raise a "content of the file is newer" prompt on save.
+            const allMembersMock = jest.fn().mockResolvedValue({
+                success: true,
+                apiResponse: {
+                    items: [{ member: "MEM1" }],
+                },
+                commandResponse: "",
+            });
+            jest.spyOn(ZoweExplorerApiRegister, "getMvsApi").mockReturnValue({
+                allMembers: allMembersMock,
+            } as any);
+
+            const fakePds = Object.assign(Object.create(Object.getPrototypeOf(testEntries.pds)), testEntries.pds);
+            const initialMtime = 1000;
+            const existingMember = new DsEntry("MEM1", true);
+            existingMember.metadata = new DsEntryMetadata({ ...fakePds.metadata, path: path.posix.join(fakePds.metadata.path, "MEM1") });
+            existingMember.mtime = initialMtime;
+            existingMember.wasAccessed = true;
+            fakePds.entries = new Map([["MEM1", existingMember]]);
+
+            await (DatasetFSProvider.instance as any).fetchEntriesForDataset(fakePds, testUris.pds, {
+                isRoot: false,
+                slashAfterProfilePos: testUris.pds.path.indexOf("/", 1),
+                profileName: "sestest",
+                profile: testProfile,
+            });
+
+            const memberAfter = fakePds.entries.get("MEM1") as DsEntry;
+            expect(memberAfter.mtime).toBe(initialMtime);
+            expect(memberAfter.wasAccessed).toBe(false);
+
+            // A second listing must keep the mtime stable so VS Code's resolved-stat mtime
+            // matches the stat returned during validateWriteFile, avoiding the spurious conflict.
+            await (DatasetFSProvider.instance as any).fetchEntriesForDataset(fakePds, testUris.pds, {
+                isRoot: false,
+                slashAfterProfilePos: testUris.pds.path.indexOf("/", 1),
+                profileName: "sestest",
+                profile: testProfile,
+            });
+            expect((fakePds.entries.get("MEM1") as DsEntry).mtime).toBe(initialMtime);
         });
         it("calls handleProfileAuthOnError in the case of an API error", async () => {
             const allMembersMock = jest

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
@@ -1892,7 +1892,7 @@ describe("DatasetFSProvider", () => {
             expect(memberAfter.wasAccessed).toBe(false);
 
             // A second listing must keep the mtime stable so VS Code's resolved-stat mtime
-            // matches the stat returned during validateWriteFile, avoiding the spurious conflict.
+            // matches the stat returned during VS Code's `validateWriteFile`, avoiding the spurious conflict.
             await (DatasetFSProvider.instance as any).fetchEntriesForDataset(fakePds, testUris.pds, {
                 isRoot: false,
                 slashAfterProfilePos: testUris.pds.path.indexOf("/", 1),

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
@@ -179,6 +179,44 @@ describe("UssFSProvider", () => {
             listFilesMock.mockRestore();
         });
 
+        it("does not bump mtime when listFiles returns no mtime (regression: VS Code FILE_MODIFIED_SINCE)", async () => {
+            // Sibling regression test for https://github.com/zowe/zowe-explorer-vscode/issues/4206:
+            // when the API does not return an `mtime`, `statImplementation` previously set
+            // `entry.mtime = Date.now()` on every call. VS Code's `FileService.validateWriteFile`
+            // would then see `options.mtime < stat.mtime` on save and raise a stale-write
+            // conflict prompt. The provider must keep `mtime` stable across stat calls when no
+            // modification time is available from the API.
+            const initialMtime = 1234;
+            const fakeFile = new UssFile(testEntries.file.name);
+            Object.assign(fakeFile, testEntries.file);
+            fakeFile.mtime = initialMtime;
+            fakeFile.wasAccessed = true;
+
+            lookupMock.mockReturnValue(fakeFile);
+            const listFilesMock = jest.spyOn(UssFSProvider.instance, "listFiles").mockResolvedValue({
+                success: true,
+                apiResponse: {
+                    items: [{ name: fakeFile.name }],
+                },
+                commandResponse: "",
+            });
+
+            const statUri = testUris.file.with({ query: "fetch=true" });
+            await UssFSProvider.instance.stat(statUri);
+
+            expect(fakeFile.mtime).toBe(initialMtime);
+            expect(fakeFile.wasAccessed).toBe(false);
+
+            // Subsequent stat must continue to report the same mtime so that VS Code does not
+            // think the file has been modified externally between resolve and save.
+            fakeFile.wasAccessed = true;
+            await UssFSProvider.instance.stat(statUri);
+            expect(fakeFile.mtime).toBe(initialMtime);
+            expect(fakeFile.wasAccessed).toBe(false);
+
+            listFilesMock.mockRestore();
+        });
+
         it("returns a file as 'read-only' when query has conflict parameter", async () => {
             lookupMock.mockReturnValueOnce(testEntries.file);
             await expect(UssFSProvider.instance.stat(testUris.conflictFile)).resolves.toStrictEqual({

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -159,9 +159,14 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                         entry.wasAccessed = false;
                     }
                 } else {
-                    // For profiles that don't provide mtime data, always invalidate to force refresh
+                    // The data set has no modification attributes available. Invalidate the cache to
+                    // force a re-fetch on the next read, but leave `mtime` untouched. Bumping `mtime`
+                    // here would cause VS Code's built-in stale-write detection (see
+                    // FileService.validateWriteFile) to compare the stored model mtime against an
+                    // ever-advancing stat mtime, falsely raising a "content of the file is newer"
+                    // conflict on save. Etag-based conflict detection still runs in `writeFile` via
+                    // the 412 response from the mainframe.
                     entry.wasAccessed = false;
-                    entry.mtime = Date.now();
                 }
             }
             return entry;
@@ -322,9 +327,13 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                     tempEntry.wasAccessed = false;
                 }
             } else if (ds.member) {
-                // For profiles that don't provide mtime data, always invalidate to force refresh
+                // The member has no modification attributes available (e.g., created without ISPF
+                // stats). Invalidate the cache to force a re-fetch on the next read, but leave
+                // `mtime` alone. Bumping `mtime` on every stat would trigger VS Code's built-in
+                // FILE_MODIFIED_SINCE detection on save (see FileService.validateWriteFile), even
+                // though the content hasn't actually changed. Etag-based conflict detection still
+                // runs in `writeFile` via the 412 response from the mainframe.
                 tempEntry.wasAccessed = false;
-                tempEntry.mtime = Date.now();
             }
 
             entry.entries.set(fullMemberName, tempEntry);

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -159,11 +159,11 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                         entry.wasAccessed = false;
                     }
                 } else {
-                    // The data set has no modification attributes available. Invalidate the cache to
+                    // The data set has no timestamp attributes available. Invalidate the cache to
                     // force a re-fetch on the next read, but leave `mtime` untouched. Bumping `mtime`
-                    // here would cause VS Code's built-in stale-write detection (see
-                    // FileService.validateWriteFile) to compare the stored model mtime against an
-                    // ever-advancing stat mtime, falsely raising a "content of the file is newer"
+                    // here triggers VS Code's built-in stale-write detection (see
+                    // `FileService.validateWriteFile`) to compare the stored model mtime against an
+                    // always-advancing stat mtime, falsely raising a "content of the file is newer"
                     // conflict on save. Etag-based conflict detection still runs in `writeFile` via
                     // the 412 response from the mainframe.
                     entry.wasAccessed = false;
@@ -328,11 +328,12 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                 }
             } else if (ds.member) {
                 // The member has no modification attributes available (e.g., created without ISPF
-                // stats). Invalidate the cache to force a re-fetch on the next read, but leave
-                // `mtime` alone. Bumping `mtime` on every stat would trigger VS Code's built-in
-                // FILE_MODIFIED_SINCE detection on save (see FileService.validateWriteFile), even
-                // though the content hasn't actually changed. Etag-based conflict detection still
-                // runs in `writeFile` via the 412 response from the mainframe.
+                // stats). Invalidate the cache to force a re-fetch on the next read request, but leave
+                // `mtime` alone. Bumping `mtime` here triggers VS Code's built-in stale-write detection (see
+                // `FileService.validateWriteFile`) to compare the stored model mtime against an
+                // always-advancing stat mtime, falsely raising a "content of the file is newer"
+                // conflict on save. Etag-based conflict detection still runs in `writeFile` via
+                // the 412 response from the mainframe.
                 tempEntry.wasAccessed = false;
             }
 

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -140,10 +140,11 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
                 if (apiMtime == null) {
                     // No modification time was returned by the API. Invalidate the cache to force a
                     // re-fetch on the next read, but leave `entry.mtime` untouched. Bumping `mtime`
-                    // on every stat would trigger VS Code's built-in FILE_MODIFIED_SINCE detection
-                    // (see FileService.validateWriteFile), causing a spurious "content of the file
-                    // is newer" prompt on save. Etag-based conflict detection still runs in
-                    // `writeFile` via the 412 response from the mainframe.
+                    // here triggers VS Code's built-in stale-write detection (see
+                    // `FileService.validateWriteFile`) to compare the stored model mtime against an
+                    // always-advancing stat mtime, falsely raising a "content of the file is newer"
+                    // conflict on save. Etag-based conflict detection still runs in `writeFile` via
+                    // the 412 response from the mainframe.
                     entry.wasAccessed = false;
                 } else {
                     const newTime = dayjs(apiMtime).valueOf();

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -138,8 +138,13 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
                 const apiMtime = (fileResp.apiResponse?.items ?? [])?.[0]?.mtime;
 
                 if (apiMtime == null) {
+                    // No modification time was returned by the API. Invalidate the cache to force a
+                    // re-fetch on the next read, but leave `entry.mtime` untouched. Bumping `mtime`
+                    // on every stat would trigger VS Code's built-in FILE_MODIFIED_SINCE detection
+                    // (see FileService.validateWriteFile), causing a spurious "content of the file
+                    // is newer" prompt on save. Etag-based conflict detection still runs in
+                    // `writeFile` via the 412 response from the mainframe.
                     entry.wasAccessed = false;
-                    entry.mtime = Date.now();
                 } else {
                     const newTime = dayjs(apiMtime).valueOf();
                     if (entry.mtime != newTime) {


### PR DESCRIPTION
## Proposed changes

### The problem on `main`

When saving changes to a data set or data set member without attributes in Zowe Explorer, VS Code's conflict dialog appears. The same also applies to a USS file (details below).

### Root cause

For PDS members without an `m4date` attribute, Zowe Explorer resets the `mtime` to `Date.now()`:

https://github.com/zowe/zowe-explorer-vscode/blob/0172773f43a85ee7369172d9861562b383b738f2/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts#L325-L327

The same applies for [sequential data sets](https://github.com/zowe/zowe-explorer-vscode/blob/0172773f43a85ee7369172d9861562b383b738f2/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts#L162-L164) without this attribute, as well as [USS files without an `mtime` attribute](https://github.com/zowe/zowe-explorer-vscode/blob/0172773f43a85ee7369172d9861562b383b738f2/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts#L141-L142).

This triggers an error within VS Code's file service. When the write request occurs, VS Code detects that the `mtime` returned from the filesystem entry is newer than the last known `mtime` for that resource in the editor and displays a conflict dialog:

https://github.com/microsoft/vscode/blob/7d2415849572fc354dc2a77be04882211026ef7a/src/vs/platform/files/common/fileService.ts#L500-L538

https://github.com/microsoft/vscode/blob/7d2415849572fc354dc2a77be04882211026ef7a/src/vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler.ts#L127-L129

### Fix

Based on the logic and error in VS Code's file service, it's clear that the `mtime` of a filesystem entry **should not be updated** when we do not have an adequate timestamp from an API response.

Removing the `mtime = Date.now()` assignment and keeping the `wasAccessed = false` logic ensures that the next read request receives the latest contents, while preventing false positives for conflict detection.

### Trade-offs

The benefit of updating `mtime` in this scenario was for profile types whose APIs **do not provide** a timestamp attribute. Now that updates to `mtime` in this PR are both consistent and accurate, those profile types do not benefit from live editor updates when switching between windows. The **"Pull from Mainframe"** context-menu option allows the user to retrieve the latest data set or USS file contents for those profile types.

Ultimately, its in our best interest to align with the VS Code extension guidelines. With this in mind, I'd recommend that profile types that want to retain this "live editor update" capability should return an `m4date` attribute on data sets or an `mtime` attribute on USS files. This follows suit with the z/OSMF REST API and matches current expectations in Zowe Explorer.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [x] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):