### PR TITLE
fix: pass cwd as-is to SDK (already escaped)

### DIFF
--- a/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/profiles/ZoweExplorerZosmfApi.unit.test.ts
@@ -920,7 +920,7 @@ describe("ZosmfCommandApi", () => {
         });
     });
 
-    it("issueUnixCommand should properly escape single quotes in cwd", async () => {
+    it("issueUnixCommand should pass cwd raw to executeSshCwd (as the SDK handles escaping)", async () => {
         const obj = new ZoweExplorerZosmf.CommandApi();
         const spy = sharedSpyOn(zosuss.Shell, "executeSshCwd");
         spy.mockClear().mockResolvedValue(undefined);
@@ -928,13 +928,13 @@ describe("ZosmfCommandApi", () => {
         expect(spy).toHaveBeenCalledWith(
             SshSessionobj,
             "ls",
-            "'dir'\\''with'\\''quotes'",
+            "dir'with'quotes",
             expect.any(Function),
             true
         );
     });
 
-    it("issueUnixCommand should safely wrap shell metacharacters in single quotes", async () => {
+    it("issueUnixCommand should pass cwd raw to executeSshCwd even with shell metacharacters", async () => {
         const obj = new ZoweExplorerZosmf.CommandApi();
         const spy = sharedSpyOn(zosuss.Shell, "executeSshCwd");
         spy.mockClear().mockResolvedValue(undefined);
@@ -944,13 +944,13 @@ describe("ZosmfCommandApi", () => {
         expect(spy).toHaveBeenCalledWith(
             SshSessionobj,
             "pwd",
-            "'test'\\''dir$(sleep 5)`whoami`'", 
+            "test'dir$(sleep 5)`whoami`", 
             expect.any(Function),
             true
         );
     });
 
-    it("issueUnixCommand should handle consecutive and edge single quotes in cwd", async () => {
+    it("issueUnixCommand should pass cwd raw to executeSshCwd even with consecutive/edge single quotes", async () => {
         const obj = new ZoweExplorerZosmf.CommandApi();
         const spy = sharedSpyOn(zosuss.Shell, "executeSshCwd");
         spy.mockClear().mockResolvedValue(undefined);
@@ -960,7 +960,7 @@ describe("ZosmfCommandApi", () => {
         expect(spy).toHaveBeenCalledWith(
             SshSessionobj,
             "ls",
-            "''\\'''\\''weird'\\'''\\''dir'\\'''",
+            "''weird''dir'",
             expect.any(Function),
             true
         );

--- a/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
+++ b/packages/zowe-explorer-api/src/profiles/ZoweExplorerZosmfApi.ts
@@ -540,7 +540,7 @@ import { IDataSetCount } from "../dataset/IDataSetCount";
                 await zosuss.Shell.executeSshCwd(
                     sshSession,
                     command,
-                    "'" + cwd.replace(/'/g, "'\\''") + "'",
+                    cwd,
                     (data: string) => {
                         stdout += data;
                     },


### PR DESCRIPTION
## Proposed changes

Fixes issue surfaced by #4330 - the SDK already escapes the cwd, we don't need any quotes around it - we can pass as-is. 
Also addresses an issue surfaced when exec mode was added to the SDKs. When that work was added, escaping was implemented, but ZE was never updated. This caused an issue where any CWD is interpreted literally with double-quotes wrapped around it, which does not match the CWD the user expects based on their input. Now, we pass CWD as-is to the SDK and the SDK handles the escaping.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new test cases and they are passing
- [x] I have manually tested the changes
