### PR TITLE
chore: fix CI matrix checks for artifacts

### DIFF
--- a/.github/workflows/zowe-explorer-ci.yml
+++ b/.github/workflows/zowe-explorer-ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Unlock Keyring
         id: unlock-keyring
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.node-version == 'lts/-1' && matrix.os == 'ubuntu-22.04'
         uses: t1m0thyj/unlock-keyring@v1
 
       - name: Integration tests
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
-        if: always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-22.04'
+        if: always() && steps.build.outcome == 'success' && matrix.node-version == 'lts/-1' && matrix.os == 'ubuntu-22.04'
         with:
           name: zowe-explorer-results
           path: |
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload API test results
         uses: actions/upload-artifact@v4
-        if: always() && steps.build.outcome == 'success' && matrix.os == 'ubuntu-22.04'
+        if: always() && steps.build.outcome == 'success' && matrix.node-version == 'lts/-1' && matrix.os == 'ubuntu-22.04'
         with:
           name: zowe-explorer-api-results
           path: packages/zowe-explorer-api/results/
@@ -91,12 +91,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Package VSIX
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.node-version == 'lts/-1' && matrix.os == 'ubuntu-22.04'
         run: pnpm package
         working-directory: packages/zowe-explorer
 
       - name: Archive VSIX artifact
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.node-version == 'lts/-1' && matrix.os == 'ubuntu-22.04'
         uses: actions/upload-artifact@v4
         with:
           name: zowe-explorer-vsix

--- a/.github/workflows/zowe-explorer-ftp-ci.yml
+++ b/.github/workflows/zowe-explorer-ftp-ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.node-version == 'lts/-1' && matrix.os == 'ubuntu-22.04'
         with:
           name: zowe-explorer-ftp-extension-results
           path: packages/zowe-explorer-ftp-extension/results/
@@ -66,12 +66,12 @@ jobs:
       #     env_vars: OS,NODE
 
       - name: Package VSIX
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.node-version == 'lts/-1' && matrix.os == 'ubuntu-22.04'
         run: pnpm package
         working-directory: packages/zowe-explorer-ftp-extension
 
       - name: Archive VSIX artifact
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.node-version == 'lts/-1' && matrix.os == 'ubuntu-22.04'
         uses: actions/upload-artifact@v4
         with:
           name: zowe-explorer-ftp-extension-vsix


### PR DESCRIPTION
## Proposed changes

Restores matrix checks around artifact publishing, test results, etc.

## Release Notes

Milestone: N/A

Changelog: N/A

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [x] Other (please specify above in "Proposed changes" section)

## Checklist

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.