### PR TITLE
Fix regression when submitting jobs from a favorited PDS member

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ## TBD Release
 
+### Bug fixes
+
+- Fixed an issue where submitting a job from a favorited PDS member would fail. [#4286](https://github.com/zowe/zowe-explorer-vscode/pull/4286)
+
+## `3.5.0`
+
 ### New features and enhancements
 
 - Enhanced "Show Attributes" feature with improved visual presentation: aligned all attribute table columns consistently across core and extender sections, added thousands separators for numeric values, and automatically appends the `%` symbol to "Used Space" values for better readability. [#3927](https://github.com/zowe/zowe-explorer-vscode/issues/3927)

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
-- Fixed an issue where submitting a job from a favorited PDS member would fail. [#4286](https://github.com/zowe/zowe-explorer-vscode/pull/4286)
+- Fixed an issue where submitting a job from a favorited PDS member would fail. [#4282](https://github.com/zowe/zowe-explorer-vscode/issues/4282)
 
 ## `3.5.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
@@ -435,6 +435,22 @@ describe("Dataset Actions Unit Tests - Function refreshPS", () => {
         await DatasetActions.refreshPS(child);
         expect(blockMocks.fetchDsAtUri).toHaveBeenCalledWith(child.resourceUri, { editor: undefined });
     });
+    it("Checking favorite PDS Member refresh when member node context has favorite suffix", async () => {
+        createGlobalMocks();
+        const blockMocks = createBlockMocksShared();
+        const parent = new ZoweDatasetNode({
+            label: "parent",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            parentNode: blockMocks.datasetSessionNode,
+        });
+        const child = new ZoweDatasetNode({ label: "child", collapsibleState: vscode.TreeItemCollapsibleState.None, parentNode: parent });
+        parent.contextValue = Constants.DS_PDS_CONTEXT + Constants.FAV_SUFFIX;
+        child.contextValue = Constants.DS_MEMBER_CONTEXT + Constants.FAV_SUFFIX;
+
+        await DatasetActions.refreshPS(child);
+        
+        expect(blockMocks.fetchDsAtUri).toHaveBeenCalledWith(child.resourceUri, { editor: undefined });
+    });
     it("Checking favorite PS refresh", async () => {
         createGlobalMocks();
         const blockMocks = createBlockMocksShared();

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/JobActions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/JobActions.unit.test.ts
@@ -968,6 +968,42 @@ describe("Jobs Actions Unit Tests - Function submitMember", () => {
             "Job submitted: [TESTJOB(JOB1234)](command:zowe.jobs.setJobSpool?%5B%22test%22%2C%22JOB1234%22%5D)"
         );
     });
+    it("Checking Submit Job for PDS Member with favorite suffix context", async () => {
+        createGlobalMocks();
+        const blockMocks = createBlockMocks();
+        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        const favProfileNode = new ZoweDatasetNode({
+            label: "test",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            parentNode: blockMocks.datasetSessionNode,
+        });
+        favProfileNode.contextValue = Constants.FAV_PROFILE_CONTEXT;
+        const favoriteSubNode = new ZoweDatasetNode({
+            label: "TEST.JCL",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            parentNode: favProfileNode,
+        });
+        favoriteSubNode.contextValue = Constants.DS_PDS_CONTEXT + Constants.FAV_SUFFIX;
+        const favoriteMember = new ZoweDatasetNode({
+            label: "MEMBER1",
+            collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+            parentNode: favoriteSubNode,
+        });
+        // Set the context value with the favorite suffix to trigger the bug condition we fixed
+        favoriteMember.contextValue = Constants.DS_MEMBER_CONTEXT + Constants.FAV_SUFFIX;
+        const submitJobSpy = vi.spyOn(blockMocks.jesApi, "submitJob");
+        submitJobSpy.mockClear();
+        submitJobSpy.mockResolvedValueOnce(blockMocks.iJob);
+
+        await DatasetActions.submitMember(favoriteMember);
+        expect(submitJobSpy).toHaveBeenCalled();
+        // Since the member is in a PDS, even if the member itself is favorited, the label should still be PDS(member)
+        expect(submitJobSpy.mock.calls[0][0]).toEqual("TEST.JCL(MEMBER1)");
+        expect(mocked(Gui.showMessage)).toHaveBeenCalled();
+        expect(mocked(Gui.showMessage).mock.calls[0][0]).toEqual(
+            "Job submitted: [TESTJOB(JOB1234)](command:zowe.jobs.setJobSpool?%5B%22test%22%2C%22JOB1234%22%5D)"
+        );
+    });
     it("Checking Submit Job for Favourite PS Dataset content", async () => {
         createGlobalMocks();
         const blockMocks = createBlockMocks();

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/JobActions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/JobActions.unit.test.ts
@@ -989,7 +989,7 @@ describe("Jobs Actions Unit Tests - Function submitMember", () => {
             collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
             parentNode: favoriteSubNode,
         });
-        // Set the context value with the favorite suffix to trigger the bug condition we fixed
+
         favoriteMember.contextValue = Constants.DS_MEMBER_CONTEXT + Constants.FAV_SUFFIX;
         const submitJobSpy = vi.spyOn(blockMocks.jesApi, "submitJob");
         submitJobSpy.mockClear();
@@ -997,7 +997,7 @@ describe("Jobs Actions Unit Tests - Function submitMember", () => {
 
         await DatasetActions.submitMember(favoriteMember);
         expect(submitJobSpy).toHaveBeenCalled();
-        // Since the member is in a PDS, even if the member itself is favorited, the label should still be PDS(member)
+
         expect(submitJobSpy.mock.calls[0][0]).toEqual("TEST.JCL(MEMBER1)");
         expect(mocked(Gui.showMessage)).toHaveBeenCalled();
         expect(mocked(Gui.showMessage).mock.calls[0][0]).toEqual(

--- a/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
@@ -2000,7 +2000,7 @@ export class DatasetActions {
             const defaultMessage = vscode.l10n.t("Cannot submit, item invalid.");
             switch (true) {
                 // For favorited or non-favorited sequential DS:
-                case SharedContext.isFavorite(node):
+                case SharedContext.isFavorite(node) && !SharedContext.isDsMember(node):
                 case SharedContext.isSessionNotFav(node.getParent()):
                     sesName = node.getParent().getLabel() as string;
                     label = node.label as string;
@@ -2188,7 +2188,7 @@ export class DatasetActions {
         try {
             switch (true) {
                 // For favorited or non-favorited sequential DS:
-                case SharedContext.isFavorite(node):
+                case SharedContext.isFavorite(node) && !SharedContext.isDsMember(node):
                 case SharedContext.isSessionNotFav(node.getParent()):
                 case SharedContext.isDs(node):
                     label = node.label as string;


### PR DESCRIPTION
## Proposed changes

Submitting a job from a favorited PDS member would result in a failure on v3.5.0

**How to test**

1. Create a PDS with a member containing JCL

```
//HELLO    JOB  (ACCT),'HELLO WORLD',
//              CLASS=A,
//              MSGCLASS=H,
//              MSGLEVEL=(1,1),
//              NOTIFY=&SYSUID
//STEP1    EXEC PGM=IEFBR14
```

2. Right Click -> Submit Job on the member
3. The submission should pass
4. Add the PDS or individual member as a favorite
5. Attempt to submit the job again
6. The submission should pass again


## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
