### PR TITLE
Add configurable setting for job delete confirmation dialog

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### New features and enhancements
 
+- Added a new VS Code toggle setting `zowe.jobs.confirmDelete` that allows users to disable the job deletion confirmation dialog. [#4315](https://github.com/zowe/zowe-explorer-vscode/issues/4315)
 - Renamed references to "MVS Command" to "Console Command" for clarity. [#4300](https://github.com/zowe/zowe-explorer-vscode/issues/4300)
 
 ### Bug fixes

--- a/packages/zowe-explorer/package.json
+++ b/packages/zowe-explorer/package.json
@@ -2078,6 +2078,12 @@
           "description": "%zowe.jobs.confirmSubmission%",
           "scope": "window"
         },
+        "zowe.jobs.confirmDelete": {
+          "type": "boolean",
+          "default": true,
+          "description": "%zowe.jobs.confirmDelete%",
+          "scope": "window"
+        },
         "zowe.commands.useIntegratedTerminals": {
           "type": "boolean",
           "default": false,

--- a/packages/zowe-explorer/package.nls.json
+++ b/packages/zowe-explorer/package.nls.json
@@ -117,6 +117,7 @@
   "zowe.jobs.default.sort.direction.description": "Default direction to sort jobs",
   "zowe.jobs.default.sort.description": "Default sort order for jobs",
   "zowe.jobs.confirmSubmission": "Require user confirmation before submitting a job",
+  "zowe.jobs.confirmDelete": "Prompt for confirmation before deleting jobs.",
   "zowe.jobs.confirmSubmission.yourJobs": "Your Jobs",
   "zowe.jobs.confirmSubmission.otherUserJobs": "Other user Jobs",
   "zowe.jobs.confirmSubmission.allJobs": "All Jobs",

--- a/packages/zowe-explorer/src/trees/job/JobActions.ts
+++ b/packages/zowe-explorer/src/trees/job/JobActions.ts
@@ -34,14 +34,17 @@ export class JobActions {
             comment: ["Job name"],
         });
         const deleteButton = vscode.l10n.t("Delete");
-        const result = await Gui.warningMessage(message, {
-            items: [deleteButton],
-            vsCodeOpts: { modal: true },
-        });
-        if (!result || result === "Cancel") {
-            ZoweLogger.debug(vscode.l10n.t("Delete action was canceled."));
-            Gui.showMessage(vscode.l10n.t("Delete action was cancelled."));
-            return;
+        const confirmDelete = vscode.workspace.getConfiguration().get<boolean>("zowe.jobs.confirmDelete", true);
+        if (confirmDelete) {
+            const result = await Gui.warningMessage(message, {
+                items: [deleteButton],
+                vsCodeOpts: { modal: true },
+            });
+            if (!result || result === "Cancel") {
+                ZoweLogger.debug(vscode.l10n.t("Delete action was canceled."));
+                Gui.showMessage(vscode.l10n.t("Delete action was cancelled."));
+                return;
+            }
         }
 
         try {
@@ -72,14 +75,17 @@ export class JobActions {
             args: [jobs.length, displayedJobNames, additionalJobsCount > 0 ? `\n...and ${additionalJobsCount} more` : ""],
             comment: ["Jobs length", "Job names", "Additional jobs count"],
         });
-        const deleteChoice = await Gui.warningMessage(message, {
-            items: [deleteButton],
-            vsCodeOpts: { modal: true },
-        });
-        if (!deleteChoice || deleteChoice === "Cancel") {
-            ZoweLogger.debug(vscode.l10n.t("Delete action was canceled."));
-            Gui.showMessage(vscode.l10n.t("Delete action was cancelled."));
-            return;
+        const confirmDelete = vscode.workspace.getConfiguration().get<boolean>("zowe.jobs.confirmDelete", true);
+        if (confirmDelete) {
+            const deleteChoice = await Gui.warningMessage(message, {
+                items: [deleteButton],
+                vsCodeOpts: { modal: true },
+            });
+            if (!deleteChoice || deleteChoice === "Cancel") {
+                ZoweLogger.debug(vscode.l10n.t("Delete action was canceled."));
+                Gui.showMessage(vscode.l10n.t("Delete action was cancelled."));
+                return;
+            }
         }
         const deletionResult: ReadonlyArray<IZoweJobTreeNode | Error> = await Promise.all(
             jobs.map(async (job) => {


### PR DESCRIPTION
## Proposed changes

Resolves #4315

Adds a new VS Code setting, `zowe.jobs.confirmDelete`, that allows users to disable the job deletion confirmation dialog.

The setting defaults to `true`, preserving the current behavior. When disabled, users can delete jobs without being prompted for confirmation.

The setting is applied to both single-job and multi-job deletion workflows.

## Release Notes

Milestone: TBD

Changelog:

* Added `zowe.jobs.confirmDelete` setting to control whether users are prompted before deleting jobs.

## Types of changes

* [x] Enhancement (non-breaking change which adds or improves functionality)

## Checklist

### General

* [x] I have read the CONTRIBUTOR GUIDANCE wiki
* [ ] All PR dependencies have been merged and published (if applicable)
* [ ] A GIF or screenshot is included in the PR for visual changes
* [ ] The pre-publish command has been executed
* [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes

### Code coverage

* [ ] There is coverage for the code that I have added
* [ ] I have added new test cases and they are passing
* [x] I have manually tested the changes

### Deployment

* [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
* [ ] I have added developer documentation (if applicable)
* [ ] Documentation should be added to Zowe Docs
* [ ] These changes may need ported to the appropriate branches

## Further comments

The existing delete confirmation behavior remains unchanged by default. The new setting provides an option for power users and enables easier automation and end-to-end testing scenarios where interactive confirmation dialogs are undesirable.
