### PR TITLE
Submit jcl encoding

### DIFF
--- a/packages/zowex-for-zowe-explorer/src/api/SshJesApi.ts
+++ b/packages/zowex-for-zowe-explorer/src/api/SshJesApi.ts
@@ -89,10 +89,12 @@ export class SshJesApi extends SshCommonApi implements MainframeInteraction.IJes
     }
 
     public async submitJcl(jcl: string, _internalReaderRecfm?: string, _internalReaderLrecl?: string): Promise<zosjobs.IJob> {
+        const encoding = this.profile?.profile?.jobEncoding;
         const response = await (
             await this.client
         ).jobs.submitJcl({
             jcl: B64String.encode(jcl),
+            encoding,
         });
         return { jobid: response.jobId, jobname: response.jobName } as zosjobs.IJob;
     }


### PR DESCRIPTION
## Proposed changes

Add support for the encoding property when using the `submit jcl` command palette option.

**How to test**

Set `encoding` and `jobEncoding` to `IBM-1399` in an ssh profile
Open a file containing jcl. (local or in ZE with said ssh profile).

ex:

```
//TEST02J  JOB (ACCT001),'TEST',CLASS=A,MSGCLASS=X,
//             MSGLEVEL=(1,1),NOTIFY=&SYSUID
//*
//* 日本語コメント: このJCLは日本語を含みます
//*
//STEP1    EXEC PGM=IEFBR14
//*
//STEP2    EXEC PGM=IEBGENER
//SYSPRINT DD SYSOUT=*
//SYSUT1   DD *
日本語メッセージのテスト
This is a test of Japanese message output
実行日時: 2026年4月
/*
//SYSUT2   DD SYSOUT=*
//SYSIN    DD DUMMY
```

Open the command palette and run: `ZE: Submit as JCL` (select profile if needed)
Review the spool output and observe that the Japanese characters are consistent


## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new test cases and they are passing
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

Testing for these changes will be added in an upcoming PR covering all commands at this level
