### PR TITLE
fix(tables): rename context menu option from 'Display in Tree' to 'Locate in Tree'

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Renamed the context menu option "Display in Tree" to "Locate in Tree" in the Jobs table view for better clarity. [#3771](https://github.com/zowe/zowe-explorer-vscode/issues/3771)
 - Fixed an issue that caused a rename to fail when removing the rightmost qualifier from a data set name. [#4273](https://github.com/zowe/zowe-explorer-vscode/issues/4273)
 - Fixed an issue where copying a USS file across profiles when a profile encoding was configured would corrupt characters in the destination file because the encoding was not passed to the upload call. [#4262](https://github.com/zowe/zowe-explorer-vscode/pull/4262)
 - Fixed an issue where submitting a job from a favorited PDS member would fail. [#4282](https://github.com/zowe/zowe-explorer-vscode/issues/4282)

--- a/packages/zowe-explorer/__tests__/__e2e__/features/views/DatasetTableView.feature
+++ b/packages/zowe-explorer/__tests__/__e2e__/features/views/DatasetTableView.feature
@@ -46,7 +46,7 @@ Scenario: User wants to focus on a PDS to view its members
 Scenario: User wants to reveal PDS member in tree from table view
     Given a user who has the dataset table view opened with PDS members
     When the user right-clicks on a member row
-    And selects "Display in Tree" from the context menu
+    And selects "Locate in Tree" from the context menu
     Then the PDS member is revealed and focused in the Data Sets tree
 
 Scenario: User wants to navigate back from PDS members view
@@ -58,7 +58,7 @@ Scenario: User wants to navigate back from PDS members view
 Scenario: User wants to reveal dataset in tree from table view
     Given a user who has the dataset table view opened
     When the user right-clicks on a dataset row
-    And selects "Display in Tree" from the context menu
+    And selects "Locate in Tree" from the context menu
     Then the dataset is revealed and focused in the Data Sets tree
 
 Scenario: User wants to use hierarchical tree view for datasets with PDS

--- a/packages/zowe-explorer/__tests__/__e2e__/step_definitions/views/DatasetTableView.steps.ts
+++ b/packages/zowe-explorer/__tests__/__e2e__/step_definitions/views/DatasetTableView.steps.ts
@@ -425,9 +425,9 @@ When("the user right-clicks on a member row", async function () {
     );
 });
 
-When('selects "Display in Tree" from the context menu', async function () {
+When('selects "Locate in Tree" from the context menu', async function () {
     const page = await getTableViewPage(this);
-    await page.clickContextMenuItem("Display in Tree");
+    await page.clickContextMenuItem("Locate in Tree");
 });
 
 Then("the dataset is revealed and focused in the Data Sets tree", async function () {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTableView.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetTableView.unit.test.ts
@@ -2510,7 +2510,7 @@ describe("DatasetTableView action handlers/callbacks", () => {
                 const contextOptions = (datasetTableView as any).contextOptions;
 
                 expect(contextOptions.displayInTree).toBeDefined();
-                expect(contextOptions.displayInTree.title).toBe("Display in Tree");
+                expect(contextOptions.displayInTree.title).toBe("Locate in Tree");
                 expect(contextOptions.displayInTree.command).toBe("display-in-tree");
                 expect(contextOptions.displayInTree.callback.typ).toBe("single-row");
                 expect(contextOptions.displayInTree.callback.fn).toBe(DatasetTableView.displayInTree);

--- a/packages/zowe-explorer/l10n/bundle.l10n.json
+++ b/packages/zowe-explorer/l10n/bundle.l10n.json
@@ -581,7 +581,7 @@
   "Disable Profile Validation": "Disable Profile Validation",
   "Disable validation of server check for profile": "Disable validation of server check for profile",
   "Disabled": "Disabled",
-  "Display in Tree": "Display in Tree",
+  "Locate in Tree": "Locate in Tree",
   "Display release notes after an update": "Display release notes after an update",
   "Display the data set in the **DATA SETS** tree": "Display the data set in the **DATA SETS** tree",
   "Do you wish to apply this for all trees?": "Do you wish to apply this for all trees?",

--- a/packages/zowe-explorer/l10n/poeditor.json
+++ b/packages/zowe-explorer/l10n/poeditor.json
@@ -979,7 +979,7 @@
   "Disable Profile Validation": "",
   "Disable validation of server check for profile": "",
   "Disabled": "",
-  "Display in Tree": "",
+  "Locate in Tree": "",
   "Display release notes after an update": "",
   "Display the data set in the **DATA SETS** tree": "",
   "Do you wish to apply this for all trees?": "",

--- a/packages/zowe-explorer/src/trees/dataset/DatasetTableView.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetTableView.ts
@@ -395,7 +395,7 @@ export class DatasetTableView {
     private PAGE_SIZE_OPTIONS = [10, 25, 50, 100, 500, 1000];
     private contextOptions: Record<string, Table.ContextMenuOption> = {
         displayInTree: {
-            title: l10n.t("Display in Tree"),
+            title: l10n.t("Locate in Tree"),
             command: "display-in-tree",
             callback: {
                 fn: DatasetTableView.displayInTree,

--- a/packages/zowe-explorer/src/trees/job/JobTableView.ts
+++ b/packages/zowe-explorer/src/trees/job/JobTableView.ts
@@ -30,7 +30,7 @@ export class JobTableView {
             },
         },
         displayInTree: {
-            title: l10n.t("Display in Tree"),
+            title: l10n.t("Locate in Tree"),
             command: "display-in-tree",
             callback: {
                 fn: JobTableView.displayInTree,


### PR DESCRIPTION
Closes #3771

## What changed

The context menu option in both the Data Sets and Jobs table views has been renamed from **"Display in Tree"** to **"Locate in Tree"**.

## Why

"Display in Tree" reads like a toggle — as if clicking it will show or hide something. The actual behaviour is navigation: it jumps to the item and focuses it in the tree view. "Locate in Tree" describes that action accurately, which is the same conclusion the UX review in the issue reached.

## Files updated

| File | Change |
|---|---|
| `src/trees/dataset/DatasetTableView.ts` | Label updated |
| `src/trees/job/JobTableView.ts` | Label updated |
| `l10n/bundle.l10n.json` | l10n key renamed |
| `l10n/poeditor.json` | l10n key renamed |
| `__tests__/__unit__/.../DatasetTableView.unit.test.ts` | Assertion updated |
| `__tests__/__e2e__/features/.../DatasetTableView.feature` | Step text updated (×2) |
| `__tests__/__e2e__/step_definitions/.../DatasetTableView.steps.ts` | Step definition updated (×2) |

## Testing

- 157/157 unit tests pass
- Zero remaining occurrences of the old string confirmed via grep
