### PR TITLE
Fix error in auto-comment workflow

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -9,12 +9,14 @@ permissions:
 jobs:
   processLabelAction:
     name: Process Label Action
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          sparse-checkout: .github
 
       - name: Process Label Action
-        uses: dessant/label-actions@v4
+        uses: dessant/label-actions@65225c179d3b2502f6eda7b3d15101a3f412366b # v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config-path: '.github/label-actions.yml'

--- a/.github/workflows/merge-by-comments.yml
+++ b/.github/workflows/merge-by-comments.yml
@@ -6,11 +6,11 @@ on:
 jobs:
     rfr_add_date:
         name: "Post merge-by date as comment"
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-slim
         permissions:
             pull-requests: write
         steps:
-            - uses: zowe-actions/shared-actions/merge-by@main
+            - uses: zowe-actions/shared-actions/merge-by@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
               continue-on-error: true
               with:
                 operation: "bump-dates"

--- a/.github/workflows/merge-by-table.yml
+++ b/.github/workflows/merge-by-table.yml
@@ -15,12 +15,12 @@ on:
 jobs:
     rfr_add_date:
         name: "Build table and notify users"
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-slim
         permissions:
             discussions: write
             pull-requests: write
         steps:
-            - uses: zowe-actions/shared-actions/merge-by@main
+            - uses: zowe-actions/shared-actions/merge-by@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
               continue-on-error: true
               with:
                 operation: "build-table"

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -18,16 +18,16 @@ permissions:
 jobs:
   update-project:
     name: Move project item
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-slim
     steps:
-    - uses: zowe-actions/shared-actions/project-move-item@main
+    - uses: zowe-actions/shared-actions/project-move-item@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
       if: ${{ github.event.issue && fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}
       with:
         item-status: ${{ fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
-    - uses: zowe-actions/shared-actions/project-move-item@main
+    - uses: zowe-actions/shared-actions/project-move-item@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
       if: ${{ github.event.pull_request }}
       with:
         assign-author: true


### PR DESCRIPTION
**What It Does**

Fixes [this error](https://github.com/zowe/zowe-explorer-vscode/actions/runs/32385954089/job/96480364404) which was resolved in https://github.com/dessant/label-actions/commit/3bbbcc1244c9443644eeb4a48345dab91d56d4e5:
> Error: ValidationError: "github-token" length must be less than or equal to 100 characters long

Also updates workflows that are solely GitHub automation to use [ubuntu-slim](https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/) runner so they will run faster 😋 