### PR TITLE
Allow comma separated job prefixes

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Replaced repetitive `if (err instanceof Error)` patterns with `handleError` and `errorMessage` utility functions from `@zowe/zowe-explorer-api`. [#4207](https://github.com/zowe/zowe-explorer-vscode/issues/4207)
 - Added new VS Code toggle setting for enabling various features within Zowe Explorer. [#4242](https://github.com/zowe/zowe-explorer-vscode/issues/4242)
+- Added support for comma-separated job prefixes in the Jobs tree filter, matching existing dataset filter behaviour. [#4395](https://github.com/zowe/zowe-explorer-vscode/issues/4395)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Replaced repetitive `if (err instanceof Error)` patterns with `handleError` and `errorMessage` utility functions from `@zowe/zowe-explorer-api`. [#4207](https://github.com/zowe/zowe-explorer-vscode/issues/4207)
 - Added new VS Code toggle setting for enabling various features within Zowe Explorer. [#4242](https://github.com/zowe/zowe-explorer-vscode/issues/4242)
-- Added support for comma-separated job prefixes in the Jobs tree filter, matching existing dataset filter behaviour. [#4395](https://github.com/zowe/zowe-explorer-vscode/issues/4395)
+- Added support for comma-separated job prefixes in the **JOBS** tree filter, matching existing data set filter behavior. [#4395](https://github.com/zowe/zowe-explorer-vscode/issues/4395)
 
 ### Bug fixes
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/JobTree.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/JobTree.unit.test.ts
@@ -1120,7 +1120,7 @@ describe("ZosJobsProvider unit tests - Function getPopulatedPickerArray", () => 
                 label: `Job Prefix`,
                 value: "job*",
                 show: true,
-                placeHolder: `Enter job prefix`,
+                placeHolder: `Enter job prefix, use a comma to separate multiple prefixes`,
                 validateInput: (text) => SharedUtils.jobStringValidator(text, "prefix"),
             },
             {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/job/ZoweJobNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/job/ZoweJobNode.unit.test.ts
@@ -1231,6 +1231,81 @@ describe("ZosJobsProvider - getJobs", () => {
         expect(warnLoggerSpy).toHaveBeenCalledWith("[ZoweJobNode.getJobs] Session undefined for profile sestest");
         jesApiMock.mockRestore();
     });
+
+    it("should issue one API call per comma-separated prefix and merge results", async () => {
+        const globalMocks = await createGlobalMocks();
+        const job1 = { ...globalMocks.testIJob, jobname: "ABC001", jobid: "JOB00001" };
+        const job2 = { ...globalMocks.testIJob, jobname: "DEF001", jobid: "JOB00002" };
+        const getJobsByParametersMock = vi.fn().mockResolvedValueOnce([job1]).mockResolvedValueOnce([job2]);
+        vi.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValue({
+            getJobsByParameters: getJobsByParametersMock,
+            getSession: () => globalMocks.testSession,
+        } as any);
+        const result = await globalMocks.testJobNode.getJobs("*", "ABC*,DEF*", "", "*");
+        expect(getJobsByParametersMock).toHaveBeenCalledTimes(2);
+        expect(getJobsByParametersMock).toHaveBeenCalledWith({ owner: "*", prefix: "ABC*", status: "*", execData: true });
+        expect(getJobsByParametersMock).toHaveBeenCalledWith({ owner: "*", prefix: "DEF*", status: "*", execData: true });
+        expect(result).toHaveLength(2);
+        expect(result.map((j) => j.jobid)).toEqual(["JOB00001", "JOB00002"]);
+    });
+
+    it("should deduplicate jobs returned by multiple prefix API calls", async () => {
+        const globalMocks = await createGlobalMocks();
+        const job1 = { ...globalMocks.testIJob, jobname: "ABC001", jobid: "JOB00001" };
+        const getJobsByParametersMock = vi.fn().mockResolvedValue([job1]);
+        vi.spyOn(ZoweExplorerApiRegister, "getJesApi").mockReturnValue({
+            getJobsByParameters: getJobsByParametersMock,
+            getSession: () => globalMocks.testSession,
+        } as any);
+        // Both prefix calls return the same job — should be deduplicated
+        const result = await globalMocks.testJobNode.getJobs("*", "ABC*,AB*", "", "*");
+        expect(result).toHaveLength(1);
+        expect(result[0].jobid).toBe("JOB00001");
+    });
+});
+
+describe("ZoweJobNode - prefix setter", () => {
+    it("stores a bare prefix unchanged", async () => {
+        const globalMocks = await createGlobalMocks();
+        const node = globalMocks.testJobNode;
+        node.prefix = "ABC";
+        expect(node.prefix).toBe("ABC");
+    });
+
+    it("stores a wildcarded prefix unchanged", async () => {
+        const globalMocks = await createGlobalMocks();
+        const node = globalMocks.testJobNode;
+        node.prefix = "ABC*";
+        expect(node.prefix).toBe("ABC*");
+    });
+
+    it("stores a full 8-char prefix unchanged", async () => {
+        const globalMocks = await createGlobalMocks();
+        const node = globalMocks.testJobNode;
+        node.prefix = "BAQBANKZ";
+        expect(node.prefix).toBe("BAQBANKZ");
+    });
+
+    it("trims whitespace around each comma-separated part", async () => {
+        const globalMocks = await createGlobalMocks();
+        const node = globalMocks.testJobNode;
+        node.prefix = "ABC , DEF*";
+        expect(node.prefix).toBe("ABC,DEF*");
+    });
+
+    it("stores comma-separated prefixes as-is (no wildcards injected)", async () => {
+        const globalMocks = await createGlobalMocks();
+        const node = globalMocks.testJobNode;
+        node.prefix = "ABC,DEF*,BAQBANKZ";
+        expect(node.prefix).toBe("ABC,DEF*,BAQBANKZ");
+    });
+
+    it("resets to '*' when an empty string is assigned", async () => {
+        const globalMocks = await createGlobalMocks();
+        const node = globalMocks.testJobNode;
+        node.prefix = "";
+        expect(node.prefix).toBe("*");
+    });
 });
 
 describe("Job - sortJobs", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/shared/SharedUtils.unit.test.ts
@@ -2262,3 +2262,49 @@ describe("SharedUtils helpers", () => {
         });
     });
 });
+
+describe("Shared utils unit tests - jobStringValidator", () => {
+    describe("owner validation", () => {
+        it("returns null for a valid owner (≤8 chars)", () => {
+            expect(SharedUtils.jobStringValidator("MYUSER", "owner")).toBeNull();
+        });
+
+        it("returns an error for an owner exceeding 8 chars", () => {
+            expect(SharedUtils.jobStringValidator("TOOLONGOWNER", "owner")).not.toBeNull();
+        });
+    });
+
+    describe("prefix validation", () => {
+        it("returns null for a simple valid prefix", () => {
+            expect(SharedUtils.jobStringValidator("ABC*", "prefix")).toBeNull();
+        });
+
+        it("returns null for a prefix without wildcard (bare name, ≤8 chars)", () => {
+            expect(SharedUtils.jobStringValidator("ABC", "prefix")).toBeNull();
+        });
+
+        it("returns an error for a prefix exceeding 8 chars", () => {
+            expect(SharedUtils.jobStringValidator("TOOLONGPR", "prefix")).not.toBeNull();
+        });
+
+        it("returns null for comma-separated prefixes where each part is ≤8 chars", () => {
+            expect(SharedUtils.jobStringValidator("ABC*, DEF*", "prefix")).toBeNull();
+        });
+
+        it("returns null for comma-separated prefixes without wildcards", () => {
+            expect(SharedUtils.jobStringValidator("ABC,DEF,GHI", "prefix")).toBeNull();
+        });
+
+        it("returns an error when any comma-separated part exceeds 8 chars", () => {
+            expect(SharedUtils.jobStringValidator("ABC*, TOOLONGPREFIX", "prefix")).not.toBeNull();
+        });
+
+        it("returns an error for an empty part (trailing comma)", () => {
+            expect(SharedUtils.jobStringValidator("ABC,", "prefix")).not.toBeNull();
+        });
+
+        it("returns an error for an empty part (leading comma)", () => {
+            expect(SharedUtils.jobStringValidator(",ABC", "prefix")).not.toBeNull();
+        });
+    });
+});

--- a/packages/zowe-explorer/l10n/bundle.l10n.json
+++ b/packages/zowe-explorer/l10n/bundle.l10n.json
@@ -169,6 +169,7 @@
   "Added support for adding VSAM datasets to favorites. <a>#4103</a>": "Added support for adding VSAM datasets to favorites. <a>#4103</a>",
   "Added support for adding a Zowe profile across all trees <a>#2603</a>": "Added support for adding a Zowe profile across all trees <a>#2603</a>",
   "Added support for asynchronous operations when using integrated terminals. <a>#3640</a>": "Added support for asynchronous operations when using integrated terminals. <a>#3640</a>",
+  "Added support for comma-separated job prefixes in the Jobs tree filter, matching existing dataset filter behaviour. <a>#4395</a>": "Added support for comma-separated job prefixes in the Jobs tree filter, matching existing dataset filter behaviour. <a>#4395</a>",
   "Added support for consoleName property in z/OSMF profiles when issuing MVS commands <a>#1667</a>": "Added support for consoleName property in z/OSMF profiles when issuing MVS commands <a>#1667</a>",
   "Added support for consoleName property in z/OSMF profiles when issuing MVS commands. <a>#1667</a>": "Added support for consoleName property in z/OSMF profiles when issuing MVS commands. <a>#1667</a>",
   "Added support for copying data sets from multiple source LPARs at once in the cross-LPAR copy/paste functionality. <a>#3945</a>": "Added support for copying data sets from multiple source LPARs at once in the cross-LPAR copy/paste functionality. <a>#3945</a>",

--- a/packages/zowe-explorer/l10n/bundle.l10n.json
+++ b/packages/zowe-explorer/l10n/bundle.l10n.json
@@ -169,7 +169,7 @@
   "Added support for adding VSAM datasets to favorites. <a>#4103</a>": "Added support for adding VSAM datasets to favorites. <a>#4103</a>",
   "Added support for adding a Zowe profile across all trees <a>#2603</a>": "Added support for adding a Zowe profile across all trees <a>#2603</a>",
   "Added support for asynchronous operations when using integrated terminals. <a>#3640</a>": "Added support for asynchronous operations when using integrated terminals. <a>#3640</a>",
-  "Added support for comma-separated job prefixes in the Jobs tree filter, matching existing dataset filter behaviour. <a>#4395</a>": "Added support for comma-separated job prefixes in the Jobs tree filter, matching existing dataset filter behaviour. <a>#4395</a>",
+  "Added support for comma-separated job prefixes in the **JOBS** tree filter, matching existing data set filter behavior. <a>#4395</a>": "Added support for comma-separated job prefixes in the **JOBS** tree filter, matching existing data set filter behavior. <a>#4395</a>",
   "Added support for consoleName property in z/OSMF profiles when issuing MVS commands <a>#1667</a>": "Added support for consoleName property in z/OSMF profiles when issuing MVS commands <a>#1667</a>",
   "Added support for consoleName property in z/OSMF profiles when issuing MVS commands. <a>#1667</a>": "Added support for consoleName property in z/OSMF profiles when issuing MVS commands. <a>#1667</a>",
   "Added support for copying data sets from multiple source LPARs at once in the cross-LPAR copy/paste functionality. <a>#3945</a>": "Added support for copying data sets from multiple source LPARs at once in the cross-LPAR copy/paste functionality. <a>#3945</a>",

--- a/packages/zowe-explorer/l10n/bundle.l10n.json
+++ b/packages/zowe-explorer/l10n/bundle.l10n.json
@@ -575,7 +575,7 @@
   "Enter command here...": "Enter command here...",
   "Enter file extension (e.g. csv)": "Enter file extension (e.g. csv)",
   "Enter job owner ID": "Enter job owner ID",
-  "Enter job prefix": "Enter job prefix",
+  "Enter job prefix, use a comma to separate multiple prefixes": "Enter job prefix, use a comma to separate multiple prefixes",
   "Enter job status": "Enter job status",
   "Enter local filter...": "Enter local filter...",
   "Enter or update the TSO command": "Enter or update the TSO command",

--- a/packages/zowe-explorer/l10n/poeditor.json
+++ b/packages/zowe-explorer/l10n/poeditor.json
@@ -780,6 +780,7 @@
   "Added support for adding VSAM datasets to favorites. <a>#4103</a>": "",
   "Added support for adding a Zowe profile across all trees <a>#2603</a>": "",
   "Added support for asynchronous operations when using integrated terminals. <a>#3640</a>": "",
+  "Added support for comma-separated job prefixes in the Jobs tree filter, matching existing dataset filter behaviour. <a>#4395</a>": "",
   "Added support for consoleName property in z/OSMF profiles when issuing MVS commands <a>#1667</a>": "",
   "Added support for consoleName property in z/OSMF profiles when issuing MVS commands. <a>#1667</a>": "",
   "Added support for copying data sets from multiple source LPARs at once in the cross-LPAR copy/paste functionality. <a>#3945</a>": "",

--- a/packages/zowe-explorer/l10n/poeditor.json
+++ b/packages/zowe-explorer/l10n/poeditor.json
@@ -1053,7 +1053,7 @@
   "Enter command here...": "",
   "Enter file extension (e.g. csv)": "",
   "Enter job owner ID": "",
-  "Enter job prefix": "",
+  "Enter job prefix, use a comma to separate multiple prefixes": "",
   "Enter job status": "",
   "Enter local filter...": "",
   "Enter or update the TSO command": "",

--- a/packages/zowe-explorer/l10n/poeditor.json
+++ b/packages/zowe-explorer/l10n/poeditor.json
@@ -780,7 +780,7 @@
   "Added support for adding VSAM datasets to favorites. <a>#4103</a>": "",
   "Added support for adding a Zowe profile across all trees <a>#2603</a>": "",
   "Added support for asynchronous operations when using integrated terminals. <a>#3640</a>": "",
-  "Added support for comma-separated job prefixes in the Jobs tree filter, matching existing dataset filter behaviour. <a>#4395</a>": "",
+  "Added support for comma-separated job prefixes in the **JOBS** tree filter, matching existing data set filter behavior. <a>#4395</a>": "",
   "Added support for consoleName property in z/OSMF profiles when issuing MVS commands <a>#1667</a>": "",
   "Added support for consoleName property in z/OSMF profiles when issuing MVS commands. <a>#1667</a>": "",
   "Added support for copying data sets from multiple source LPARs at once in the cross-LPAR copy/paste functionality. <a>#3945</a>": "",

--- a/packages/zowe-explorer/src/trees/job/JobTree.ts
+++ b/packages/zowe-explorer/src/trees/job/JobTree.ts
@@ -70,7 +70,7 @@ export class JobTree extends ZoweTreeProvider<IZoweJobTreeNode> implements Types
             label: `Job Prefix`,
             value: "*",
             show: true,
-            placeHolder: vscode.l10n.t("Enter job prefix"),
+            placeHolder: vscode.l10n.t("Enter job prefix, use a comma to separate multiple prefixes"),
             validateInput: (text: string): string | null => SharedUtils.jobStringValidator(text, "prefix"),
         },
         {

--- a/packages/zowe-explorer/src/trees/job/ZoweJobNode.ts
+++ b/packages/zowe-explorer/src/trees/job/ZoweJobNode.ts
@@ -406,7 +406,11 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
             if (newPrefix.length === 0) {
                 this._prefix = "*";
             } else {
-                this._prefix = newPrefix;
+                // Normalise whitespace around each comma-separated part.
+                this._prefix = newPrefix
+                    .split(",")
+                    .map((p) => p.trim())
+                    .join(",");
             }
         }
     }
@@ -437,12 +441,20 @@ export class ZoweJobNode extends ZoweTreeNode implements IZoweJobTreeNode {
                     ZoweLogger.warn(`[ZoweJobNode.getJobs] Session undefined for profile ${cachedProfile.name}`);
                     return undefined;
                 }
-                jobsInternal = await ZoweExplorerApiRegister.getJesApi(cachedProfile).getJobsByParameters({
-                    owner,
-                    prefix,
-                    status,
-                    execData: true,
-                });
+                // Support comma-separated prefixes by issuing one API call per prefix value
+                // and merging the results.
+                const prefixParts = prefix.split(",").map((p) => p.trim()).filter(Boolean);
+                const allJobs = await Promise.all(
+                    prefixParts.map((p) =>
+                        ZoweExplorerApiRegister.getJesApi(cachedProfile).getJobsByParameters({
+                            owner,
+                            prefix: p,
+                            status,
+                            execData: true,
+                        })
+                    )
+                );
+                jobsInternal = allJobs.flat();
 
                 /**
                  *    Note: Temporary fix

--- a/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
+++ b/packages/zowe-explorer/src/trees/shared/SharedUtils.ts
@@ -147,17 +147,22 @@ export class SharedUtils {
     }
 
     /**
-     * Function that validates job prefix
-     * @param {string} text - prefix text
-     * @returns undefined | string
+     * Function that validates job owner or prefix input.
+     * For prefix, comma-separated values are supported; each individual value must be at most
+     * {@link Constants.JOBS_MAX_PREFIX} characters long.
+     * @param {string} text - owner or prefix text
+     * @returns null when valid, otherwise a localised error string
      */
     public static jobStringValidator(text: string, localizedParam: "owner" | "prefix"): string | null {
         switch (localizedParam) {
             case "owner":
                 return text.length > Constants.JOBS_MAX_PREFIX ? vscode.l10n.t("Invalid job owner") : null;
             case "prefix":
-            default:
-                return text.length > Constants.JOBS_MAX_PREFIX ? vscode.l10n.t("Invalid job prefix") : null;
+            default: {
+                const parts = text.split(",").map((p) => p.trim());
+                const invalid = parts.some((p) => p.length === 0 || p.length > Constants.JOBS_MAX_PREFIX);
+                return invalid ? vscode.l10n.t("Invalid job prefix") : null;
+            }
         }
     }
 


### PR DESCRIPTION
<!-- 
**NOTE:** The team reserves the right to close pull requests that fail to meet quality standards or lack human contribution.
-->

## Proposed changes

The Jobs tree filter dialog now supports comma-separated prefixes, matching the behaviour already available for dataset filters. Users can enter ABC,DEF*,MYJOB in the Job Prefix field and Zowe Explorer will issue one API call per prefix, then merge and deduplicate the results before displaying them.

Each comma-separated part is also whitespace-trimmed on assignment, so ABC , DEF is normalised to ABC,DEF before being sent to the API.

The jobStringValidator used in the filter input box has been updated to validate each comma-separated part independently — every part must be non-empty and at most 8 characters, matching the z/OSMF API constraint.

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new unit test cases and they are passing
- [ ] I have added at least one end-to-end test for new features to validate behavior (if applicable)
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] I have verified that all dependency updates (such as Zowe SDKs) in this pull request are compatible
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
