### PR TITLE
(v2) verifying path and clipboard contents

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
-- Updated the USS paste action to validate clipboard contents and to evaluate the newly santized USS clipboard path. [#4397](https://github.com/zowe/zowe-explorer-vscode/pull/4397)
+- Updated the USS paste action to validate clipboard contents and to evaluate the newly santized USS clipboard path. [#4397](https://github.com/zowe/zowe-explorer-vscode/pull/4397).
 
 ## `2.18.4`
 

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -8,8 +8,6 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 - Updated the USS paste action to validate clipboard contents and to evaluate the newly santized USS clipboard path. [#4397](https://github.com/zowe/zowe-explorer-vscode/pull/4397)
 
-### Bug fixes
-
 ## `2.18.4`
 
 ### Bug fixes

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
+- Updated the USS paste action to validate clipboard contents and to evaluate the newly santized USS clipboard path. [#4397](https://github.com/zowe/zowe-explorer-vscode/pull/4397)
+
+### Bug fixes
+
 ## `2.18.4`
 
 ### Bug fixes

--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 
 ### Bug fixes
 
-- Updated the USS paste action to validate clipboard contents and to evaluate the newly santized USS clipboard path. [#4397](https://github.com/zowe/zowe-explorer-vscode/pull/4397).
+- Updated the USS paste action to validate clipboard contents and to evaluate the newly sanitized USS clipboard path. [#4397](https://github.com/zowe/zowe-explorer-vscode/pull/4397).
 
 ## `2.18.4`
 

--- a/packages/zowe-explorer/__tests__/__unit__/uss/FileStructure.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/FileStructure.unit.test.ts
@@ -1,0 +1,116 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import * as path from "path";
+import * as globals from "../../../src/globals";
+import { ZoweLogger } from "../../../src/utils/LoggerUtils";
+import { isValidUssFileTree, UssFileType, UssFileUtils } from "../../../src/uss/FileStructure";
+
+describe("FileStructure unit tests - function isValidUssFileTree", () => {
+    it("accepts a minimal valid file node", () => {
+        expect(isValidUssFileTree({ ussPath: "/a/b", type: UssFileType.File })).toBe(true);
+    });
+
+    it("accepts a valid directory node with optional fields and nested children", () => {
+        const node = {
+            ussPath: "/a",
+            type: UssFileType.Directory,
+            baseName: "a",
+            sessionName: "sestest",
+            binary: false,
+            children: [{ ussPath: "/a/b", type: UssFileType.File }],
+        };
+        expect(isValidUssFileTree(node)).toBe(true);
+    });
+
+    it.each([
+        ["null", null],
+        ["a non-object", "not an object"],
+        ["a number", 42],
+    ])("rejects %s", (_desc, value) => {
+        expect(isValidUssFileTree(value)).toBe(false);
+    });
+
+    it("rejects a node with a missing or non-string ussPath", () => {
+        expect(isValidUssFileTree({ type: UssFileType.File })).toBe(false);
+        expect(isValidUssFileTree({ ussPath: 5, type: UssFileType.File })).toBe(false);
+    });
+
+    it("rejects a node with an invalid type", () => {
+        expect(isValidUssFileTree({ ussPath: "/a", type: 99 })).toBe(false);
+        expect(isValidUssFileTree({ ussPath: "/a", type: "File" })).toBe(false);
+        expect(isValidUssFileTree({ ussPath: "/a" })).toBe(false);
+    });
+
+    it("rejects a node with wrong optional field types", () => {
+        expect(isValidUssFileTree({ ussPath: "/a", type: UssFileType.File, baseName: 1 })).toBe(false);
+        expect(isValidUssFileTree({ ussPath: "/a", type: UssFileType.File, sessionName: {} })).toBe(false);
+        expect(isValidUssFileTree({ ussPath: "/a", type: UssFileType.File, binary: "true" })).toBe(false);
+    });
+
+    it("rejects a node whose children are not an array or contain an invalid child", () => {
+        expect(isValidUssFileTree({ ussPath: "/a", type: UssFileType.Directory, children: "nope" })).toBe(false);
+        expect(
+            isValidUssFileTree({
+                ussPath: "/a",
+                type: UssFileType.Directory,
+                children: [{ ussPath: "/a/b", type: 99 }],
+            })
+        ).toBe(false);
+    });
+});
+
+describe("FileStructure unit tests - function UssFileUtils.resolveLocalPath", () => {
+    let ussDir: string;
+
+    beforeAll(() => {
+        jest.spyOn(ZoweLogger, "trace").mockImplementation();
+        // Set USS_DIR directly rather than calling defineGlobals(), which reaches into vscode.env/Uri.
+        Object.defineProperty(globals, "USS_DIR", { value: path.join("/test/path/temp", "_U_"), configurable: true });
+        ussDir = path.resolve(globals.USS_DIR);
+    });
+
+    it("recomputes a path under USS_DIR from the profile name and USS path", () => {
+        const result = UssFileUtils.resolveLocalPath("sestest", "/u/users/test/file.txt");
+        expect(result).toBe(path.resolve(ussDir, "sestest", "u", "users", "test", "file.txt"));
+        expect(result.startsWith(ussDir + path.sep)).toBe(true);
+    });
+
+    it("ignores leading slashes and '.' segments in the USS path", () => {
+        const result = UssFileUtils.resolveLocalPath("sestest", "///u/./users//file");
+        expect(result).toBe(path.resolve(ussDir, "sestest", "u", "users", "file"));
+    });
+
+    it("throws when the USS path is missing or empty", () => {
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "")).toThrow(/missing or invalid USS path/);
+        expect(() => UssFileUtils.resolveLocalPath("sestest", undefined as unknown as string)).toThrow(/missing or invalid USS path/);
+    });
+
+    it("rejects '..' traversal segments that would escape USS_DIR", () => {
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "/../../../../etc/passwd")).toThrow(/unsafe USS path/);
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "a/../../b")).toThrow(/unsafe USS path/);
+    });
+
+    it("rejects backslash-separated '..' traversal segments", () => {
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "..\\..\\Windows\\System32")).toThrow(/unsafe USS path/);
+    });
+
+    it("rejects drive-letter / absolute-path roots supplied via the USS path", () => {
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "C:/Windows/System32")).toThrow(/unsafe USS path/);
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "/D:/data")).toThrow(/unsafe USS path/);
+    });
+
+    it("never lets a hostile profile name escape USS_DIR", () => {
+        // Even if a caller passes traversal via the profile name, the containment
+        // assertion must reject the resolved path.
+        expect(() => UssFileUtils.resolveLocalPath("../../..", "/file")).toThrow(/escapes the local USS directory/);
+    });
+});

--- a/packages/zowe-explorer/__tests__/__unit__/uss/FileStructure.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/FileStructure.unit.test.ts
@@ -31,12 +31,10 @@ describe("FileStructure unit tests - function isValidUssFileTree", () => {
         expect(isValidUssFileTree(node)).toBe(true);
     });
 
-    it.each([
-        ["null", null],
-        ["a non-object", "not an object"],
-        ["a number", 42],
-    ])("rejects %s", (_desc, value) => {
-        expect(isValidUssFileTree(value)).toBe(false);
+    it("rejects values that are not objects", () => {
+        expect(isValidUssFileTree(null)).toBe(false);
+        expect(isValidUssFileTree("not an object")).toBe(false);
+        expect(isValidUssFileTree(42)).toBe(false);
     });
 
     it("rejects a node with a missing or non-string ussPath", () => {

--- a/packages/zowe-explorer/__tests__/__unit__/uss/FileStructure.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/FileStructure.unit.test.ts
@@ -93,22 +93,22 @@ describe("FileStructure unit tests - function UssFileUtils.resolveLocalPath", ()
     });
 
     it("rejects '..' traversal segments that would escape USS_DIR", () => {
-        expect(() => UssFileUtils.resolveLocalPath("sestest", "/../../../../etc/passwd")).toThrow(/unsafe USS path/);
-        expect(() => UssFileUtils.resolveLocalPath("sestest", "a/../../b")).toThrow(/unsafe USS path/);
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "/../../../../etc/passwd")).toThrow(/missing or invalid USS path/);
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "a/../../b")).toThrow(/missing or invalid USS path/);
     });
 
     it("rejects backslash-separated '..' traversal segments", () => {
-        expect(() => UssFileUtils.resolveLocalPath("sestest", "..\\..\\Windows\\System32")).toThrow(/unsafe USS path/);
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "..\\..\\Windows\\System32")).toThrow(/missing or invalid USS path/);
     });
 
     it("rejects drive-letter / absolute-path roots supplied via the USS path", () => {
-        expect(() => UssFileUtils.resolveLocalPath("sestest", "C:/Windows/System32")).toThrow(/unsafe USS path/);
-        expect(() => UssFileUtils.resolveLocalPath("sestest", "/D:/data")).toThrow(/unsafe USS path/);
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "C:/Windows/System32")).toThrow(/missing or invalid USS path/);
+        expect(() => UssFileUtils.resolveLocalPath("sestest", "/D:/data")).toThrow(/missing or invalid USS path/);
     });
 
     it("never lets a hostile profile name escape USS_DIR", () => {
         // Even if a caller passes traversal via the profile name, the containment
         // assertion must reject the resolved path.
-        expect(() => UssFileUtils.resolveLocalPath("../../..", "/file")).toThrow(/escapes the local USS directory/);
+        expect(() => UssFileUtils.resolveLocalPath("../../..", "/file")).toThrow(/missing or invalid USS path/);
     });
 });

--- a/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
@@ -1466,6 +1466,13 @@ describe("ZoweUSSNode Unit Tests - Function node.pasteUssTree()", () => {
             })
         );
         globalMocks.basePath.mockResolvedValue("/temp");
+        // The __mocks__/path.ts stub does not implement path.resolve/path.sep, which
+        // UssFileUtils.resolveLocalPath relies on. That method is unit-tested against the
+        // real "path" module in FileStructure.unit.test.ts, so here we stub it to a
+        // deterministic local path and keep these tests focused on paste orchestration.
+        jest.spyOn(UssFileUtils, "resolveLocalPath").mockImplementation(
+            (profileName: string, ussPath: string) => `/local/${profileName ?? ""}${ussPath}`
+        );
         return newMocks;
     }
 
@@ -1599,6 +1606,7 @@ describe("ZoweUSSNode Unit Tests - Function node.pasteUssTree()", () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks(globalMocks);
         const errorHandlingSpy = jest.spyOn(profileUtils, "errorHandling").mockResolvedValue(undefined);
+        errorHandlingSpy.mockClear();
         const pasteSpy = jest.spyOn(blockMocks.testNode, "paste");
         pasteSpy.mockClear();
 
@@ -1617,6 +1625,7 @@ describe("ZoweUSSNode Unit Tests - Function node.pasteUssTree()", () => {
         const globalMocks = createGlobalMocks();
         const blockMocks = createBlockMocks(globalMocks);
         const errorHandlingSpy = jest.spyOn(profileUtils, "errorHandling").mockResolvedValue(undefined);
+        errorHandlingSpy.mockClear();
         const pasteSpy = jest.spyOn(blockMocks.testNode, "paste");
         pasteSpy.mockClear();
 

--- a/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/uss/ZoweUSSNode.unit.test.ts
@@ -34,6 +34,7 @@ import * as ussUtils from "../../../src/uss/utils";
 import { ZoweLogger } from "../../../src/utils/LoggerUtils";
 import { TreeProviders } from "../../../src/shared/TreeProviders";
 import { LocalFileManagement } from "../../../src/utils/LocalFileManagement";
+import * as profileUtils from "../../../src/utils/ProfilesUtils";
 
 jest.mock("fs");
 jest.mock("path");
@@ -1592,5 +1593,38 @@ describe("ZoweUSSNode Unit Tests - Function node.pasteUssTree()", () => {
         jest.spyOn(blockMocks.mockUssApi, "uploadDirectory").mockRejectedValueOnce(blockMocks.fileResponse);
 
         await blockMocks.testNode.pasteUssTree();
+    });
+
+    it("Tests node.pasteUssTree() rejects clipboard contents that are not a valid USS file structure", async () => {
+        const globalMocks = createGlobalMocks();
+        const blockMocks = createBlockMocks(globalMocks);
+        const errorHandlingSpy = jest.spyOn(profileUtils, "errorHandling").mockResolvedValue(undefined);
+        const pasteSpy = jest.spyOn(blockMocks.testNode, "paste");
+        pasteSpy.mockClear();
+
+        // Well-formed JSON, but the children are not valid UssFileTree nodes (attacker-controlled shape).
+        globalMocks.readText.mockResolvedValueOnce(JSON.stringify({ children: [{ ussPath: 5, type: "File", localPath: "/etc/passwd" }] }));
+
+        await blockMocks.testNode.pasteUssTree();
+
+        expect(pasteSpy).not.toHaveBeenCalled();
+        expect(errorHandlingSpy).toHaveBeenCalledTimes(1);
+        expect(errorHandlingSpy.mock.calls[0][0]).toBeInstanceOf(Error);
+        expect((errorHandlingSpy.mock.calls[0][0] as Error).message).toContain("not a valid USS file structure");
+    });
+
+    it("Tests node.pasteUssTree() rejects clipboard contents whose top-level children is not an array", async () => {
+        const globalMocks = createGlobalMocks();
+        const blockMocks = createBlockMocks(globalMocks);
+        const errorHandlingSpy = jest.spyOn(profileUtils, "errorHandling").mockResolvedValue(undefined);
+        const pasteSpy = jest.spyOn(blockMocks.testNode, "paste");
+        pasteSpy.mockClear();
+
+        globalMocks.readText.mockResolvedValueOnce(JSON.stringify({ children: "not-an-array" }));
+
+        await blockMocks.testNode.pasteUssTree();
+
+        expect(pasteSpy).not.toHaveBeenCalled();
+        expect(errorHandlingSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/zowe-explorer/i18n/sample/src/uss/FileStructure.i18n.json
+++ b/packages/zowe-explorer/i18n/sample/src/uss/FileStructure.i18n.json
@@ -1,0 +1,3 @@
+{
+  "resolveLocalPath.invalidPath": "Cannot paste: missing or invalid USS path"
+}

--- a/packages/zowe-explorer/src/uss/FileStructure.ts
+++ b/packages/zowe-explorer/src/uss/FileStructure.ts
@@ -117,13 +117,13 @@ export class UssFileUtils {
         const segments = ussPath.split(/[/\\]+/).filter((segment) => segment.length > 0 && segment !== ".");
         const isUnsafeSegment = (segment: string): boolean => segment === ".." || /^[a-zA-Z]:$/.test(segment);
         if (segments.some(isUnsafeSegment)) {
-            throw new Error(`Cannot paste: unsafe USS path "${ussPath}".`);
+            throw new Error(`Cannot paste: missing or invalid USS path "${ussPath}".`);
         }
 
         const ussDir = path.resolve(globals.USS_DIR);
         const localPath = path.resolve(ussDir, profileName ?? "", ...segments);
         if (localPath !== ussDir && !localPath.startsWith(ussDir + path.sep)) {
-            throw new Error(`Cannot paste: resolved path for USS path "${ussPath}" escapes the local USS directory.`);
+            throw new Error(`Cannot paste: missing or invalid USS path "${ussPath}".`);
         }
 
         return localPath;

--- a/packages/zowe-explorer/src/uss/FileStructure.ts
+++ b/packages/zowe-explorer/src/uss/FileStructure.ts
@@ -96,9 +96,18 @@ export class UssFileUtils {
     }
 
     /**
+     * Builds the uniform,  error for a rejected USS paste path
+     */
+    private static invalidPathError(ussPath?: string): Error {
+        return ussPath != null && ussPath.length > 0
+            ? new Error(`Cannot paste: missing or invalid USS path "${ussPath}".`)
+            : new Error("Cannot paste: missing or invalid USS path.");
+    }
+
+    /**
      * Recomputes the local file system path for a USS path that is about to be
-     * pasted, ignoring any `localPath` supplied by the clipboard
-     * contents. The resulting path is guaranteed to live inside `globals.USS_DIR`.
+     * pasted, ignoring any `localPath` supplied by the clipboard.
+     * The resulting path is guaranteed to live inside `globals.USS_DIR`.
      *
      * @param profileName The name of the profile that owns the paste destination
      * @param ussPath The remote USS path taken from the (untrusted) file tree node
@@ -108,7 +117,7 @@ export class UssFileUtils {
     public static resolveLocalPath(profileName: string, ussPath: string): string {
         ZoweLogger.trace("UssFileUtils.resolveLocalPath called.");
         if (typeof ussPath !== "string" || ussPath.length === 0) {
-            throw new Error("Cannot paste: missing or invalid USS path.");
+            throw UssFileUtils.invalidPathError();
         }
 
         // Treat the USS path as relative to the local USS directory: strip any
@@ -117,13 +126,13 @@ export class UssFileUtils {
         const segments = ussPath.split(/[/\\]+/).filter((segment) => segment.length > 0 && segment !== ".");
         const isUnsafeSegment = (segment: string): boolean => segment === ".." || /^[a-zA-Z]:$/.test(segment);
         if (segments.some(isUnsafeSegment)) {
-            throw new Error(`Cannot paste: unsafe USS path "${ussPath}".`);
+            throw UssFileUtils.invalidPathError(ussPath);
         }
 
         const ussDir = path.resolve(globals.USS_DIR);
         const localPath = path.resolve(ussDir, profileName ?? "", ...segments);
         if (localPath !== ussDir && !localPath.startsWith(ussDir + path.sep)) {
-            throw new Error(`Cannot paste: resolved path for "${ussPath}" escapes the local USS directory.`);
+            throw UssFileUtils.invalidPathError(ussPath);
         }
 
         return localPath;

--- a/packages/zowe-explorer/src/uss/FileStructure.ts
+++ b/packages/zowe-explorer/src/uss/FileStructure.ts
@@ -45,10 +45,9 @@ export interface UssFileTree {
 }
 
 /**
- * Type guard that validates an untrusted value (e.g. parsed from the clipboard)
+ * Type guard that validates an untrusted value (ie parsed from the clipboard)
  * has the shape of a `UssFileTree` node before it is used anywhere else.
- * Does not validate `localPath`/trust it for anything - that value is always
- * recomputed locally, never taken from the (potentially attacker-controlled) input.
+ * path value is always recomputed locally, never taken from the input
  */
 export function isValidUssFileTree(node: unknown): node is UssFileTree {
     if (typeof node !== "object" || node === null) {
@@ -70,10 +69,8 @@ export function isValidUssFileTree(node: unknown): node is UssFileTree {
     if (tree.binary != null && typeof tree.binary !== "boolean") {
         return false;
     }
-    if (tree.children != null) {
-        if (!Array.isArray(tree.children) || !tree.children.every((child) => isValidUssFileTree(child))) {
-            return false;
-        }
+    if (tree.children != null && (!Array.isArray(tree.children) || !tree.children.every((child) => isValidUssFileTree(child)))) {
+        return false;
     }
     return true;
 }
@@ -100,7 +97,7 @@ export class UssFileUtils {
 
     /**
      * Recomputes the local file system path for a USS path that is about to be
-     * pasted, ignoring any `localPath` supplied by the (untrusted) clipboard
+     * pasted, ignoring any `localPath` supplied by the clipboard
      * contents. The resulting path is guaranteed to live inside `globals.USS_DIR`.
      *
      * @param profileName The name of the profile that owns the paste destination

--- a/packages/zowe-explorer/src/uss/FileStructure.ts
+++ b/packages/zowe-explorer/src/uss/FileStructure.ts
@@ -10,8 +10,16 @@
  */
 
 import * as path from "path";
+import * as nls from "vscode-nls";
 import * as globals from "../globals";
 import { ZoweLogger } from "../utils/LoggerUtils";
+
+// Set up localization
+nls.config({
+    messageFormat: nls.MessageFormat.bundle,
+    bundleFormat: nls.BundleFormat.standalone,
+})();
+const localize: nls.LocalizeFunc = nls.loadMessageBundle();
 
 /**
  * File types within the USS tree structure
@@ -107,8 +115,9 @@ export class UssFileUtils {
      */
     public static resolveLocalPath(profileName: string, ussPath: string): string {
         ZoweLogger.trace("UssFileUtils.resolveLocalPath called.");
+        const invalidPathMsg = localize("resolveLocalPath.invalidPath", "Cannot paste: missing or invalid USS path");
         if (typeof ussPath !== "string" || ussPath.length === 0) {
-            throw new Error("Cannot paste: missing or invalid USS path.");
+            throw new Error(`${invalidPathMsg}.`);
         }
 
         // Treat the USS path as relative to the local USS directory: strip any
@@ -117,13 +126,13 @@ export class UssFileUtils {
         const segments = ussPath.split(/[/\\]+/).filter((segment) => segment.length > 0 && segment !== ".");
         const isUnsafeSegment = (segment: string): boolean => segment === ".." || /^[a-zA-Z]:$/.test(segment);
         if (segments.some(isUnsafeSegment)) {
-            throw new Error(`Cannot paste: missing or invalid USS path "${ussPath}".`);
+            throw new Error(`${invalidPathMsg}: ${ussPath}`);
         }
 
         const ussDir = path.resolve(globals.USS_DIR);
         const localPath = path.resolve(ussDir, profileName ?? "", ...segments);
         if (localPath !== ussDir && !localPath.startsWith(ussDir + path.sep)) {
-            throw new Error(`Cannot paste: missing or invalid USS path "${ussPath}".`);
+            throw new Error(`${invalidPathMsg}: ${ussPath}`);
         }
 
         return localPath;

--- a/packages/zowe-explorer/src/uss/FileStructure.ts
+++ b/packages/zowe-explorer/src/uss/FileStructure.ts
@@ -96,18 +96,9 @@ export class UssFileUtils {
     }
 
     /**
-     * Builds the uniform,  error for a rejected USS paste path
-     */
-    private static invalidPathError(ussPath?: string): Error {
-        return ussPath != null && ussPath.length > 0
-            ? new Error(`Cannot paste: missing or invalid USS path "${ussPath}".`)
-            : new Error("Cannot paste: missing or invalid USS path.");
-    }
-
-    /**
      * Recomputes the local file system path for a USS path that is about to be
-     * pasted, ignoring any `localPath` supplied by the clipboard.
-     * The resulting path is guaranteed to live inside `globals.USS_DIR`.
+     * pasted, ignoring any `localPath` supplied by the clipboard
+     * contents. The resulting path is guaranteed to live inside `globals.USS_DIR`.
      *
      * @param profileName The name of the profile that owns the paste destination
      * @param ussPath The remote USS path taken from the (untrusted) file tree node
@@ -116,8 +107,9 @@ export class UssFileUtils {
      */
     public static resolveLocalPath(profileName: string, ussPath: string): string {
         ZoweLogger.trace("UssFileUtils.resolveLocalPath called.");
+        const invalidPathMsg = "Cannot paste: missing or invalid USS path";
         if (typeof ussPath !== "string" || ussPath.length === 0) {
-            throw UssFileUtils.invalidPathError();
+            throw new Error(`${invalidPathMsg}.`);
         }
 
         // Treat the USS path as relative to the local USS directory: strip any
@@ -126,13 +118,13 @@ export class UssFileUtils {
         const segments = ussPath.split(/[/\\]+/).filter((segment) => segment.length > 0 && segment !== ".");
         const isUnsafeSegment = (segment: string): boolean => segment === ".." || /^[a-zA-Z]:$/.test(segment);
         if (segments.some(isUnsafeSegment)) {
-            throw UssFileUtils.invalidPathError(ussPath);
+            throw new Error(`${invalidPathMsg} "${ussPath}".`);
         }
 
         const ussDir = path.resolve(globals.USS_DIR);
         const localPath = path.resolve(ussDir, profileName ?? "", ...segments);
         if (localPath !== ussDir && !localPath.startsWith(ussDir + path.sep)) {
-            throw UssFileUtils.invalidPathError(ussPath);
+            throw new Error(`${invalidPathMsg} "${ussPath}".`);
         }
 
         return localPath;

--- a/packages/zowe-explorer/src/uss/FileStructure.ts
+++ b/packages/zowe-explorer/src/uss/FileStructure.ts
@@ -9,6 +9,8 @@
  *
  */
 
+import * as path from "path";
+import * as globals from "../globals";
 import { ZoweLogger } from "../utils/LoggerUtils";
 
 /**
@@ -43,6 +45,40 @@ export interface UssFileTree {
 }
 
 /**
+ * Type guard that validates an untrusted value (e.g. parsed from the clipboard)
+ * has the shape of a `UssFileTree` node before it is used anywhere else.
+ * Does not validate `localPath`/trust it for anything - that value is always
+ * recomputed locally, never taken from the (potentially attacker-controlled) input.
+ */
+export function isValidUssFileTree(node: unknown): node is UssFileTree {
+    if (typeof node !== "object" || node === null) {
+        return false;
+    }
+    const tree = node as Record<string, unknown>;
+    if (typeof tree.ussPath !== "string") {
+        return false;
+    }
+    if (tree.type !== UssFileType.File && tree.type !== UssFileType.Directory) {
+        return false;
+    }
+    if (tree.baseName != null && typeof tree.baseName !== "string") {
+        return false;
+    }
+    if (tree.sessionName != null && typeof tree.sessionName !== "string") {
+        return false;
+    }
+    if (tree.binary != null && typeof tree.binary !== "boolean") {
+        return false;
+    }
+    if (tree.children != null) {
+        if (!Array.isArray(tree.children) || !tree.children.every((child) => isValidUssFileTree(child))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
  * Interprets a file/directory list as a tree structure
  */
 export class UssFileUtils {
@@ -60,5 +96,39 @@ export class UssFileUtils {
         }
 
         return fileTree.children.every((node) => UssFileUtils.toSameSession(node, destSessionName));
+    }
+
+    /**
+     * Recomputes the local file system path for a USS path that is about to be
+     * pasted, ignoring any `localPath` supplied by the (untrusted) clipboard
+     * contents. The resulting path is guaranteed to live inside `globals.USS_DIR`.
+     *
+     * @param profileName The name of the profile that owns the paste destination
+     * @param ussPath The remote USS path taken from the (untrusted) file tree node
+     * @returns An absolute local path underneath `globals.USS_DIR`
+     * @throws if `ussPath` is not a safe, containable path
+     */
+    public static resolveLocalPath(profileName: string, ussPath: string): string {
+        ZoweLogger.trace("UssFileUtils.resolveLocalPath called.");
+        if (typeof ussPath !== "string" || ussPath.length === 0) {
+            throw new Error("Cannot paste: missing or invalid USS path.");
+        }
+
+        // Treat the USS path as relative to the local USS directory: strip any
+        // leading slashes and reject drive letters/UNC roots/".." segments so it
+        // can never be interpreted as an OS-absolute path or escape via traversal.
+        const segments = ussPath.split(/[/\\]+/).filter((segment) => segment.length > 0 && segment !== ".");
+        const isUnsafeSegment = (segment: string): boolean => segment === ".." || /^[a-zA-Z]:$/.test(segment);
+        if (segments.some(isUnsafeSegment)) {
+            throw new Error(`Cannot paste: unsafe USS path "${ussPath}".`);
+        }
+
+        const ussDir = path.resolve(globals.USS_DIR);
+        const localPath = path.resolve(ussDir, profileName ?? "", ...segments);
+        if (localPath !== ussDir && !localPath.startsWith(ussDir + path.sep)) {
+            throw new Error(`Cannot paste: resolved path for "${ussPath}" escapes the local USS directory.`);
+        }
+
+        return localPath;
     }
 }

--- a/packages/zowe-explorer/src/uss/FileStructure.ts
+++ b/packages/zowe-explorer/src/uss/FileStructure.ts
@@ -107,9 +107,8 @@ export class UssFileUtils {
      */
     public static resolveLocalPath(profileName: string, ussPath: string): string {
         ZoweLogger.trace("UssFileUtils.resolveLocalPath called.");
-        const invalidPathMsg = "Cannot paste: missing or invalid USS path";
         if (typeof ussPath !== "string" || ussPath.length === 0) {
-            throw new Error(`${invalidPathMsg}.`);
+            throw new Error("Cannot paste: missing or invalid USS path.");
         }
 
         // Treat the USS path as relative to the local USS directory: strip any
@@ -118,13 +117,13 @@ export class UssFileUtils {
         const segments = ussPath.split(/[/\\]+/).filter((segment) => segment.length > 0 && segment !== ".");
         const isUnsafeSegment = (segment: string): boolean => segment === ".." || /^[a-zA-Z]:$/.test(segment);
         if (segments.some(isUnsafeSegment)) {
-            throw new Error(`${invalidPathMsg} "${ussPath}".`);
+            throw new Error(`Cannot paste: unsafe USS path "${ussPath}".`);
         }
 
         const ussDir = path.resolve(globals.USS_DIR);
         const localPath = path.resolve(ussDir, profileName ?? "", ...segments);
         if (localPath !== ussDir && !localPath.startsWith(ussDir + path.sep)) {
-            throw new Error(`${invalidPathMsg} "${ussPath}".`);
+            throw new Error(`Cannot paste: resolved path for USS path "${ussPath}" escapes the local USS directory.`);
         }
 
         return localPath;

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -32,7 +32,7 @@ import { autoDetectEncoding, fileExistsCaseSensitiveSync, injectAdditionalDataTo
 import * as contextually from "../shared/context";
 import { closeOpenedTextFile } from "../utils/workspace";
 import * as nls from "vscode-nls";
-import { UssFileTree, UssFileType, UssFileUtils } from "./FileStructure";
+import { isValidUssFileTree, UssFileTree, UssFileType, UssFileUtils } from "./FileStructure";
 import { ZoweLogger } from "../utils/LoggerUtils";
 import { initializeFileOpening, updateOpenFiles } from "../shared/utils";
 import { IZoweUssTreeOpts } from "../shared/IZoweTreeOpts";
@@ -669,12 +669,18 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
                 recursive: uss.tree.type === UssFileType.Directory,
             });
         } else {
-            const existsLocally = fs.existsSync(uss.tree.localPath);
+            // Never trust the clipboard-supplied localPath: recompute it from the
+            // destination profile and USS path, and require it to stay inside USS_DIR.
+            console.log("DEBUG profileName", this.getSessionNode().getProfileName(), "ussPath", uss.tree.ussPath, "USS_DIR", globals.USS_DIR);
+            const localPath = UssFileUtils.resolveLocalPath(this.getSessionNode().getProfileName(), uss.tree.ussPath);
+            console.log("DEBUG localPath", localPath);
+            const existsLocally = fs.existsSync(localPath);
+            console.log("DEBUG existsLocally", existsLocally);
             switch (uss.tree.type) {
                 case UssFileType.Directory:
                     if (!existsLocally) {
                         // We will need to build the file structure locally, to pull files down if needed
-                        fs.mkdirSync(uss.tree.localPath, { recursive: true });
+                        fs.mkdirSync(localPath, { recursive: true });
                     }
                     // Not all APIs respect the recursive option, so it's best to
                     // recurse within this operation to avoid missing files/folders
@@ -688,14 +694,14 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
                 case UssFileType.File:
                     if (!existsLocally) {
                         await uss.api.getContents(uss.tree.ussPath, {
-                            file: uss.tree.localPath,
+                            file: localPath,
                             binary: uss.tree.binary,
                             returnEtag: true,
                             encoding: this.profile.profile?.encoding,
                             responseTimeout: this.profile.profile?.responseTimeout,
                         });
                     }
-                    await uss.api.putContent(uss.tree.localPath, outputPath, uss.options);
+                    await uss.api.putContent(localPath, outputPath, uss.options);
                     break;
             }
         }
@@ -713,7 +719,16 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
 
         const prof = this.getProfile();
         try {
-            const fileTreeToPaste: UssFileTree = JSON.parse(clipboardContents);
+            const parsedClipboardContents: unknown = JSON.parse(clipboardContents);
+            if (
+                typeof parsedClipboardContents !== "object" ||
+                parsedClipboardContents === null ||
+                !Array.isArray((parsedClipboardContents as { children?: unknown }).children) ||
+                !(parsedClipboardContents as { children: unknown[] }).children.every((child) => isValidUssFileTree(child))
+            ) {
+                throw new Error("Cannot paste: clipboard contents are not a valid USS file structure.");
+            }
+            const fileTreeToPaste = parsedClipboardContents as UssFileTree;
             const api = ZoweExplorerApiRegister.getUssApi(this.profile);
             const sessionName = this.getSessionNode().getLabel() as string;
 

--- a/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
+++ b/packages/zowe-explorer/src/uss/ZoweUSSNode.ts
@@ -671,11 +671,8 @@ export class ZoweUSSNode extends ZoweTreeNode implements IZoweUSSTreeNode {
         } else {
             // Never trust the clipboard-supplied localPath: recompute it from the
             // destination profile and USS path, and require it to stay inside USS_DIR.
-            console.log("DEBUG profileName", this.getSessionNode().getProfileName(), "ussPath", uss.tree.ussPath, "USS_DIR", globals.USS_DIR);
             const localPath = UssFileUtils.resolveLocalPath(this.getSessionNode().getProfileName(), uss.tree.ussPath);
-            console.log("DEBUG localPath", localPath);
             const existsLocally = fs.existsSync(localPath);
-            console.log("DEBUG existsLocally", existsLocally);
             switch (uss.tree.type) {
                 case UssFileType.Directory:
                     if (!existsLocally) {


### PR DESCRIPTION
<!-- 
**NOTE:** The team reserves the right to close pull requests that fail to meet quality standards or lack human contribution.
-->

## Proposed changes

Updates USS Paste. path is now evaluated after sanitization, rather than being read from clipboard. Also checks the clipboard contents for valid "shape"-> will error if node has unexpected properties
## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:
v2.18.5?
Changelog:
- Updated the USS paste action to validate clipboard contents and to evaluate the newly santized USS clipboard path

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [X] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [X] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [X] There is coverage for the code that I have added
- [X] I have added new unit test cases and they are passing
- [ ] I have added at least one end-to-end test for new features to validate behavior (if applicable)
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] I have verified that all dependency updates (such as Zowe SDKs) in this pull request are compatible
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

pasting now computes local path from `globals.USS_DIR+profile+ussPath`. aka global base is read and sanitized pieces are added to create the final paste path