### PR TITLE
fix(zowex): `SshJesApi.getJobsByParameters` should handle status

### DIFF
--- a/packages/zowex-for-zowe-explorer/CHANGELOG.md
+++ b/packages/zowex-for-zowe-explorer/CHANGELOG.md
@@ -6,6 +6,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Recent Changes
 
+- Fixed an issue where the `SshJesApi.getJobsByParameters` function did not provide the status parameter to the request. Now, jobs are correctly filtered by status. [#4345](https://github.com/zowe/zowe-explorer-vscode/issues/4345)
 - Implemented the `issueUnixCommand` function, allowing users to issue z/OS UNIX commands with an SSH profile. [#4337](https://github.com/zowe/zowe-explorer-vscode/pull/4337)
 - Added the functionality to copy datasets and members in the Data Sets tree. [#377](https://github.com/zowe/zowex/pull/377)
 - Updated the `promptForProfile` function to deprioritize project-level configurations and disable profile creation during zowex server uninstall and restart operations. [#4224](https://github.com/zowe/zowe-explorer-vscode/pull/4224)

--- a/packages/zowex-for-zowe-explorer/src/api/SshJesApi.ts
+++ b/packages/zowex-for-zowe-explorer/src/api/SshJesApi.ts
@@ -21,6 +21,7 @@ export class SshJesApi extends SshCommonApi implements MainframeInteraction.IJes
         ).jobs.listJobs({
             owner: params.owner?.toUpperCase(),
             prefix: params.prefix,
+            status: params.status,
         });
         return response.items.map(
             (item): Partial<zosjobs.IJob> => ({


### PR DESCRIPTION
## Proposed changes

Fixes an issue seen while working on #4328 where the status is ignored for all job list requests.
This only affects the VSCE; the SDK and the backend support filtering by status, we just did not forward the status parameter to the request.

### How to test

- `pnpm i && pnpm build` on this branch
- Run extension in Dev Host
- List jobs under an SSH profile, but before submitting the filter, change the status filter to "Output"
- Submit the search
- Notice that all listed jobs are completed

Then test with Active to see running jobs, Input to see jobs in input phase, etc  😋 

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes