### PR TITLE
Fix extension handling when fetching and renaming ds

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### New features and enhancements
 
+- Added a function `trimExtension` in the `FsDatasetsUtils` class for stripping extension suffix off of a data set name. [#4326](https://github.com/zowe/zowe-explorer-vscode/pull/4326)
+
 ### Bug fixes
 
 ## `3.5.0`

--- a/packages/zowe-explorer-api/__tests__/__unit__/fs/utils/datasets.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/fs/utils/datasets.unit.test.ts
@@ -46,3 +46,18 @@ describe("isPdsEntry", () => {
         expect(FsDatasetsUtils.isPdsEntry(ds)).toBe(false);
     });
 });
+
+describe("trimExtension", () => {
+    it("returns a path without its extension", () => {
+        const uriBasename = "TEST.COBOL.DS.cbl";
+        expect(FsDatasetsUtils.trimExtension(uriBasename)).toBe("TEST.COBOL.DS");
+    });
+    it("returns a path as-is if no extension is detected", () => {
+        const uriBasename = "TEST.SOME.DS";
+        expect(FsDatasetsUtils.trimExtension(uriBasename)).toBe("TEST.SOME.DS");
+    });
+    it("returns a path as-is if extension is last qualifier of name", () => {
+        const uriBasename = "TEST.DS.REXX";
+        expect(FsDatasetsUtils.trimExtension(uriBasename)).toBe("TEST.DS.REXX");
+    });
+});

--- a/packages/zowe-explorer-api/src/fs/utils/FsDatasetsUtils.ts
+++ b/packages/zowe-explorer-api/src/fs/utils/FsDatasetsUtils.ts
@@ -10,7 +10,7 @@
  */
 
 import { IFileSystemEntry } from "../types/abstract";
-import { DsEntry, PdsEntry } from "../types/datasets";
+import { DsEntry, PdsEntry, DS_EXTENSION_MAP } from "../types/datasets";
 
 export class FsDatasetsUtils {
     public static isDsEntry(entry: IFileSystemEntry): entry is DsEntry {
@@ -23,5 +23,15 @@ export class FsDatasetsUtils {
 
     public static isPdsEntry(entry: IFileSystemEntry): entry is PdsEntry {
         return entry != null && entry instanceof PdsEntry;
+    }
+
+    public static trimExtension(dsName: string): string {
+        for (const ext of DS_EXTENSION_MAP.keys()) {
+            if (dsName.endsWith(ext)) {
+                return dsName.replace(ext, "");
+            }
+        }
+
+        return dsName;
     }
 }

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Added support for favoriting migrated data sets and synchronizing their migration/recall status. [#4308](https://github.com/zowe/zowe-explorer-vscode/pull/4308)
 - Fixed a localization issue where changing `Zowe > Logger` in a non-English language would use the localized value instead of the expected internal enum value for setting the log level. [#4292](https://github.com/zowe/zowe-explorer-vscode/issues/4292)
 - Fixed an issue where the `certAccount` property was not supported in z/OSMF profiles for authenticating with certificates stored in the OS keychain. [#4309](https://github.com/zowe/zowe-explorer-vscode/pull/4309)
+- Fixed an issue when renaming a data set or member where new extension suffix was not detected. [#4142](https://github.com/zowe/zowe-explorer-vscode/issues/4142)
+- Fixed an issue where renaming a sequential data set with an extension suffix like `.jcl` would fail. [#4326](https://github.com/zowe/zowe-explorer-vscode/pull/4326)
 
 ## `3.5.0`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
@@ -2424,6 +2424,25 @@ describe("DatasetFSProvider", () => {
             expect(mockMvsApi.renameDataSet).toHaveBeenCalledWith(before, after);
         });
 
+        it("renames a PS and trims extensions", async () => {
+            const oldPs = new DsEntry("USER.DATA.PS.c", false);
+            oldPs.metadata = new DsEntryMetadata({ profile: testProfile, path: "/USER.DATA.PS.c" });
+            const mockMvsApi = {
+                renameDataSet: vi.fn(),
+            };
+            vi.spyOn(ZoweExplorerApiRegister, "getMvsApi").mockReturnValue(mockMvsApi as any);
+            vi.spyOn(DatasetFSProvider.instance as any, "lookup").mockImplementation((uri): DirEntry | FileEntry =>
+                (uri as Uri).path.includes("USER.DATA.PS2") ? (undefined as any) : oldPs
+            );
+            vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue({ ...testEntries.session });
+
+            const oldUri = Uri.from({ scheme: ZoweScheme.DS, path: "/sestest/USER.DATA.PS.c" });
+            const newUri = oldUri.with({ path: "/sestest/USER.DATA.PS2.c" });
+
+            await DatasetFSProvider.instance.rename(oldUri, newUri, { overwrite: true });
+            expect(mockMvsApi.renameDataSet).toHaveBeenCalledWith("USER.DATA.PS", "USER.DATA.PS2");
+        });
+
         it("renames a PDS", async () => {
             const oldPds = new PdsEntry("USER.DATA.PDS");
             oldPds.metadata = new DsEntryMetadata({ profile: testProfile, path: "/USER.DATA.PDS" });

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetFSProvider.unit.test.ts
@@ -942,7 +942,7 @@ describe("DatasetFSProvider", () => {
                 items: [
                     {
                         dsorg: "PS",
-                        id: "ZOWE",
+                        dsname: "ZOWE",
                         lrecl,
                         recfm: "FB",
                     },
@@ -956,6 +956,7 @@ describe("DatasetFSProvider", () => {
             const parent = { entries: new Map(), metadata: { profile: { name: "profile" }, path: "/" } };
             const binaryEntry = { ...testEntries.pdsMember, wasAccessed: true, encoding: { kind: "binary" } } as DsEntry;
             parent.entries.set("MEMBER1", binaryEntry);
+            dsResponseMock.apiResponse.items[0].dsname = testEntries.pds.name;
             vi.spyOn(provider as any, "lookupParentDirectory").mockReturnValueOnce(parent);
 
             const mockMvsApi = {
@@ -991,6 +992,7 @@ describe("DatasetFSProvider", () => {
             const psEntry = { ...testEntries.ps, metadata: testEntries.ps.metadata } as DsEntry;
             const sessionEntry = { ...testEntries.session };
             sessionEntry.entries.set("USER.DATA.PS", psEntry);
+            dsResponseMock.apiResponse.items[0].dsname = psEntry.name;
             const lookupParentDirMock = vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(sessionEntry);
             vi.spyOn(DatasetFSProvider.instance as any, "lookup").mockReturnValue(psEntry);
             const newContents = new Uint8Array([3, 6, 9]);
@@ -1018,6 +1020,7 @@ describe("DatasetFSProvider", () => {
             const psEntry = { ...testEntries.ps, metadata: testEntries.ps.metadata } as DsEntry;
             const sessionEntry = { ...testEntries.session };
             sessionEntry.entries.set("USER.DATA.PS", psEntry);
+            dsResponseMock.apiResponse.items[0].dsname = psEntry.name;
             const lookupParentDirMock = vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(sessionEntry);
             vi.spyOn(DatasetFSProvider.instance as any, "lookup").mockReturnValue(psEntry);
             const handleConflictMock = vi
@@ -1047,6 +1050,7 @@ describe("DatasetFSProvider", () => {
             const psEntry = { ...testEntries.ps, metadata: testEntries.ps.metadata } as DsEntry;
             const sessionEntry = { ...testEntries.session };
             sessionEntry.entries.set("USER.DATA.PS", psEntry);
+            dsResponseMock.apiResponse.items[0].dsname = psEntry.name;
             const lookupParentDirMock = vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(sessionEntry);
             vi.spyOn(DatasetFSProvider.instance as any, "lookup").mockReturnValue(psEntry);
             const handleErrorMock = vi.spyOn(DatasetFSProvider.instance as any, "_handleError").mockImplementation((() => undefined) as any);
@@ -1100,6 +1104,7 @@ describe("DatasetFSProvider", () => {
             it("in a PS data set with one invalid line", async () => {
                 const sessionEntry = { ...testEntries.session };
                 sessionEntry.entries.set("USER.DATA.PS", psEntry);
+                dsResponseMock.apiResponse.items[0].dsname = psEntry.name;
                 vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(sessionEntry);
                 vi.spyOn(vscode.workspace, "openTextDocument").mockResolvedValue({ lineCount: 1, lineAt } as any);
 
@@ -1113,6 +1118,7 @@ describe("DatasetFSProvider", () => {
             it("in a PS data set with multiple invalid lines", async () => {
                 const sessionEntry = { ...testEntries.session };
                 sessionEntry.entries.set("USER.DATA.PS", psEntry);
+                dsResponseMock.apiResponse.items[0].dsname = psEntry.name;
                 vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(sessionEntry);
                 vi.spyOn(vscode.workspace, "openTextDocument").mockResolvedValue({ lineCount: 10, lineAt } as any);
 
@@ -1126,6 +1132,7 @@ describe("DatasetFSProvider", () => {
             it("in a PDS member with one invalid line", async () => {
                 const pdsEntry = { ...testEntries.pds };
                 pdsEntry.entries.set("MEMBER1", pdsMemberEntry);
+                dsResponseMock.apiResponse.items[0].dsname = pdsEntry.name;
                 vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(pdsEntry);
                 vi.spyOn(vscode.workspace, "openTextDocument").mockResolvedValue({ lineCount: 1, lineAt } as any);
 
@@ -1139,6 +1146,7 @@ describe("DatasetFSProvider", () => {
             it("in a PDS member with multiple invalid lines", async () => {
                 const pdsEntry = { ...testEntries.pds };
                 pdsEntry.entries.set("MEMBER1", pdsMemberEntry);
+                dsResponseMock.apiResponse.items[0].dsname = pdsEntry.name;
                 vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(pdsEntry);
                 vi.spyOn(vscode.workspace, "openTextDocument").mockResolvedValue({ lineCount: 10, lineAt } as any);
 
@@ -1154,7 +1162,7 @@ describe("DatasetFSProvider", () => {
                 const dsResponseMock = {
                     success: true,
                     apiResponse: {
-                        items: [{ name: "USER.DATA.PS", recfm: "U", blksz: 10 }],
+                        items: [{ dsname: "USER.DATA.PS", recfm: "U", blksz: 10 }],
                     },
                     commandResponse: "",
                 };
@@ -1181,7 +1189,7 @@ describe("DatasetFSProvider", () => {
                 const dsResponseMock = {
                     success: true,
                     apiResponse: {
-                        items: [{ name: "USER.DATA.PS" }],
+                        items: [{ dsname: "USER.DATA.PS" }],
                     },
                     commandResponse: "",
                 };
@@ -1213,7 +1221,7 @@ describe("DatasetFSProvider", () => {
                 const dsResponseMock = {
                     success: true,
                     apiResponse: {
-                        items: [{ name: "USER.DATA.PS", recfm: "VB", lrecl: lrecl }],
+                        items: [{ dsname: "USER.DATA.PS", recfm: "VB", lrecl: lrecl }],
                     },
                     commandResponse: "",
                 };
@@ -1247,6 +1255,7 @@ describe("DatasetFSProvider", () => {
                 }),
                 dataSet: vi.fn().mockResolvedValue(dsResponseMock),
             };
+            dsResponseMock.apiResponse.items[0].dsname = testEntries.ps.name;
             vi.spyOn(ZoweExplorerApiRegister, "getMvsApi").mockReturnValue(mockMvsApi as any);
             const statusMsgMock = vi.spyOn(Gui, "setStatusBarMessage");
             const session = {
@@ -1279,6 +1288,7 @@ describe("DatasetFSProvider", () => {
                 ...testEntries.session,
                 entries: new Map([[testEntries.ps.name, { ...testEntries.ps, wasAccessed: false }]]),
             };
+            dsResponseMock.apiResponse.items[0].dsname = testEntries.ps.name;
             const lookupParentDirMock = vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(session);
             const newContents = new Uint8Array([]);
             await DatasetFSProvider.instance.writeFile(testUris.ps, newContents, { create: false, overwrite: true });
@@ -1293,6 +1303,7 @@ describe("DatasetFSProvider", () => {
                 ...testEntries.session,
                 entries: new Map([[testEntries.ps.name, { ...testEntries.ps }]]),
             };
+            dsResponseMock.apiResponse.items[0].dsname = testEntries.ps.name;
             const testUriWithDiffQuery = testUris.ps.with({ query: "inDiff=true" });
             const lookupParentDirMock = vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(session);
             const newContents = new Uint8Array([]);
@@ -1309,6 +1320,7 @@ describe("DatasetFSProvider", () => {
                 ...testEntries.session,
                 entries: new Map(),
             };
+            dsResponseMock.apiResponse.items[0].dsname = testEntries.ps.name;
             vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(session);
             let err;
             try {
@@ -1325,6 +1337,7 @@ describe("DatasetFSProvider", () => {
                 ...testEntries.session,
                 entries: new Map([[testEntries.ps.name, { ...testEntries.ps, wasAccessed: false }]]),
             };
+            dsResponseMock.apiResponse.items[0].dsname = testEntries.ps.name;
             vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(session);
             let err;
             try {
@@ -1341,6 +1354,7 @@ describe("DatasetFSProvider", () => {
                 ...testEntries.session,
                 entries: new Map([[testEntries.ps.name, { ...testEntries.pds }]]),
             };
+            dsResponseMock.apiResponse.items[0].dsname = testEntries.pds.name;
             vi.spyOn(DatasetFSProvider.instance as any, "lookupParentDirectory").mockReturnValue(session);
             let err;
             try {
@@ -1370,7 +1384,7 @@ describe("DatasetFSProvider", () => {
             vi.spyOn(ZoweExplorerApiRegister, "getMvsApi").mockReturnValue({
                 dataSet: vi.fn().mockResolvedValue({
                     success: true,
-                    apiResponse: { items: [{ name: "USER.DATA.PS", dsorg: "PS" }] },
+                    apiResponse: { items: [{ dsname: "USER.DATA.PS", dsorg: "PS" }] },
                 }),
             } as any);
             await DatasetFSProvider.instance.stat(testUris.ps);
@@ -1407,7 +1421,7 @@ describe("DatasetFSProvider", () => {
             vi.spyOn(ZoweExplorerApiRegister, "getMvsApi").mockReturnValue({
                 dataSet: vi.fn().mockResolvedValue({
                     success: true,
-                    apiResponse: { items: [{ name: "USER.DATA.PS", dsorg: "PS" }] },
+                    apiResponse: { items: [{ dsname: "USER.DATA.PS", dsorg: "PS" }] },
                 }),
             } as any);
             const uriWithFetchQuery = testUris.ps.with({ query: "fetch=true" });
@@ -1422,7 +1436,7 @@ describe("DatasetFSProvider", () => {
             const dataSetMock = vi.fn().mockResolvedValue({
                 success: true,
                 apiResponse: {
-                    items: [{ name: "USER.DATA.PS", dsorg: "PS" }],
+                    items: [{ dsname: "USER.DATA.PS", dsorg: "PS" }],
                 },
                 commandResponse: "",
             });
@@ -1506,7 +1520,7 @@ describe("DatasetFSProvider", () => {
 
             const dataSetMock = vi.fn().mockResolvedValue({
                 success: true,
-                apiResponse: { items: [{ name: "USER.DATA.PS", dsorg: "PS" }] },
+                apiResponse: { items: [{ dsname: "USER.DATA.PS", dsorg: "PS" }] },
             });
             vi.spyOn(ZoweExplorerApiRegister, "getMvsApi").mockReturnValue({ dataSet: dataSetMock } as any);
             const result = await DatasetFSProvider.instance.stat(testUris.ps);
@@ -1550,7 +1564,7 @@ describe("DatasetFSProvider", () => {
                 vi.spyOn(ZoweExplorerApiRegister, "getMvsApi").mockReturnValue({
                     dataSet: vi.fn().mockResolvedValue({
                         success: true,
-                        apiResponse: { items: [{ name: "USER.DATA.PS", dsorg: "PS" }] },
+                        apiResponse: { items: [{ dsname: "USER.DATA.PS", dsorg: "PS" }] },
                         commandResponse: "",
                     }),
                 } as any);
@@ -2062,7 +2076,7 @@ describe("DatasetFSProvider", () => {
                             profile: testProfile,
                         })
                     ).rejects.toThrow();
-                    expect(dataSetMock).toHaveBeenCalledWith("USER.DATA", { attributes: true });
+                    expect(dataSetMock).toHaveBeenCalledWith("USER.DATA", { attributes: true, maxLength: 1 });
                 });
 
                 it("existing URI", async () => {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTree.unit.test.ts
@@ -4914,6 +4914,67 @@ describe("Dataset Tree Unit Tests - Function rename", () => {
             { overwrite: false }
         );
     });
+
+    it("Tests that rename() of member preserves extension in new URI", async () => {
+        createGlobalMocks();
+        const blockMocks = createBlockMocks();
+        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        mocked(Gui.showInputBox).mockResolvedValueOnce("NEWMEM");
+        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
+        const testTree = new DatasetTree();
+        testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
+
+        const node = new ZoweDatasetNode({
+            label: "OLDMEM",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            parentNode: testTree.mSessionNodes[1],
+            session: blockMocks.session,
+            profile: testTree.mSessionNodes[1].getProfile(),
+            contextOverride: Constants.DS_MEMBER_CONTEXT,
+        });
+        node.resourceUri = vscode.Uri.from({
+            scheme: ZoweScheme.DS,
+            path: "/sestest/HLQ.TEST.PDS/OLDMEM.jcl",
+        });
+
+        await testTree.rename(node);
+
+        expect(blockMocks.rename).toHaveBeenLastCalledWith(
+            expect.objectContaining({ path: "/sestest/HLQ.TEST.PDS/OLDMEM.jcl", scheme: ZoweScheme.DS }),
+            expect.objectContaining({ path: "/sestest/HLQ.TEST.PDS/NEWMEM.jcl", scheme: ZoweScheme.DS }),
+            { overwrite: false }
+        );
+    });
+
+    it("Tests that rename() of ps adds extension in new URI", async () => {
+        createGlobalMocks();
+        const blockMocks = createBlockMocks();
+        mocked(Profiles.getInstance).mockReturnValue(blockMocks.profileInstance);
+        mocked(Gui.showInputBox).mockResolvedValueOnce("HLQ.TEST.RENAME.COBOL");
+        mocked(vscode.window.createTreeView).mockReturnValueOnce(blockMocks.treeView);
+        const testTree = new DatasetTree();
+        testTree.mSessionNodes.push(blockMocks.datasetSessionNode);
+
+        const node = new ZoweDatasetNode({
+            label: "HLQ.TEST.RENAME.NODE",
+            collapsibleState: vscode.TreeItemCollapsibleState.None,
+            parentNode: testTree.mSessionNodes[1],
+            session: blockMocks.session,
+            profile: testTree.mSessionNodes[1].getProfile(),
+        });
+        node.resourceUri = vscode.Uri.from({
+            scheme: ZoweScheme.DS,
+            path: "/sestest/HLQ.TEST.RENAME.NODE",
+        });
+
+        await testTree.rename(node);
+
+        expect(blockMocks.rename).toHaveBeenLastCalledWith(
+            expect.objectContaining({ path: "/sestest/HLQ.TEST.RENAME.NODE", scheme: ZoweScheme.DS }),
+            expect.objectContaining({ path: "/sestest/HLQ.TEST.RENAME.COBOL.cbl", scheme: ZoweScheme.DS }),
+            { overwrite: false }
+        );
+    });
 });
 
 describe("Dataset Tree Unit Tests - Function checkFilterPattern", () => {

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -411,22 +411,14 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
                         throw vscode.FileSystemError.FileNotFound(uri);
                     }
                 } else {
-                    const requestedDsName = uriPath[0];
-                    const extension = DatasetUtils.getExtension(requestedDsName);
-                    const apiLookupName =
-                        extension && requestedDsName.toLowerCase().endsWith(extension)
-                            ? requestedDsName.slice(0, requestedDsName.length - extension.length)
-                            : requestedDsName;
-
-                    const resp = await ZoweExplorerApiRegister.getMvsApi(uriInfo.profile).dataSet(apiLookupName, {
+                    const requestedDsName = FsDatasetsUtils.trimExtension(uriPath[0]);
+                    const resp = await ZoweExplorerApiRegister.getMvsApi(uriInfo.profile).dataSet(requestedDsName, {
                         attributes: true,
+                        maxLength: 1,
                     });
 
                     const responseItems = resp.apiResponse?.items ?? [];
-                    const matchedItem =
-                        responseItems.find((ds) => (ds?.dsname ?? ds?.name)?.toUpperCase() === apiLookupName.toUpperCase()) ??
-                        (responseItems.every((ds) => typeof (ds?.dsname ?? ds?.name) !== "string") ? responseItems[0] : undefined);
-
+                    const matchedItem = responseItems.find((item) => item.dsname?.toUpperCase() === requestedDsName.toUpperCase());
                     if (resp.success && matchedItem) {
                         entryIsDir = matchedItem.dsorg?.startsWith("PO");
                         entryStats = DatasetUtils.getDataSetStats(matchedItem);
@@ -1061,7 +1053,10 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
             await AuthUtils.ensureAuthNotCancelled(profile);
             await AuthHandler.waitForUnlock(entry.metadata.profile);
             if (FsDatasetsUtils.isPdsEntry(entry) || !entry.isMember) {
-                await ZoweExplorerApiRegister.getMvsApi(entry.metadata.profile).renameDataSet(oldName, newName);
+                await ZoweExplorerApiRegister.getMvsApi(entry.metadata.profile).renameDataSet(
+                    FsDatasetsUtils.trimExtension(oldName),
+                    FsDatasetsUtils.trimExtension(newName)
+                );
             } else {
                 const pdsName = path.basename(path.posix.join(entry.metadata.path, ".."));
                 await ZoweExplorerApiRegister.getMvsApi(entry.metadata.profile).renameDataSetMember(

--- a/packages/zowe-explorer/src/trees/dataset/DatasetInit.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetInit.ts
@@ -63,7 +63,9 @@ export class DatasetInit {
             vscode.commands.registerCommand("zowe.ds.refreshNode", async (node, nodeList) => {
                 const statusMsg = Gui.setStatusBarMessage(`$(sync~spin) ${vscode.l10n.t("Pulling from Mainframe...")}`);
                 let selectedNodes = SharedUtils.getSelectedNodeList(node, nodeList);
-                selectedNodes = selectedNodes.filter((element) => SharedContext.isDs(element) || SharedContext.isDsMember(element) || SharedContext.isMigrated(element));
+                selectedNodes = selectedNodes.filter(
+                    (element) => SharedContext.isDs(element) || SharedContext.isDsMember(element) || SharedContext.isMigrated(element)
+                );
                 for (const item of selectedNodes) {
                     await DatasetActions.refreshPS(item as IZoweDatasetTreeNode);
                 }
@@ -73,7 +75,9 @@ export class DatasetInit {
         context.subscriptions.push(
             vscode.commands.registerCommand("zowe.ds.refreshDataset", async (node, nodeList) => {
                 let selectedNodes = SharedUtils.getSelectedNodeList(node, nodeList);
-                selectedNodes = selectedNodes.filter((element) => SharedContext.isDs(element) || SharedContext.isPdsNotFav(element) || SharedContext.isMigrated(element));
+                selectedNodes = selectedNodes.filter(
+                    (element) => SharedContext.isDs(element) || SharedContext.isPdsNotFav(element) || SharedContext.isMigrated(element)
+                );
                 for (const item of selectedNodes) {
                     if (SharedContext.isMigrated(item)) {
                         await DatasetActions.refreshPS(item as IZoweDatasetTreeNode);

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTree.ts
@@ -2288,8 +2288,9 @@ Would you like to do this now?`,
             })
         );
         if (afterMemberName && afterMemberName !== beforeMemberName) {
+            const extension = path.parse(node.resourceUri.path).ext;
             const newUri = node.resourceUri.with({
-                path: path.posix.join(path.posix.dirname(node.resourceUri.path), afterMemberName),
+                path: path.posix.join(path.posix.dirname(node.resourceUri.path), extension ? afterMemberName.concat(extension) : afterMemberName),
             });
             await vscode.workspace.fs.rename(node.resourceUri, newUri, { overwrite: false });
             node.resourceUri = newUri;
@@ -2353,8 +2354,9 @@ Would you like to do this now?`,
             })
         );
         if (afterDataSetName && afterDataSetName !== beforeDataSetName) {
+            const extension = DatasetUtils.getExtension(afterDataSetName);
             const newUri = node.resourceUri.with({
-                path: path.posix.join(path.posix.dirname(node.resourceUri.path), afterDataSetName),
+                path: path.posix.join(path.posix.dirname(node.resourceUri.path), extension ? afterDataSetName.concat(extension) : afterDataSetName),
             });
             await vscode.workspace.fs.rename(node.resourceUri, newUri, { overwrite: false });
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
Fixes a regression in #4295 where a favorited migrated PDS named `IBMUSER.TEST.REXX` would not show as migrated because the `.REXX` qualifier would be processed as an extension and stripped off in `fetchDataset` API.

Also fixes #4142 with extensions not being handled properly when renaming data sets and members.

### How to Test
* Rename a sequential data set:
  * When there is no extension suffix (e.g. `TEST.PS` -> `TEST.PS2`)
  * When extension suffix is being preserved (e.g. `TEST.JCL` -> `TEST2.JCL`)
  * When extension suffix is being added (e.g. `TEST.PS` -> `TEST.JCL`)
  * When extension suffix is being removed (e.g. `TEST.JCL` -> `TEST.PS`)
* Renaming member should work for PDS with + without extension suffix

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone: 3.5.1

Changelog: TBD

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
