### PR TITLE
tests: End-to-end tests for commands, implement `SshCommandApi.issueUnixCommand`

### DIFF
--- a/packages/zowe-explorer/__tests__/__e2e__/.env.example
+++ b/packages/zowe-explorer/__tests__/__e2e__/.env.example
@@ -10,6 +10,7 @@ ZE_TEST_VSCODE_VER="stable"
 
 # Profile variables
 ZE_TEST_PROFILE_NAME="<profileName>" # The name of the profile in your Zowe config to use for testing
+ZE_TEST_TSO_PROFILE_NAME="<tsoProfileName>" # The name of the TSO profile in your Zowe config to use for testing
 ZE_TEST_PROFILE_USER="testUser" # The user to leverage during the e2e tests
 
 # USS variables

--- a/packages/zowe-explorer/__tests__/__e2e__/.env.example
+++ b/packages/zowe-explorer/__tests__/__e2e__/.env.example
@@ -11,6 +11,7 @@ ZE_TEST_VSCODE_VER="stable"
 # Profile variables
 ZE_TEST_PROFILE_NAME="<profileName>" # The name of the profile in your Zowe config to use for testing
 ZE_TEST_TSO_PROFILE_NAME="<tsoProfileName>" # The name of the TSO profile in your Zowe config to use for testing
+ZE_TEST_SSH_PROFILE_NAME="<sshProfileName>" # The name of the SSH profile in your Zowe config to use for testing
 ZE_TEST_PROFILE_USER="testUser" # The user to leverage during the e2e tests
 
 # USS variables

--- a/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
+++ b/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
@@ -8,10 +8,11 @@ Scenario Outline: User wants to issue a command
     And a user selects a TSO profile if required
     Then a user can enter in <cmd> as the command and submit it
     Then a notification appears with message "<msg>"
+    And the "<channel>" output channel contains output matching "<regex>"
 
     Examples:
-      | opt | cmd | msg |
-      | Issue TSO Command | PROFILE | TSO command submitted. |
-      | Issue Console Command | D T | Console command submitted. |
-      | Issue Unix Command | pwd | Unix command submitted. |
+      | opt | cmd | msg | channel | regex |
+      | Issue TSO Command | PROFILE | TSO command submitted. | Zowe TSO Command | (IKJ\d+I\|READY\|PREFIX\() |
+      | Issue Console Command | D T | Console command submitted. | Zowe Console Command | (IEE\d+I\|CNZ\d+I\|TIME) |
+      | Issue Unix Command | pwd | Unix command submitted. | Zowe Unix Command | \/ |
 

--- a/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
+++ b/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
@@ -15,5 +15,5 @@ Scenario Outline: User wants to issue a command
       | opt | cmd | msg | channel | regex | serviceProfileType |
       | Issue TSO Command | PROFILE | TSO command submitted. | Zowe TSO Command | (IKJ\d+I\|READY\|PREFIX\() | tso |
       | Issue Console Command | D T | Console command submitted. | Zowe Console Command | (IEE\d+I\|CNZ\d+I\|TIME) | none |
-      | Issue Unix Command | pwd | Unix command submitted. | Zowe Unix Command | \/ | ssh |
+      | Issue Unix Command | pwd | Unix command submitted. | Zowe Unix Command | USS_DIR | ssh |
 

--- a/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
+++ b/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
@@ -5,6 +5,7 @@ Scenario Outline: User wants to issue a command
     When a user selects <opt> from the command palette
     Then a quick pick appears to select a profile
     When a user selects a profile
+    And a user selects a TSO profile if required
     Then a user can enter in <cmd> as the command and submit it
     Then a notification appears with message "<msg>"
 

--- a/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
+++ b/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
@@ -5,14 +5,15 @@ Scenario Outline: User wants to issue a command
     When a user selects <opt> from the command palette
     Then a quick pick appears to select a profile
     When a user selects a profile
-    And a user selects a TSO profile if required
+    And a user selects a secondary profile of type "<serviceProfileType>" if required
+    And a user selects a working directory if required
     Then a user can enter in <cmd> as the command and submit it
     Then a notification appears with message "<msg>"
     And the "<channel>" output channel contains output matching "<regex>"
 
     Examples:
-      | opt | cmd | msg | channel | regex |
-      | Issue TSO Command | PROFILE | TSO command submitted. | Zowe TSO Command | (IKJ\d+I\|READY\|PREFIX\() |
-      | Issue Console Command | D T | Console command submitted. | Zowe Console Command | (IEE\d+I\|CNZ\d+I\|TIME) |
-      | Issue Unix Command | pwd | Unix command submitted. | Zowe Unix Command | \/ |
+      | opt | cmd | msg | channel | regex | serviceProfileType |
+      | Issue TSO Command | PROFILE | TSO command submitted. | Zowe TSO Command | (IKJ\d+I\|READY\|PREFIX\() | tso |
+      | Issue Console Command | D T | Console command submitted. | Zowe Console Command | (IEE\d+I\|CNZ\d+I\|TIME) | none |
+      | Issue Unix Command | pwd | Unix command submitted. | Zowe Unix Command | \/ | ssh |
 

--- a/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
+++ b/packages/zowe-explorer/__tests__/__e2e__/features/dialogs/IssueCommand.feature
@@ -6,9 +6,11 @@ Scenario Outline: User wants to issue a command
     Then a quick pick appears to select a profile
     When a user selects a profile
     Then a user can enter in <cmd> as the command and submit it
+    Then a notification appears with message "<msg>"
 
     Examples:
-      | opt | cmd |
-      | Issue TSO Command | PROFILE |
-      | Issue Console Command | D T |
-      | Issue Unix Command | pwd |
+      | opt | cmd | msg |
+      | Issue TSO Command | PROFILE | TSO command submitted. |
+      | Issue Console Command | D T | Console command submitted. |
+      | Issue Unix Command | pwd | Unix command submitted. |
+

--- a/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
+++ b/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
@@ -61,11 +61,15 @@ When("a user selects a profile", async function () {
     await expect(this.input.elem).toBeDisplayedInViewport();
 });
 
-When("a user selects a TSO profile if required", async function () {
+When(/a user selects a secondary profile of type "(.*)" if required/, async function (profileType: string) {
     await expect(this.input).toBeDefined();
-    if (this.openedCommand === "Issue TSO Command") {
-        // Since we are issuing a TSO command, check if VS Code is prompting for a TSO service profile
-        const placeholder = await this.input.getPlaceHolder();
+    if (profileType === "none") {
+        return;
+    }
+
+    const placeholder = await this.input.getPlaceHolder();
+
+    if (profileType === "tso") {
         if (placeholder.includes("Select a TSO profile") || placeholder.includes("Select the profile")) {
             console.log(`TSO profile selection required (placeholder: "${placeholder}"). Selecting TSO profile...`);
             const tsoProfileName = process.env.ZE_TEST_TSO_PROFILE_NAME || process.env.ZE_TEST_PROFILE_NAME;
@@ -78,6 +82,36 @@ When("a user selects a TSO profile if required", async function () {
         } else {
             console.log(`TSO profile selection not prompted. Current placeholder: "${placeholder}"`);
         }
+    } else if (profileType === "ssh") {
+        if (
+            placeholder.includes("submit the Unix command") ||
+            placeholder.includes("Select an SSH profile") ||
+            placeholder.includes("Select the profile")
+        ) {
+            console.log(`SSH profile selection required (placeholder: "${placeholder}"). Selecting SSH profile...`);
+            const sshProfileName = process.env.ZE_TEST_SSH_PROFILE_NAME;
+            if (sshProfileName) {
+                await this.input.selectQuickPick(sshProfileName);
+            } else {
+                await this.input.selectQuickPick(0);
+            }
+            await expect(this.input.elem).toBeDisplayedInViewport();
+        } else {
+            console.log(`SSH profile selection not prompted. Current placeholder: "${placeholder}"`);
+        }
+    }
+});
+
+When("a user selects a working directory if required", async function () {
+    await expect(this.input).toBeDefined();
+    if (this.openedCommand === "Issue Unix Command") {
+        // Since we are issuing a Unix command, we expect it to ask for the working directory path
+        console.log("Checking working directory prompt...");
+        const dir = process.env.ZE_TEST_USS_FILTER || "/";
+        console.log(`Entering working directory path: "${dir}"`);
+        await this.input.setText(dir);
+        await this.input.confirm();
+        await expect(this.input.elem).toBeDisplayedInViewport();
     }
 });
 

--- a/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
+++ b/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
@@ -11,6 +11,7 @@
 
 import { Then, When } from "@cucumber/cucumber";
 import { ProfileInfo } from "@zowe/imperative";
+import { Key } from "webdriverio";
 import * as path from "path";
 
 const ALLOWED_COMMANDS_BY_PROFILE_TYPE: Record<string, string[]> = {
@@ -62,6 +63,25 @@ async function selectQuickPickItem(inputBox: any, indexOrText: string | number):
             timeoutMsg: `Quick pick item "${indexOrText}" was not found or could not be selected within 10 seconds.`,
         }
     );
+}
+
+async function setInputText(inputBox: any, text: string): Promise<void> {
+    // Click the input box to focus it
+    await inputBox.elem.click();
+    await browser.pause(100);
+
+    // Select all text: CMD+A on macOS, CTRL+A on Windows/Linux
+    const modifierKey = process.platform === "darwin" ? Key.Command : Key.Control;
+    await browser.action("key").down(modifierKey).down("a").up(modifierKey).up("a").perform();
+    await browser.pause(100);
+
+    // Delete selected text
+    await browser.action("key").down(Key.Backspace).up(Key.Backspace).perform();
+    await browser.pause(100);
+
+    // Type the new text
+    await browser.keys(text);
+    await browser.pause(200);
 }
 
 When(/a user selects (.*) from the command palette/, async function (command: string) {
@@ -139,14 +159,14 @@ When("a user selects a working directory if required", async function () {
         console.log("Checking working directory prompt...");
         const dir = process.env.ZE_TEST_USS_FILTER || "/";
         console.log(`Entering working directory path: "${dir}"`);
-        await this.input.setText(dir);
+        await setInputText(this.input, dir);
         await this.input.confirm();
         await expect(this.input.elem).toBeDisplayedInViewport();
     }
 });
 
 Then(/a user can enter in (.*) as the command and submit it/, async function (command: string) {
-    await this.input.setText(command);
+    await setInputText(this.input, command);
     await this.input.confirm();
 });
 

--- a/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
+++ b/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
@@ -148,7 +148,15 @@ Then(/the "(.*)" output channel contains output matching "(.*)"/, async function
     // Select our target output channel
     await outputView.selectChannel(channelName);
 
-    const regex = new RegExp(regexPattern);
+    // Dynamic resolution of placeholders
+    let finalPattern = regexPattern;
+    if (regexPattern === "USS_DIR") {
+        const ussDir = process.env.ZE_TEST_USS_FILTER || "/";
+        // Escape special regex characters in the directory path to ensure a safe match
+        finalPattern = ussDir.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&");
+    }
+
+    const regex = new RegExp(finalPattern);
 
     // Wait up to a few seconds for the command output to stream to the channel.
     await browser.waitUntil(
@@ -163,7 +171,7 @@ Then(/the "(.*)" output channel contains output matching "(.*)"/, async function
         },
         {
             timeout: 10000,
-            timeoutMsg: `Output matching pattern "${regexPattern}" did not appear in output channel "${channelName}" within timeout.`,
+            timeoutMsg: `Output matching pattern "${finalPattern}" did not appear in output channel "${channelName}" within timeout.`,
         }
     );
 });

--- a/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
+++ b/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
@@ -105,3 +105,31 @@ Then(/a notification appears with message "(.*)"/, async function (expectedMessa
         }
     );
 });
+
+Then(/the "(.*)" output channel contains output matching "(.*)"/, async function (channelName: string, regexPattern: string) {
+    const workbench = await browser.getWorkbench();
+    const bottomBar = workbench.getBottomBar();
+    const outputView = await bottomBar.openOutputView();
+
+    // Select our target output channel
+    await outputView.selectChannel(channelName);
+
+    const regex = new RegExp(regexPattern);
+
+    // Wait up to a few seconds for the command output to stream to the channel.
+    await browser.waitUntil(
+        async () => {
+            const lines = await outputView.getText();
+            for (const line of lines) {
+                if (regex.test(line)) {
+                    return true;
+                }
+            }
+            return false;
+        },
+        {
+            timeout: 10000,
+            timeoutMsg: `Output matching pattern "${regexPattern}" did not appear in output channel "${channelName}" within timeout.`,
+        }
+    );
+});

--- a/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
+++ b/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
@@ -15,7 +15,7 @@ import * as path from "path";
 
 const ALLOWED_COMMANDS_BY_PROFILE_TYPE: Record<string, string[]> = {
     zosmf: ["Issue TSO Command", "Issue Console Command", "Issue Unix Command"],
-    ssh: ["Issue TSO Command"],
+    ssh: ["Issue TSO Command", "Issue Unix Command"],
 };
 
 async function getProfileType(profileName: string): Promise<string | undefined> {

--- a/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
+++ b/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
@@ -10,8 +10,40 @@
  */
 
 import { Then, When } from "@cucumber/cucumber";
+import { ProfileInfo } from "@zowe/imperative";
+import * as path from "path";
+
+const ALLOWED_COMMANDS_BY_PROFILE_TYPE: Record<string, string[]> = {
+    zosmf: ["Issue TSO Command", "Issue Console Command", "Issue Unix Command"],
+    ssh: ["Issue TSO Command"],
+};
+
+async function getProfileType(profileName: string): Promise<string | undefined> {
+    try {
+        const homeDir = process.env.ZOWE_TEST_DIR ? path.resolve(process.env.ZOWE_TEST_DIR) : undefined;
+        const profileInfo = new ProfileInfo("zowe");
+        await profileInfo.readProfilesFromDisk({ homeDir });
+        const allProfiles = profileInfo.getAllProfiles();
+        const found = allProfiles.find((prof) => prof.profName === profileName);
+        if (found) {
+            return found.profType;
+        }
+    } catch (error) {
+        console.error(`Failed to infer profile type for "${profileName}" via @zowe/imperative:`, error);
+    }
+    return undefined;
+}
 
 When(/a user selects (.*) from the command palette/, async function (command: string) {
+    const profileName = process.env.ZE_TEST_PROFILE_NAME;
+    const profileType = profileName ? await getProfileType(profileName) : process.env.ZE_TEST_PROFILE_TYPE || "zosmf";
+    const allowedCommands = ALLOWED_COMMANDS_BY_PROFILE_TYPE[profileType];
+
+    if (allowedCommands && !allowedCommands.includes(command)) {
+        console.log(`Skipping command "${command}" for profile "${profileName}" of type "${profileType}"`);
+        return "skipped";
+    }
+
     this.input = await (await browser.getWorkbench()).executeQuickPick(`Zowe Explorer: ${command}`);
     this.openedCommand = command;
 });
@@ -20,12 +52,36 @@ Then("a quick pick appears to select a profile", async function () {
 });
 When("a user selects a profile", async function () {
     await expect(this.input).toBeDefined();
-    const qpItems = await this.input.getQuickPicks();
-    await qpItems.at(0).select();
+    const profileName = process.env.ZE_TEST_PROFILE_NAME;
+    if (profileName) {
+        await this.input.selectQuickPick(profileName);
+    } else {
+        await this.input.selectQuickPick(0);
+    }
     await expect(this.input.elem).toBeDisplayedInViewport();
 });
 
 Then(/a user can enter in (.*) as the command and submit it/, async function (command: string) {
     await this.input.setText(command);
     await this.input.confirm();
+});
+
+Then(/a notification appears with message "(.*)"/, async function (expectedMessage: string) {
+    const workbench = await browser.getWorkbench();
+    await browser.waitUntil(
+        async () => {
+            const notifications = await workbench.getNotifications();
+            for (const notif of notifications) {
+                const message = await notif.getMessage();
+                if (message.includes(expectedMessage)) {
+                    return true;
+                }
+            }
+            return false;
+        },
+        {
+            timeout: 15000,
+            timeoutMsg: `Notification with message "${expectedMessage}" did not appear within timeout.`,
+        }
+    );
 });

--- a/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
+++ b/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
@@ -34,6 +34,36 @@ async function getProfileType(profileName: string): Promise<string | undefined> 
     return undefined;
 }
 
+async function selectQuickPickItem(inputBox: any, indexOrText: string | number): Promise<void> {
+    await browser.waitUntil(
+        async () => {
+            const picks = await inputBox.getQuickPicks();
+            if (picks.length === 0) {
+                return false;
+            }
+            if (typeof indexOrText === "number") {
+                if (picks.length > indexOrText) {
+                    await picks[indexOrText].select();
+                    return true;
+                }
+            } else {
+                for (const pick of picks) {
+                    const label = await pick.getLabel();
+                    if (label.includes(indexOrText)) {
+                        await pick.select();
+                        return true;
+                    }
+                }
+            }
+            return false;
+        },
+        {
+            timeout: 10000,
+            timeoutMsg: `Quick pick item "${indexOrText}" was not found or could not be selected within 10 seconds.`,
+        }
+    );
+}
+
 When(/a user selects (.*) from the command palette/, async function (command: string) {
     const profileName = process.env.ZE_TEST_PROFILE_NAME;
     const profileType = profileName ? await getProfileType(profileName) : process.env.ZE_TEST_PROFILE_TYPE || "zosmf";
@@ -54,9 +84,9 @@ When("a user selects a profile", async function () {
     await expect(this.input).toBeDefined();
     const profileName = process.env.ZE_TEST_PROFILE_NAME;
     if (profileName) {
-        await this.input.selectQuickPick(profileName);
+        await selectQuickPickItem(this.input, profileName);
     } else {
-        await this.input.selectQuickPick(0);
+        await selectQuickPickItem(this.input, 0);
     }
     await expect(this.input.elem).toBeDisplayedInViewport();
 });
@@ -74,9 +104,9 @@ When(/a user selects a secondary profile of type "(.*)" if required/, async func
             console.log(`TSO profile selection required (placeholder: "${placeholder}"). Selecting TSO profile...`);
             const tsoProfileName = process.env.ZE_TEST_TSO_PROFILE_NAME || process.env.ZE_TEST_PROFILE_NAME;
             if (tsoProfileName) {
-                await this.input.selectQuickPick(tsoProfileName);
+                await selectQuickPickItem(this.input, tsoProfileName);
             } else {
-                await this.input.selectQuickPick(0);
+                await selectQuickPickItem(this.input, 0);
             }
             await expect(this.input.elem).toBeDisplayedInViewport();
         } else {
@@ -91,9 +121,9 @@ When(/a user selects a secondary profile of type "(.*)" if required/, async func
             console.log(`SSH profile selection required (placeholder: "${placeholder}"). Selecting SSH profile...`);
             const sshProfileName = process.env.ZE_TEST_SSH_PROFILE_NAME;
             if (sshProfileName) {
-                await this.input.selectQuickPick(sshProfileName);
+                await selectQuickPickItem(this.input, sshProfileName);
             } else {
-                await this.input.selectQuickPick(0);
+                await selectQuickPickItem(this.input, 0);
             }
             await expect(this.input.elem).toBeDisplayedInViewport();
         } else {

--- a/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
+++ b/packages/zowe-explorer/__tests__/__e2e__/step_definitions/dialogs/IssueCommand.steps.ts
@@ -61,6 +61,26 @@ When("a user selects a profile", async function () {
     await expect(this.input.elem).toBeDisplayedInViewport();
 });
 
+When("a user selects a TSO profile if required", async function () {
+    await expect(this.input).toBeDefined();
+    if (this.openedCommand === "Issue TSO Command") {
+        // Since we are issuing a TSO command, check if VS Code is prompting for a TSO service profile
+        const placeholder = await this.input.getPlaceHolder();
+        if (placeholder.includes("Select a TSO profile") || placeholder.includes("Select the profile")) {
+            console.log(`TSO profile selection required (placeholder: "${placeholder}"). Selecting TSO profile...`);
+            const tsoProfileName = process.env.ZE_TEST_TSO_PROFILE_NAME || process.env.ZE_TEST_PROFILE_NAME;
+            if (tsoProfileName) {
+                await this.input.selectQuickPick(tsoProfileName);
+            } else {
+                await this.input.selectQuickPick(0);
+            }
+            await expect(this.input.elem).toBeDisplayedInViewport();
+        } else {
+            console.log(`TSO profile selection not prompted. Current placeholder: "${placeholder}"`);
+        }
+    }
+});
+
 Then(/a user can enter in (.*) as the command and submit it/, async function (command: string) {
     await this.input.setText(command);
     await this.input.confirm();

--- a/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/dataset/DatasetActions.unit.test.ts
@@ -693,7 +693,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
 
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith(
             `The following 1 item(s) were deleted:\n ` +
-            `${blockMocks.testMemberNode.getParent().getLabel().toString()}(${blockMocks.testMemberNode.getLabel().toString()})`
+                `${blockMocks.testMemberNode.getParent().getLabel().toString()}(${blockMocks.testMemberNode.getLabel().toString()})`
         );
         expect(blockMocks.fixMultiSelectMock).toHaveBeenCalledWith(blockMocks.testDatasetTree, blockMocks.testMemberNode.getParent());
     });
@@ -743,7 +743,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
 
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith(
             `The following 2 item(s) were deleted:\n ` +
-            `${blockMocks.testDatasetNode.getLabel().toString()}\n ${blockMocks.testVsamNode.getLabel().toString()}`
+                `${blockMocks.testDatasetNode.getLabel().toString()}\n ${blockMocks.testVsamNode.getLabel().toString()}`
         );
     });
 
@@ -776,7 +776,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
 
         expect(mocked(Gui.warningMessage)).toHaveBeenCalledWith(
             `Are you sure you want to delete the following 1 item(s)?\nThis will permanently remove these data sets and/or members from your ` +
-            `system.\n\n ${blockMocks.testFavoritedNode.getLabel().toString()}`,
+                `system.\n\n ${blockMocks.testFavoritedNode.getLabel().toString()}`,
             { items: ["Delete"], vsCodeOpts: { modal: true } }
         );
     });
@@ -794,7 +794,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
 
         expect(mocked(Gui.warningMessage)).toHaveBeenCalledWith(
             `Are you sure you want to delete the following 1 item(s)?\nThis will permanently remove these data sets and/or members from your ` +
-            `system.\n\n ${blockMocks.testFavoritedNode.getLabel().toString()}(${blockMocks.testFavMemberNode.getLabel().toString()})`,
+                `system.\n\n ${blockMocks.testFavoritedNode.getLabel().toString()}(${blockMocks.testFavMemberNode.getLabel().toString()})`,
             { items: ["Delete"], vsCodeOpts: { modal: true } }
         );
     });
@@ -861,7 +861,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
 
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith(
             `The following 2 item(s) were deleted:\n ` +
-            `${blockMocks.testDatasetNode.getLabel().toString()}\n ${blockMocks.testFavoritedNode.getLabel().toString()}`
+                `${blockMocks.testDatasetNode.getLabel().toString()}\n ${blockMocks.testFavoritedNode.getLabel().toString()}`
         );
     });
 
@@ -888,7 +888,7 @@ describe("Dataset Actions Unit Tests - Function deleteDatasetPrompt", () => {
         await DatasetActions.deleteDatasetPrompt(blockMocks.testDatasetTree, blockMocks.testMemberNode);
         expect(mocked(Gui.showMessage)).toHaveBeenCalledWith(
             `The following 1 item(s) were deleted:\n ` +
-            `${blockMocks.testMemberNode.getParent().getLabel().toString()}(${blockMocks.testMemberNode.getLabel().toString()})`
+                `${blockMocks.testMemberNode.getParent().getLabel().toString()}(${blockMocks.testMemberNode.getLabel().toString()})`
         );
     });
 

--- a/packages/zowex-for-zowe-explorer/CHANGELOG.md
+++ b/packages/zowex-for-zowe-explorer/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- Implemented the `issueUnixCommand` function, allowing users to issue z/OS UNIX commands with an SSH profile. [#4337](https://github.com/zowe/zowe-explorer-vscode/pull/4337)
 - Updated the `promptForProfile` function to deprioritize project-level configurations and disable profile creation during zowex server uninstall and restart operations. [#4224](https://github.com/zowe/zowe-explorer-vscode/pull/4224)
 - **Breaking:** Refactored the code to be directly integrated into Zowe Explorer. [#4210](https://github.com/zowe/zowe-explorer-vscode/pull/4210)
 - **Breaking:** Changed the settings to align with Zowe Explorer. [#4210](https://github.com/zowe/zowe-explorer-vscode/pull/4210)

--- a/packages/zowex-for-zowe-explorer/src/api/SshCommandApi.ts
+++ b/packages/zowex-for-zowe-explorer/src/api/SshCommandApi.ts
@@ -54,11 +54,11 @@ export class SshCommandApi extends SshCommonApi implements MainframeInteraction.
     }
 
     public async issueUnixCommand?(_command: string, _cwd: string, _sshSession?: SshSession): Promise<string> {
-        const response = await (await this.client).uss.issueCmd(
-            {
-                commandText: `cd '${_cwd}' && ${_command}`,
-            }
-        );
+        const response = await (
+            await this.client
+        ).uss.issueCmd({
+            commandText: `cd '${_cwd}' && ${_command}`,
+        });
         return response.data ?? "";
     }
 

--- a/packages/zowex-for-zowe-explorer/src/api/SshCommandApi.ts
+++ b/packages/zowex-for-zowe-explorer/src/api/SshCommandApi.ts
@@ -53,11 +53,17 @@ export class SshCommandApi extends SshCommonApi implements MainframeInteraction.
         }
     }
 
-    public issueUnixCommand?(_command: string, _cwd: string, _sshSession?: SshSession): Promise<string> {
-        throw new Error("Method not implemented.");
+    public async issueUnixCommand?(_command: string, _cwd: string, _sshSession?: SshSession): Promise<string> {
+        const response = await (await this.client).uss.issueCmd(
+            {
+                commandText: `cd '${_cwd}' && ${_command}`,
+            }
+        );
+        return response.data ?? "";
     }
 
     public sshProfileRequired?(): boolean {
-        return true;
+        // We are already in the context of an SSH session, a separate SSH profile is not required.
+        return false;
     }
 }

--- a/packages/zowex-for-zowe-explorer/src/api/SshMvsApi.ts
+++ b/packages/zowex-for-zowe-explorer/src/api/SshMvsApi.ts
@@ -243,22 +243,17 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         return this.buildZosFilesResponse(response);
     }
 
-    public async allocateLikeDataSet(
-        dataSetName: string,
-        likeDataSetName: string,
-    ): Promise<zosfiles.IZosFilesResponse> {
-        const listResponse = await (await this.client).ds.listDatasets({
+    public async allocateLikeDataSet(dataSetName: string, likeDataSetName: string): Promise<zosfiles.IZosFilesResponse> {
+        const listResponse = await (
+            await this.client
+        ).ds.listDatasets({
             pattern: likeDataSetName,
             maxItems: 1,
             attributes: true,
         });
 
         if (listResponse.items.length === 0) {
-            return this.buildZosFilesResponse(
-                { success: false },
-                false,
-                `Source data set "${likeDataSetName}" not found`,
-            );
+            return this.buildZosFilesResponse({ success: false }, false, `Source data set "${likeDataSetName}" not found`);
         }
 
         const sourceDs: Dataset = listResponse.items[0];
@@ -281,7 +276,9 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         }
 
         try {
-            const response = await (await this.client).ds.createDataset({
+            const response = await (
+                await this.client
+            ).ds.createDataset({
                 dsname: dataSetName,
                 attributes: attributes,
             });
@@ -298,14 +295,11 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         }
     }
 
-    public async copyDataSet(
-        fromDataSetName: string,
-        toDataSetName: string,
-        _enq?: string,
-        replace?: boolean,
-    ): Promise<zosfiles.IZosFilesResponse> {
+    public async copyDataSet(fromDataSetName: string, toDataSetName: string, _enq?: string, replace?: boolean): Promise<zosfiles.IZosFilesResponse> {
         try {
-            const response = await (await this.client).ds.copyDatasetOrMember({
+            const response = await (
+                await this.client
+            ).ds.copyDatasetOrMember({
                 source: fromDataSetName,
                 target: toDataSetName,
                 replace: replace ?? false,
@@ -328,7 +322,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
         toDataSetName: string,
         toMemberName: string,
         options: zosfiles.ICrossLparCopyDatasetOptions,
-        sourceProfile: imperative.IProfileLoaded,
+        sourceProfile: imperative.IProfileLoaded
     ): Promise<zosfiles.IZosFilesResponse> {
         const fromDataset = options["from-dataset"];
 
@@ -403,9 +397,7 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
             // When a member is specified and the target PDS exists, check whether the member already exists
             if (targetMember != null && targetFound) {
                 const memberList = await targetClient.ds.listDsMembers({ dsname: targetDsn, pattern: targetMember });
-                targetMemberFound = memberList.items.some(
-                    (item) => item.name.toUpperCase() === targetMember.toUpperCase(),
-                );
+                targetMemberFound = memberList.items.some((item) => item.name.toUpperCase() === targetMember.toUpperCase());
             }
 
             if (!targetFound) {
@@ -475,13 +467,15 @@ export class SshMvsApi extends SshCommonApi implements MainframeInteraction.IMvs
     public async copyDataSetMember(
         { dsn: fromDataSetName, member: fromMemberName }: zosfiles.IDataSet,
         { dsn: toDataSetName, member: toMemberName }: zosfiles.IDataSet,
-        options?: { replace?: boolean; overwrite?: boolean },
+        options?: { replace?: boolean; overwrite?: boolean }
     ): Promise<zosfiles.IZosFilesResponse> {
         const source = fromMemberName ? `${fromDataSetName}(${fromMemberName})` : fromDataSetName;
         const target = toMemberName ? `${toDataSetName}(${toMemberName})` : toDataSetName;
 
         try {
-            const response = await (await this.client).ds.copyDatasetOrMember({
+            const response = await (
+                await this.client
+            ).ds.copyDatasetOrMember({
                 source,
                 target,
                 replace: options?.replace ?? false,


### PR DESCRIPTION
## Proposed changes

- Enhances the current set of end-to-end tests to allow excluding commands that are not supported by a profile type.
- Refactors the end-to-end test handling for TSO commands: select a TSO profile in the list (provided by environment variable `ZE_TEST_TSO_PROFILE_NAME`) if a default is not set in your Zowe config.
- Refactors end-to-end test handling for MVS, SSH, and TSO commands to validate the output in the Output channel using regex.

| Cmd Type | Command | Expected Submission Msg | Output Validation: RegEx |
| ----------- | ----------- | ------- | --------------|
| TSO | `PROFILE` | TSO command submitted. | `(IKJ\d+I\|READY\|PREFIX\()` | 
| MVS | `D T` | Console command submitted. | `(IEE\d+I\|CNZ\d+I\|TIME)` | 
| SSH | `pwd` | Unix command submitted. | `process.env.ZE_TEST_USS_FILTER` or `/` if not provided | 

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [x] Other (please specify above in "Proposed changes" section)

## Checklist

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [ ] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes