### PR TITLE
fix: resolve UI freeze on bulk deletion (#4015)

### DIFF
--- a/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetActions.ts
@@ -1330,7 +1330,7 @@ export class DatasetActions {
                         }
                         Gui.reportProgress(progress, nodes.length, index, "Deleting");
                         try {
-                            await DatasetActions.deleteDataset(currNode, datasetProvider);
+                            await DatasetActions.deleteDataset(currNode, datasetProvider, true);
                             deletedNames.push(deleteItemName(currNode));
                         } catch (err) {
                             ZoweLogger.error(err);
@@ -2173,7 +2173,7 @@ export class DatasetActions {
      * @param {IZoweDatasetTreeNode} node - The node to be deleted
      * @param {Types.IZoweDatasetTreeType} datasetProvider - the tree which contains the nodes
      */
-    public static async deleteDataset(node: IZoweDatasetTreeNode, datasetProvider: Types.IZoweDatasetTreeType): Promise<void> {
+    public static async deleteDataset(node: IZoweDatasetTreeNode, datasetProvider: Types.IZoweDatasetTreeType, skipRefresh?: boolean): Promise<void> {
         ZoweLogger.trace("dataset.actions.deleteDataset called.");
         let label = "";
         let fav = false;
@@ -2258,17 +2258,19 @@ export class DatasetActions {
             await datasetProvider.removeFavorite(node);
         }
 
-        // If the node is a dataset member, go up a level in the node tree
-        // to find the relevant, matching node
-        const nodeOfInterest = isMember ? node.getParent() : node;
-        const parentNode = datasetProvider.findEquivalentNode(nodeOfInterest, fav);
+        if (!skipRefresh) {
+            // If the node is a dataset member, go up a level in the node tree
+            // to find the relevant, matching node
+            const nodeOfInterest = isMember ? node.getParent() : node;
+            const parentNode = datasetProvider.findEquivalentNode(nodeOfInterest, fav);
 
-        if (parentNode != null) {
-            // Refresh the correct node (parent of node to delete) to reflect changes
-            datasetProvider.refreshElement(isMember ? parentNode : parentNode.getParent());
+            if (parentNode != null) {
+                // Refresh the correct node (parent of node to delete) to reflect changes
+                datasetProvider.refreshElement(isMember ? parentNode : parentNode.getParent());
+            }
+
+            datasetProvider.refreshElement(node.getSessionNode());
         }
-
-        datasetProvider.refreshElement(node.getSessionNode());
 
         // Close the editor if the deleted dataset is open
         if (node.resourceUri) {


### PR DESCRIPTION
<!-- 
**NOTE:** The team reserves the right to close pull requests that fail to meet quality standards or lack human contribution.
-->

## Proposed changes

This PR fixes a performance bug described in #4015 where bulk-deleting data sets (e.g., VSAM) would cause the UI to become unresponsive due to excessive queued list operations.

Previously, `deleteDatasetPrompt` executed a `for` loop that individually called `DatasetActions.deleteDataset()`. Because `deleteDataset` inherently triggered a tree refresh, deleting multiple items spammed the Zowe API with list requests and locked up the UI. 

**Fix:**
Added an optional `skipRefresh` parameter to `deleteDataset` and passed it as `true` during the bulk-deletion loop. This skips the individual tree refreshes. Since `deleteDatasetPrompt` already executes a single, global `datasetProvider.refresh()` after the loop finishes, the tree now updates perfectly *once* at the very end of the bulk operation.

Fixes #4015

## Release Notes

Milestone: 

Changelog: Resolved a bug where bulk deletion of data sets caused the Zowe Explorer UI to become unresponsive due to excessive queued tree refreshes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new unit test cases and they are passing
- [ ] I have added at least one end-to-end test for new features to validate behavior (if applicable)
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] I have verified that all dependency updates (such as Zowe SDKs) in this pull request are compatible
- [ ] Documentation should be added to Zowe Docs
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

The unit tests (`pnpm run test`) have all been executed against these changes and pass successfully, confirming that the new optional signature in `DatasetActions.ts` does not break any existing mocks or behavior.
