### PR TITLE
fix bug where detectServerOnPath would store the path in config with undefined host

### DIFF
--- a/packages/zowex-for-zowe-explorer/__tests__/SSHClientCache.test.ts
+++ b/packages/zowex-for-zowe-explorer/__tests__/SSHClientCache.test.ts
@@ -711,12 +711,19 @@ describe("SshClientCache", () => {
             cache.storeServerPath = vi.fn();
         });
 
-        it("should return a parentDir if the server is successfully located on the $PATH and is executable", async () => {
-            const binary = "/my/wonderful/dir/zowex";
-            vi.mocked(ZSshUtils.detectServerOnPath).mockResolvedValue({ serverPath: binary, hasExecutePermission: true });
-            const envServerPath = await (cache as any).detectServerOnPath({}, mockProfile);
-            expect(envServerPath).toEqual("/my/wonderful/dir");
-        });
+        it(
+            "should return a parentDir if the server is successfully located on the $PATH and is executable, " +
+                "and the parentDir should be stored in config",
+            async () => {
+                const binary = "/my/wonderful/dir/zowex";
+                const expectedHost = "expected-host";
+                const profileWithHost = { ...mockProfile, profile: { ...mockProfile.profile, host: expectedHost } };
+                vi.mocked(ZSshUtils.detectServerOnPath).mockResolvedValue({ serverPath: binary, hasExecutePermission: true });
+                const envServerPath = await (cache as any).detectServerOnPath({}, profileWithHost);
+                expect(envServerPath).toEqual("/my/wonderful/dir");
+                expect(cache.storeServerPath).toHaveBeenCalledWith(expectedHost, "/my/wonderful/dir");
+            }
+        );
 
         it("should NOT return a parentDir if the server is successfully located on the $PATH but is NOT executable", async () => {
             const binary = "/my/wonderful/dir/zowex";

--- a/packages/zowex-for-zowe-explorer/__tests__/SSHClientCache.test.ts
+++ b/packages/zowex-for-zowe-explorer/__tests__/SSHClientCache.test.ts
@@ -717,9 +717,8 @@ describe("SshClientCache", () => {
             async () => {
                 const binary = "/my/wonderful/dir/zowex";
                 const expectedHost = "expected-host";
-                const profileWithHost = { ...mockProfile, profile: { ...mockProfile.profile, host: expectedHost } };
                 vi.mocked(ZSshUtils.detectServerOnPath).mockResolvedValue({ serverPath: binary, hasExecutePermission: true });
-                const envServerPath = await (cache as any).detectServerOnPath({}, profileWithHost);
+                const envServerPath = await (cache as any).detectServerOnPath({ ISshSession: { hostname: expectedHost } });
                 expect(envServerPath).toEqual("/my/wonderful/dir");
                 expect(cache.storeServerPath).toHaveBeenCalledWith(expectedHost, "/my/wonderful/dir");
             }

--- a/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
+++ b/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
@@ -106,7 +106,7 @@ export class SshClientCache extends vscode.Disposable {
      * @param profile - the SSH profile used to connect
      * @returns true if a usable version of the SSH backend server is detected on the user's path
      */
-    public async detectServerOnPath(session: SshSession, profile: imperative.IProfile): Promise<string | undefined> {
+    public async detectServerOnPath(session: SshSession, profile: imperative.IProfileLoaded): Promise<string | undefined> {
         try {
             const pathServer = await ZSshUtils.detectServerOnPath(session);
             imperative.Logger.getAppLogger().debug("detectServerOnPath return value: %s", JSON.stringify(pathServer));

--- a/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
+++ b/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
@@ -115,7 +115,7 @@ export class SshClientCache extends vscode.Disposable {
                 // path.resolve(): remove binary from the full path to set serverPath to the parent directory,
                 // the same as a user would configure the path manually
                 const parentDir = path.posix.dirname(pathServer.serverPath);
-                SshClientCache.inst.storeServerPath(profile.profile.host, parentDir);
+                SshClientCache.inst.storeServerPath(profile.profile!.host, parentDir);
                 return parentDir;
             }
         } catch (e) {

--- a/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
+++ b/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
@@ -115,7 +115,7 @@ export class SshClientCache extends vscode.Disposable {
                 // path.resolve(): remove binary from the full path to set serverPath to the parent directory,
                 // the same as a user would configure the path manually
                 const parentDir = path.posix.dirname(pathServer.serverPath);
-                SshClientCache.inst.storeServerPath(profile.host, parentDir);
+                SshClientCache.inst.storeServerPath(profile.profile.host, parentDir);
                 return parentDir;
             }
         } catch (e) {

--- a/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
+++ b/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
@@ -111,7 +111,7 @@ export class SshClientCache extends vscode.Disposable {
             const pathServer = await ZSshUtils.detectServerOnPath(session);
             imperative.Logger.getAppLogger().debug("detectServerOnPath return value: %s", JSON.stringify(pathServer));
             if (pathServer.serverPath && pathServer.hasExecutePermission) {
-                imperative.Logger.getAppLogger().debug("Skipping deploy, since a usable instance of the server exists on the user's PATH");
+                imperative.Logger.getAppLogger().debug("A usable instance of the server exists on the user's PATH");
                 // path.resolve(): remove binary from the full path to set serverPath to the parent directory,
                 // the same as a user would configure the path manually
                 const parentDir = path.posix.dirname(pathServer.serverPath);
@@ -119,7 +119,7 @@ export class SshClientCache extends vscode.Disposable {
                 return parentDir;
             }
         } catch (e) {
-            imperative.Logger.getAppLogger().error("Error detecting server on user's $PATH: %s", e);
+            imperative.Logger.getAppLogger().error(`Error detecting server on user's $PATH:`, e);
             await SshErrorHandler.getInstance().handleError(e as Error, ZoweExplorerApiType.All, "Detecting server on $PATH");
         }
         return undefined;

--- a/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
+++ b/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
@@ -118,7 +118,7 @@ export class SshClientCache extends vscode.Disposable {
                 return parentDir;
             }
         } catch (e) {
-            imperative.Logger.getAppLogger().error(`Error detecting server on user's $PATH:`, e);
+            imperative.Logger.getAppLogger().error(`Error detecting server on user's $PATH: ${(e as Error).toString()}`);
             await SshErrorHandler.getInstance().handleError(e as Error, ZoweExplorerApiType.All, "Detecting server on $PATH");
         }
         return undefined;

--- a/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
+++ b/packages/zowex-for-zowe-explorer/src/SshClientCache.ts
@@ -103,10 +103,9 @@ export class SshClientCache extends vscode.Disposable {
     /**
      * Detect if a usable instance of our server binary exists on the user's USS environment.
      * @param session - established SSH session used to detect the server
-     * @param profile - the SSH profile used to connect
      * @returns true if a usable version of the SSH backend server is detected on the user's path
      */
-    public async detectServerOnPath(session: SshSession, profile: imperative.IProfileLoaded): Promise<string | undefined> {
+    public async detectServerOnPath(session: SshSession): Promise<string | undefined> {
         try {
             const pathServer = await ZSshUtils.detectServerOnPath(session);
             imperative.Logger.getAppLogger().debug("detectServerOnPath return value: %s", JSON.stringify(pathServer));
@@ -115,7 +114,7 @@ export class SshClientCache extends vscode.Disposable {
                 // path.resolve(): remove binary from the full path to set serverPath to the parent directory,
                 // the same as a user would configure the path manually
                 const parentDir = path.posix.dirname(pathServer.serverPath);
-                SshClientCache.inst.storeServerPath(profile.profile!.host, parentDir);
+                SshClientCache.inst.storeServerPath(session.ISshSession.hostname!, parentDir);
                 return parentDir;
             }
         } catch (e) {
@@ -189,7 +188,7 @@ export class SshClientCache extends vscode.Disposable {
             }
             if (serverShouldDeploy) {
                 if (serverNotFound) {
-                    const onEnvPathServer = await this.detectServerOnPath(session, profile);
+                    const onEnvPathServer = await this.detectServerOnPath(session);
                     if (onEnvPathServer) {
                         try {
                             serverPath = onEnvPathServer;

--- a/packages/zowex-for-zowe-explorer/src/Utilities.ts
+++ b/packages/zowex-for-zowe-explorer/src/Utilities.ts
@@ -45,7 +45,7 @@ export class Utilities {
         const sshSession = ZSshUtils.buildSession(profile.profile);
         let onEnvPathServer: string | undefined = undefined;
         if (configuredServerPath == null) {
-            onEnvPathServer = await SshClientCache.inst.detectServerOnPath(sshSession, profile.profile);
+            onEnvPathServer = await SshClientCache.inst.detectServerOnPath(sshSession, profile);
             configuredServerPath = onEnvPathServer ?? ZSshClient.DEFAULT_SERVER_PATH;
         }
 

--- a/packages/zowex-for-zowe-explorer/src/Utilities.ts
+++ b/packages/zowex-for-zowe-explorer/src/Utilities.ts
@@ -45,7 +45,7 @@ export class Utilities {
         const sshSession = ZSshUtils.buildSession(profile.profile);
         let onEnvPathServer: string | undefined = undefined;
         if (configuredServerPath == null) {
-            onEnvPathServer = await SshClientCache.inst.detectServerOnPath(sshSession, profile);
+            onEnvPathServer = await SshClientCache.inst.detectServerOnPath(sshSession);
             configuredServerPath = onEnvPathServer ?? ZSshClient.DEFAULT_SERVER_PATH;
         }
 


### PR DESCRIPTION
Fix bug from #4367 . Sorry I didn't notice that before, I think it got broken somewhere along the way after my initial testing
<!-- 
**NOTE:** The team reserves the right to close pull requests that fail to meet quality standards or lack human contribution.
-->

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [x] There is coverage for the code that I have added
- [ ] I have added new unit test cases and they are passing
- [ ] I have added at least one end-to-end test for new features to validate behavior (if applicable)
- [x] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] I have verified that all dependency updates (such as Zowe SDKs) in this pull request are compatible
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
