### PR TITLE
Fix USS workspace new-file failing to open editor (#4423)

### DIFF
--- a/packages/zowe-explorer/CHANGELOG.md
+++ b/packages/zowe-explorer/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to the "vscode-extension-for-zowe" extension will be documen
 - Fixed an issue where the "Open" action in the data sets table did not validate the URI before opening it. [#4416](https://github.com/zowe/zowe-explorer-vscode/pull/4416)
 - Fixed an issue where opening a PDS member with a recognized file extension (such as JCL) from the data sets table would fail. [#4416](https://github.com/zowe/zowe-explorer-vscode/pull/4416)
 - Fixed an issue where right-clicking a filtered USS directory (session profile node with an active path filter) showed fewer context menu options than a regular directory node in the tree. [#4289](https://github.com/zowe/zowe-explorer-vscode/issues/4289)
+- Fixed an issue where creating a new file in a USS directory added to the workspace failed to open the editor with an "unexpected error", because the newly created placeholder file triggered a remote fetch for a path that did not exist yet. [#4423](https://github.com/zowe/zowe-explorer-vscode/issues/4423)
 
 ## `3.5.1`
 

--- a/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/trees/uss/UssFSProvider.unit.test.ts
@@ -1696,6 +1696,29 @@ describe("UssFSProvider", () => {
             ussApiMock.mockRestore();
             uploadEntryMock.mockRestore();
         });
+        it("marks a newly created empty file as accessed so it can be opened without a failing remote fetch (issue #4423)", async () => {
+            const uploadEntryMock = vi.spyOn(UssFSProvider.instance as any, "uploadEntry").mockResolvedValue({ apiResponse: { etag: "NEWETAG" } });
+            const folder = {
+                ...testEntries.folder,
+                entries: new Map(),
+                metadata: { ...testEntries.folder.metadata },
+            };
+            const lookupParentDirMock = vi.spyOn(UssFSProvider.instance as any, "lookupParentDirectory").mockReturnValueOnce(folder);
+
+            // Emulates VS Code's native "New File" in a USS workspace folder: writeFile with empty content.
+            await UssFSProvider.instance.writeFile(testUris.file, new Uint8Array([]), { create: true, overwrite: false });
+
+            const fileEntry = folder.entries.get("aFile.txt")!;
+            expect(fileEntry).toBeDefined();
+            expect(fileEntry.data?.length).toBe(0);
+            // An empty placeholder file is not uploaded to the mainframe yet...
+            expect(uploadEntryMock).not.toHaveBeenCalled();
+            // ...so it must be marked as accessed; otherwise readFile fetches from a remote path
+            // that does not exist yet, and the editor fails to open (issue #4423).
+            expect(fileEntry.wasAccessed).toBe(true);
+            lookupParentDirMock.mockRestore();
+            uploadEntryMock.mockRestore();
+        });
 
         it("updates a file when open in the diff view", async () => {
             const ussApiMock = vi.spyOn(ZoweExplorerApiRegister, "getUssApi");

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -777,6 +777,11 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
                 path: path.posix.join(parentDir.metadata.path, fileName),
             };
             entry.data = new Uint8Array();
+            // The provider holds authoritative content for a brand-new local entry (an empty
+            // placeholder that has not been uploaded yet). Mark it as accessed so that opening the
+            // file serves this local content instead of triggering a remote fetch for a path that
+            // does not exist on the mainframe yet, which fails to open the editor (issue #4423).
+            entry.wasAccessed = true;
             parentDir.entries.set(fileName, entry);
             parentDir.mtime = Date.now();
             parentDir.size += 1;


### PR DESCRIPTION
## Proposed changes

Fixes #4423.

When a USS directory is added to the VS Code workspace and a new file is created inside it via the native File Explorer, the editor fails to open with:

> The editor could not be opened due to an unexpected error. Please consult the log for more details.

### Root cause

VS Code's native "New File" writes an empty file through `UssFSProvider.writeFile` with `{ create: true }`. For a new, empty file the provider intentionally does **not** upload it to the mainframe (empty placeholder), but the created entry was left with `wasAccessed = false`.

Opening the editor then calls `readFile`, which — because `wasAccessed` is `false` — performs a remote lookup (`autoDetectEncoding` + `getContents`) for a path that does not exist on the mainframe yet. That request throws, and the unhandled error propagates out of `readFile`, so VS Code reports the generic "unexpected error" and refuses to open the editor.

Unlike the tree-based **Create File** action (`USSActions.createUSSNode`), which calls `ussApi.create(...)` before writing, the native workspace path never creates the file remotely, so the eager fetch has nothing to read.

### Fix

Mark the freshly created placeholder entry as `wasAccessed = true` in `writeFile`. The provider already holds authoritative local content (an empty buffer), so `readFile` now serves that instead of issuing a doomed remote fetch. The file is still uploaded to the remote system on the first real save (content length > 0), preserving existing behavior.

## Release Notes

Milestone: 3.6.0

Changelog: Fixed an issue where creating a new file in a USS directory added to the workspace failed to open the editor with an "unexpected error", because the newly created placeholder file triggered a remote fetch for a path that did not exist yet.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

**Code coverage**

- [x] There is coverage for the code that I have added
- [x] I have added new unit test cases and they are passing

Added a regression test `marks a newly created empty file as accessed so it can be opened without a failing remote fetch (issue #4423)` in `UssFSProvider.unit.test.ts`. The full `UssFSProvider.unit.test.ts` suite passes (112/112), and Prettier reports no formatting issues on the changed files.
