### PR TITLE
expose additionalDetails of imperative errors if any

### DIFF
--- a/packages/zowe-explorer-api/__tests__/__unit__/utils/ErrorCorrelator.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/utils/ErrorCorrelator.unit.test.ts
@@ -179,4 +179,25 @@ describe("displayCorrelatedError", () => {
         expect(correlateErrorMock).toHaveBeenCalledWith(ZoweExplorerApiType.All, initialError, { profileType: "zosmf" });
         expect(errorMessageMock).toHaveBeenCalledWith("Network Error. Initial error.", { items: ["More info"] });
     });
+
+    it("displays an error exposing the additionalDetails field", async () => {
+        const initialError = new ImperativeError({
+            msg: "Imperative Error.",
+            additionalDetails: "Failed to acquire ENQ on the data set!",
+            causeErrors: new Error("Initial error."),
+        });
+        const error = new CorrelatedError({
+            correlation: { summary: "Network Error." },
+            initialError: initialError,
+        });
+        const correlateErrorMock = vi.spyOn(ErrorCorrelator.getInstance(), "correlateError").mockReturnValueOnce(error);
+        const errorMessageMock = vi.spyOn(Gui, "errorMessage");
+        await ErrorCorrelator.getInstance().displayError(ZoweExplorerApiType.All, initialError, {
+            profileType: "zosmf",
+        });
+        expect(correlateErrorMock).toHaveBeenCalledWith(ZoweExplorerApiType.All, initialError, { profileType: "zosmf" });
+        expect(errorMessageMock).toHaveBeenCalledWith("Network Error. Failed to acquire ENQ on the data set! Initial error.", {
+            items: ["More info"],
+        });
+    });
 });

--- a/packages/zowe-explorer-api/src/utils/ErrorCorrelator.ts
+++ b/packages/zowe-explorer-api/src/utils/ErrorCorrelator.ts
@@ -315,8 +315,16 @@ export class ErrorCorrelator {
      */
     public async displayCorrelatedError(error: CorrelatedError, opts?: DisplayCorrelatedErrorOpts): Promise<string | undefined> {
         const errorCodeStr = error.properties.errorCode ? ` (Error Code ${error.properties.errorCode})` : "";
-        const additionalDetails =
-            error.initial instanceof ImperativeError && error.initial.causeErrors instanceof Error ? error.initial.causeErrors.message : undefined;
+        let additionalDetails = "";
+        if (error.initial instanceof ImperativeError) {
+            if (error.initial.additionalDetails) {
+                additionalDetails = error.initial.additionalDetails;
+            }
+            if (error.initial.causeErrors instanceof Error) {
+                additionalDetails += error.initial.causeErrors.message;
+            }
+        }
+
         const userSelection = await Gui.errorMessage(
             `${opts?.additionalContext ? opts.additionalContext + ": " : ""}${error.message}${errorCodeStr}${
                 additionalDetails ? " " + additionalDetails : ""

--- a/packages/zowe-explorer-api/src/utils/ErrorCorrelator.ts
+++ b/packages/zowe-explorer-api/src/utils/ErrorCorrelator.ts
@@ -318,7 +318,7 @@ export class ErrorCorrelator {
         let additionalDetails = "";
         if (error.initial instanceof ImperativeError) {
             if (error.initial.additionalDetails) {
-                additionalDetails = error.initial.additionalDetails;
+                additionalDetails = error.initial.additionalDetails + " ";
             }
             if (error.initial.causeErrors instanceof Error) {
                 additionalDetails += error.initial.causeErrors.message;

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Fixed an issue where additional error details were not displayed, particularly using SSH profiles: [zowex/#766](https://github.com/zowe/zowex/issues/766).
 - Fixed an issue where saving contents to a data set or USS file could trigger built-in conflict detection, specifically when the API does not include a timestamp for that resource. Now, the modification time of a data set or USS file in Zowe Explorer's filesystem is kept as-is if the API does not provide a timestamp. Users can continue to use the "Pull from Mainframe" context-menu option to fetch the latest contents of a data set or USS file in an opened editor. [#4206](https://github.com/zowe/zowe-explorer-vscode/issues/4206)
 - Updated USS and data set file system providers to generate notifications based on remote system changes rather than local file system cache updates. [#4162](https://github.com/zowe/zowe-explorer-vscode/pull/4162)
 - Fixed an issue where file system calls incorrectly threw a FileNotFound error for existing files, ensuring they are now fetched correctly. [#3554](https://github.com/zowe/zowe-explorer-vscode/issues/3554)

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
-- Fixed an issue where additional error details were not displayed, particularly using SSH profiles: [zowex/#766](https://github.com/zowe/zowex/issues/766).
+- Fixed an issue where additional error details were not displayed, particularly using SSH profiles. [zowex/#766](https://github.com/zowe/zowex/issues/766)
 - Fixed an issue where saving contents to a data set or USS file could trigger built-in conflict detection, specifically when the API does not include a timestamp for that resource. Now, the modification time of a data set or USS file in Zowe Explorer's filesystem is kept as-is if the API does not provide a timestamp. Users can continue to use the "Pull from Mainframe" context-menu option to fetch the latest contents of a data set or USS file in an opened editor. [#4206](https://github.com/zowe/zowe-explorer-vscode/issues/4206)
 - Updated USS and data set file system providers to generate notifications based on remote system changes rather than local file system cache updates. [#4162](https://github.com/zowe/zowe-explorer-vscode/pull/4162)
 - Fixed an issue where file system calls incorrectly threw a FileNotFound error for existing files, ensuring they are now fetched correctly. [#3554](https://github.com/zowe/zowe-explorer-vscode/issues/3554)

--- a/packages/zowe-explorer/README.md
+++ b/packages/zowe-explorer/README.md
@@ -54,7 +54,6 @@ Before you use Zowe Explorer, ensure that you meet the following prerequisites:
 ### Server side requirements
 
 - IBM z/OSMF is configured and running.
-
   - See [z/OSMF REST services for Zowe clients](https://docs.zowe.org/stable/user-guide/systemrequirements-zosmf.md#zosmf-rest-services-for-zowe-clients) for a list of services that need configuration.
 
 - If using IBM CICS or IBM z/OS FTP: Applicable plug-in services are configured and running on the mainframe.
@@ -72,7 +71,6 @@ Use various services to communicate with system resources and extract system dat
   - This connection option is integrated out-of-the-box, powered by [Zowe Remote SSH](https://github.com/zowe/zowex).
   - See [SSH documentation](https://docs.zowe.org/stable/user-guide/ze-profiles) for more information.
 - FTP
-
   - This connection is available with the [Zowe Explorer FTP Extension](https://docs.zowe.org/stable/user-guide/ze-ftp-using-ze-ftp-ext).
   - See [FTP documentation](https://www.ibm.com/docs/en/zos/3.1.0?topic=applications-transferring-files-using-ftp) for more information.
 
@@ -87,7 +85,6 @@ Use various services to communicate with system resources and extract system dat
 Team configuration stores connection information to access the mainframe. Check that you have your team configuration in place.
 
 - Your team configuration is in place when:
-
   - Selecting the **+** icon in the headers of the **DATA SETS**, **UNIX SYSTEM SERVICES**, or **JOBS** tree views presents options in the **Quick Pick** to edit your configuration file or, if available, use an existing profile.
 
 - You do not have team configuration when:

--- a/packages/zowe-explorer/__tests__/__unit__/tools/ZowePersistentFilters.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/tools/ZowePersistentFilters.unit.test.ts
@@ -93,7 +93,7 @@ describe("PersistentFilters Unit Test", () => {
             const pf: ZowePersistentFilters = new ZowePersistentFilters(PersistenceSchemaEnum.Dataset, 1, 1);
             const spy = vi.spyOn(ZoweLocalStorage, "getValue").mockReturnValue({
                 persistence: true,
-                vsamFavorites: ["vsamFav1", "vsamFav2"]
+                vsamFavorites: ["vsamFav1", "vsamFav2"],
             } as any);
             expect(pf.readVsamFavorites()).toEqual(["vsamFav1", "vsamFav2"]);
             spy.mockRestore();
@@ -102,7 +102,7 @@ describe("PersistentFilters Unit Test", () => {
         it("should return empty array if vsamFavorites is undefined", () => {
             const pf: ZowePersistentFilters = new ZowePersistentFilters(PersistenceSchemaEnum.Dataset, 1, 1);
             const spy = vi.spyOn(ZoweLocalStorage, "getValue").mockReturnValue({
-                persistence: true
+                persistence: true,
             } as any);
             expect(pf.readVsamFavorites()).toEqual([]);
             spy.mockRestore();
@@ -113,18 +113,18 @@ describe("PersistentFilters Unit Test", () => {
         it("should update regular and vsam favorites", () => {
             const pf: ZowePersistentFilters = new ZowePersistentFilters(PersistenceSchemaEnum.Dataset, 1, 1);
             const getSpy = vi.spyOn(ZoweLocalStorage, "getValue").mockReturnValue({
-                persistence: true
+                persistence: true,
             } as any);
             const setSpy = vi.spyOn(ZoweLocalStorage, "setValue").mockImplementation();
-            
+
             pf.updateFavorites({ favorites: ["fav1"], vsamFavorites: ["vsamFav1"] });
-            
+
             expect(setSpy).toHaveBeenCalledWith(PersistenceSchemaEnum.Dataset, {
                 persistence: true,
                 favorites: ["fav1"],
-                vsamFavorites: ["vsamFav1"]
+                vsamFavorites: ["vsamFav1"],
             });
-            
+
             getSpy.mockRestore();
             setSpy.mockRestore();
         });

--- a/packages/zowe-explorer/src/tools/ZowePersistentFilters.ts
+++ b/packages/zowe-explorer/src/tools/ZowePersistentFilters.ts
@@ -221,7 +221,7 @@ export class ZowePersistentFilters {
         ZoweLogger.trace("PersistentFilters.readVsamFavorites called.");
         const localStorageSchema = ZoweLocalStorage.getValue<Definitions.ZowePersistentFilter>(this.schema);
         if (localStorageSchema) {
-            return localStorageSchema[ZowePersistentFilters.vsamFavorites] as string[] || [];
+            return (localStorageSchema[ZowePersistentFilters.vsamFavorites] as string[]) || [];
         }
         return [];
     }
@@ -230,7 +230,7 @@ export class ZowePersistentFilters {
         ZoweLogger.trace("PersistentFilters.readMemberFavorites called.");
         const localStorageSchema = ZoweLocalStorage.getValue<Definitions.ZowePersistentFilter>(this.schema);
         if (localStorageSchema) {
-            return localStorageSchema[ZowePersistentFilters.memberFavorites] as string[] || [];
+            return (localStorageSchema[ZowePersistentFilters.memberFavorites] as string[]) || [];
         }
         return [];
     }
@@ -332,11 +332,7 @@ export class ZowePersistentFilters {
     /* Update functions, for updating the settings.json file in VSCode
     /*********************************************************************************************************************************************/
 
-    public updateFavorites(options: {
-        favorites: string[];
-        vsamFavorites?: string[];
-        memberFavorites?: string[];
-    }): void {
+    public updateFavorites(options: { favorites: string[]; vsamFavorites?: string[]; memberFavorites?: string[] }): void {
         ZoweLogger.trace("PersistentFilters.updateFavorites called.");
         const settings = ZoweLocalStorage.getValue<Definitions.ZowePersistentFilter>(this.schema);
         if (settings.persistence) {

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
@@ -1500,7 +1500,7 @@ Would you like to do this now?`,
         this.mPersistence.updateFavorites({
             favorites: favoritesArray,
             vsamFavorites: vsamFavoritesArray,
-            memberFavorites: memberFavoritesArray
+            memberFavorites: memberFavoritesArray,
         });
     }
 

--- a/packages/zowex-for-zowe-explorer/src/api/SshCommonApi.ts
+++ b/packages/zowex-for-zowe-explorer/src/api/SshCommonApi.ts
@@ -18,7 +18,7 @@ import { SshClientCache } from "../SshClientCache";
 import { SshErrorHandler } from "../SshErrorHandler";
 
 export class SshCommonApi implements MainframeInteraction.ICommon {
-    public constructor(public profile?: imperative.IProfileLoaded) {}
+    public constructor(public profile?: imperative.IProfileLoaded) { }
 
     public getProfileTypeName(): string {
         return ZosUssProfile.type;
@@ -162,14 +162,4 @@ export class SshCommonApi implements MainframeInteraction.ICommon {
         return undefined;
     }
 
-    /**
-     * Converts an `ImperativeError` to a plain JS error to avoid losing additional details
-     * @param maybeError The thrown error to convert
-     */
-    protected buildRequestError(maybeError: unknown): Error | unknown {
-        if (!(maybeError instanceof ImperativeError)) {
-            return maybeError;
-        }
-        return new Error(`${maybeError.message}\n${maybeError.additionalDetails}`);
-    }
 }

--- a/packages/zowex-for-zowe-explorer/src/api/SshMvsApi.ts
+++ b/packages/zowex-for-zowe-explorer/src/api/SshMvsApi.ts
@@ -222,17 +222,15 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
             lrecl: 80,
             ...(options || {}),
         };
-        try {
-            const response = await (
-                await this.client
-            ).ds.createDataset({
-                dsname: dataSetName,
-                attributes: datasetAttributes,
-            });
-            return this.buildZosFilesResponse(response);
-        } catch (err) {
-            throw this.buildRequestError(err);
-        }
+
+        const response = await (
+            await this.client
+        ).ds.createDataset({
+            dsname: dataSetName,
+            attributes: datasetAttributes,
+        });
+        return this.buildZosFilesResponse(response);
+
     }
 
     public async createDataSetMember(dataSetName: string, _options?: zosfiles.IUploadOptions): Promise<zosfiles.IZosFilesResponse> {
@@ -292,16 +290,12 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
     }
 
     public async deleteDataSet(dataSetName: string, _options?: zosfiles.IDeleteDatasetOptions): Promise<zosfiles.IZosFilesResponse> {
-        try {
-            const response = await (
-                await this.client
-            ).ds.deleteDataset({
-                dsname: dataSetName,
-            });
-            return this.buildZosFilesResponse(response);
-        } catch (err) {
-            throw this.buildRequestError(err);
-        }
+        const response = await (
+            await this.client
+        ).ds.deleteDataset({
+            dsname: dataSetName,
+        });
+        return this.buildZosFilesResponse(response);
     }
 
     private buildZosFilesResponse(apiResponse: any, success = true, errorText?: string): zosfiles.IZosFilesResponse {


### PR DESCRIPTION
## Proposed changes

If an imperative error is thrown previously we were not  displaying its `additionalDetails` value 

initially we talked about seeing how big this change needed to be, and potentially scope it to only certain operations, but considering we weren't doing anything with additionalDetails I think this should work for most things  

https://github.com/zowe/zowex/issues/766

We had talked about targeting `main` with this PR but I don't know of a z/OSMF only error that will demo this whereas you can trigger the original  error in the above issue  to get the additional detail.  I can re-create the error if it makes more sense to target main but this is testable with the zowex code... let me know 

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->

<img width="512" height="399" alt="image" src="https://github.com/user-attachments/assets/522d4f26-d04d-4a7d-b412-2f83228c8d84" />
