### PR TITLE
fix: do not set `mtime` on etag change (not in API response)

### DIFF
--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
@@ -555,10 +555,9 @@ describe("DatasetFSProvider", () => {
             expect(_updateResourceInEditorMock).toHaveBeenCalledWith(testUris.ps);
         });
 
-        it("updates mtime if the fetched e-tag differs from the existing e-tag", async () => {
+        it("should not update mtime as part of e-tag check & sync", async () => {
             const contents = "dataset contents";
             const oldMtime = 1000;
-            const newMtime = 2000;
 
             const mockMvsApi = {
                 getContents: jest.fn((dsn, opts) => {
@@ -575,14 +574,11 @@ describe("DatasetFSProvider", () => {
             jest.spyOn(DatasetFSProvider.instance as any, "_lookupAsFile").mockReturnValue(fakePo);
             jest.spyOn(ZoweExplorerApiRegister, "getMvsApi").mockReturnValue(mockMvsApi as any);
 
-            const dateNowSpy = jest.spyOn(Date, "now").mockReturnValue(newMtime);
-
             await DatasetFSProvider.instance.fetchDatasetAtUri(testUris.ps);
 
             expect(fakePo.etag).toBe("NEW_ETAG");
-            expect(fakePo.mtime).toBe(newMtime);
-
-            dateNowSpy.mockRestore();
+            expect(fakePo.mtime).toBe(oldMtime); // We don't have an mtime to work with here, keep it as-is to prevent false positive conflicts
+            // Ideally we would have an mtime to work with here, but we can't enforce this due to loose API response spec
         });
 
         it("does not update mtime if the fetched e-tag matches the existing e-tag", async () => {

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -626,7 +626,6 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                 } else {
                     dsEntry.data = data;
                     if (dsEntry.etag !== resp.apiResponse.etag) {
-                        dsEntry.mtime = Date.now();
                         if (dsEntry.etag) {
                             this.fireSoon({ type: vscode.FileChangeType.Changed, uri: uri.with({ query: "" }) });
                         }

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -560,7 +560,6 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         } else {
             file.data = data;
             if (file.etag !== resp.apiResponse.etag) {
-                file.mtime = Date.now();
                 if (file.etag) {
                     this.fireSoon({ type: vscode.FileChangeType.Changed, uri: uri.with({ query: "" }) });
                 }


### PR DESCRIPTION
## Proposed changes

### Issue on `main`

On `main` we assign `mtime` on a filesystem entry to `Date.now()` when the e-tag is updated:

https://github.com/zowe/zowe-explorer-vscode/blob/a8d3cf3866da02764bc6efbe33d88888b878db11/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts#L606-L611

The same change was applied to the USS filesystem provider:

https://github.com/zowe/zowe-explorer-vscode/blob/a8d3cf3866da02764bc6efbe33d88888b878db11/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts#L548-L553

This is prone to false positives for a couple reasons:
1. It assumes that `mtime` is the current time, which is not a guarantee
2. It assumes an `mtime` value for a data set or resource that may not offer a valid timestamp from the API

As a result of this `mtime` update, it also surfaces an issue where the `mtime` is immediately updated to `Date.now()` as soon as the file or data set is opened in the editor. At this time, the e-tag on the entry is `undefined` and the e-tag from the API response (when pulling its contents) is some stringified hex value, thus satisfying the `if` condition above. When saving, this time is compared against the `mtime` cached in the editor modal. The time from the `stat` call is newer, surfacing the conflict message.

For context, we had always assigned the `mtime`, seeing this as far back as [06c5794](https://github.com/zowe/zowe-explorer-vscode/commit/06c5794ccc8999f57831f49407e4d74dc6e16121). However, with fetch by default in place, this logic now has greater implications.

### Fix

Skipping the `mtime` update seems to be the quickest way forward since:
1. We cannot fully leverage VS Code's built-in etag handling: it relies on `mtime` (a timestamp) that we can't always provide to calculate it
2. **We do not set expectations** on an API to return an `mtime` or an `etag`. There is no type-checking for these responses.
3. Keeping the `mtime` old prevents the false positive conflict
4. Existing conflict handling (412 status code over HTTP) continues to work as-is

### Long-term proposal

We **need** to set a standard for what to expect when reading files, data sets and listing them in v4 - this includes all supported attributes, the format they should be in, and when to expect them.

Having this prevents us from playing guessing games of "does this API return an mtime? what about an etag? what about 412 error from conflict?" ... because we have to now since `apiResponse` is **typed as any** (bad practice):

https://github.com/zowe/zowe-cli/blob/d484bd7ffa4f7a4d9a09ce2536e8e41ea9f0064a/packages/zosfiles/src/doc/IZosFilesResponse.ts#L29-L33

Setting these expectations avoids making assumptions about what APIs should do - response types fill the gap.

## How to test

- Install the VSIX from this PR.
- Open Zowe Explorer and search for a pattern matching a PDS that you control OR have write access to.
- Switch to your 3270 emulator.
- Create a new member without any statistics and save some contents into the member. When saving, make sure to skip updating statistics - meaning that no attributes are saved to the data set. (In ISPF you can do this by typing `stats off` in the Command area of the edit view. Then, close out of the edit view.)
- Switch to Zowe Explorer. Refresh the member list for that PDS (or open it if you haven't already) & open the new member.
- Make changes to the member and save.
- Notice that the "unsaved" symbol is removed from the editor tab and the file is saved. Verify that the save succeeds by checking the contents from the 3270 emulator.
  - No conflict dialog should appear
  - On `main`, the conflict dialog appears here and the save is unsuccessful

## Release Notes

Milestone: 3.5.0

Changelog: Pre-existing changelog entry

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):
