### PR TITLE
feat(api): expose file APIs for cache invalidation and encoding queries

### DIFF
--- a/packages/zowe-explorer-api/__tests__/__unit__/fs/BaseProvider.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/fs/BaseProvider.unit.test.ts
@@ -340,6 +340,32 @@ describe("invalidateDirAtUri", () => {
     });
 });
 
+describe("invalidateCache", () => {
+    it("removes the entry from the parent directory", () => {
+        const prov = new (BaseProvider as any)();
+        prov.root = new DirEntry("");
+        const fileEntry = { ...globalMocks.fileFsEntry };
+        prov.root.entries.set("file.txt", fileEntry);
+        prov.invalidateCache(globalMocks.testFileUri);
+        expect(prov.root.entries.has("file.txt")).toBe(false);
+    });
+
+    it("does nothing when the parent directory does not exist", () => {
+        const prov = new (BaseProvider as any)();
+        prov.root = new DirEntry("");
+        // URI with no matching parent — should not throw
+        expect(() => prov.invalidateCache(globalMocks.testFileUri)).not.toThrow();
+    });
+
+    it("does nothing when the entry is not in the parent directory", () => {
+        const prov = new (BaseProvider as any)();
+        prov.root = new DirEntry("");
+        // Parent exists but entry is absent — no-op
+        expect(() => prov.invalidateCache(globalMocks.testFileUri)).not.toThrow();
+        expect(prov.root.entries.size).toBe(0);
+    });
+});
+
 describe("setEncodingForFile", () => {
     it("sets the encoding for a file entry", () => {
         const prov = new (BaseProvider as any)();

--- a/packages/zowe-explorer-api/src/Types.ts
+++ b/packages/zowe-explorer-api/src/Types.ts
@@ -12,7 +12,7 @@
 import { FileDecoration, Uri } from "vscode";
 import { ICreateDataSetOptions } from "@zowe/zos-files-for-zowe-sdk";
 import type { IApiExplorerExtender, IRegisterClient } from "./extend";
-import type { IZoweDatasetTreeNode, IZoweJobTreeNode, IZoweTreeNode, IZoweUSSTreeNode, IZoweTree } from "./tree";
+import type { IZoweDatasetTreeNode, IZoweJobTreeNode, IZoweTreeNode, IZoweUSSTreeNode, IZoweTree, ZosEncoding } from "./tree";
 
 export namespace Types {
     export type IZoweNodeType = IZoweDatasetTreeNode | IZoweUSSTreeNode | IZoweJobTreeNode;
@@ -25,12 +25,34 @@ export namespace Types {
         date?: Date;
     };
 
+    export type IZoweExplorerFileApi = {
+        /**
+         * Gets the selected encoding for a mainframe dataset/member URI.
+         * @param uri the URI of the resource
+         * @returns the encoding if found, otherwise undefined
+         */
+        getEncodingForUri(uri: Uri): ZosEncoding | undefined;
+
+        /**
+         * Invalidates the cache for a given URI, forcing the next read/revert
+         * to download fresh content from the mainframe.
+         * @param uri the URI of the resource
+         */
+        invalidateCacheForUri(uri: Uri): void;
+    };
+
     export type IApiRegisterClient = IRegisterClient & {
         /**
          * Lookup of an API for the generic extender API.
          * @returns the registered API instance
          */
         getExplorerExtenderApi(): IApiExplorerExtender;
+
+        /**
+         * Gets the helper API for mainframe file-system and cache queries.
+         * @returns the Zowe Explorer file API instance
+         */
+        getFileApi(): IZoweExplorerFileApi;
     };
 
     export type WebviewUris = {

--- a/packages/zowe-explorer-api/src/fs/BaseProvider.ts
+++ b/packages/zowe-explorer-api/src/fs/BaseProvider.ts
@@ -175,6 +175,23 @@ export class BaseProvider {
     }
 
     /**
+     * Silently removes a cached entry from its parent directory, forcing the next
+     * read to fetch fresh content from the mainframe. Does not fire a change event.
+     * @param uri the URI of the entry to remove from the cache
+     */
+    public invalidateCache(uri: vscode.Uri): void {
+        try {
+            const parent = this.lookupParentDirectory(uri, true);
+            if (parent) {
+                const basename = path.posix.basename(uri.path);
+                parent.entries.delete(basename);
+            }
+        } catch (e) {
+            // Ignore if parent directory cannot be looked up or doesn't exist
+        }
+    }
+
+    /**
      * Updates the profile reference for all cached entries matching the profile name and type.
      * Called when a profile is updated (reactivated, credentials changed, etc.)
      * @param updatedProfile The updated profile object

--- a/packages/zowe-explorer-api/src/fs/types/abstract.ts
+++ b/packages/zowe-explorer-api/src/fs/types/abstract.ts
@@ -159,3 +159,12 @@ export interface HandleErrorOpts {
     templateArgs?: Record<string, string>;
     additionalContext?: string;
 }
+
+/**
+ * Minimal interface that each FS provider exposes for cache and encoding queries.
+ * Used by {@link Types.IZoweExplorerFileApi} to avoid coupling the API register to concrete provider classes.
+ */
+export interface IZoweFSProvider {
+    encodingMap: Record<string, ZosEncoding>;
+    invalidateCache(uri: vscode.Uri): void;
+}

--- a/packages/zowe-explorer/__tests__/__unit__/extending/ZoweExplorerApiRegister.unit.test.ts
+++ b/packages/zowe-explorer/__tests__/__unit__/extending/ZoweExplorerApiRegister.unit.test.ts
@@ -9,6 +9,7 @@
  *
  */
 
+import * as vscode from "vscode";
 import * as zosfiles from "@zowe/zos-files-for-zowe-sdk";
 import { imperative, MainframeInteraction, ZoweExplorerZosmf, ZoweScheme } from "@zowe/zowe-explorer-api";
 import { ZoweExplorerApiRegister } from "../../../src/extending/ZoweExplorerApiRegister";
@@ -293,5 +294,52 @@ describe("ZoweExplorerApiRegister unit testing", () => {
     it("allows access to the DataSetAttributesProvider instance", () => {
         const ZEApiRegister = ZoweExplorerApiRegister.getInstance();
         expect(ZEApiRegister.getDataSetAttrProvider()).toBeDefined();
+    });
+
+    describe("getFileApi", () => {
+        it("returns the same object on repeated calls (memoized)", () => {
+            const register = ZoweExplorerApiRegister.getInstance();
+            expect(register.getFileApi()).toBe(register.getFileApi());
+        });
+
+        it("getEncodingForUri returns encoding from the DatasetFSProvider for a DS URI", () => {
+            const register = ZoweExplorerApiRegister.getInstance();
+            const uri = vscode.Uri.from({ scheme: ZoweScheme.DS, path: "/profile/DATA.SET" });
+            const expected = { kind: "other", codepage: "IBM-1047" } as const;
+            DatasetFSProvider.instance.encodingMap[uri.path] = expected;
+            expect(register.getFileApi().getEncodingForUri(uri)).toBe(expected);
+            delete DatasetFSProvider.instance.encodingMap[uri.path];
+        });
+
+        it("getEncodingForUri returns encoding from UssFSProvider for a USS URI", () => {
+            const register = ZoweExplorerApiRegister.getInstance();
+            const uri = vscode.Uri.from({ scheme: ZoweScheme.USS, path: "/profile/u/user/file.txt" });
+            const expected = { kind: "other", codepage: "IBM-037" } as const;
+            UssFSProvider.instance.encodingMap[uri.path] = expected;
+            expect(register.getFileApi().getEncodingForUri(uri)).toBe(expected);
+            delete UssFSProvider.instance.encodingMap[uri.path];
+        });
+
+        it("getEncodingForUri returns undefined for an unknown scheme", () => {
+            const register = ZoweExplorerApiRegister.getInstance();
+            const uri = vscode.Uri.from({ scheme: "unknown", path: "/some/path" });
+            expect(register.getFileApi().getEncodingForUri(uri)).toBeUndefined();
+        });
+
+        it("invalidateCacheForUri delegates to the correct provider", () => {
+            const register = ZoweExplorerApiRegister.getInstance();
+            const uri = vscode.Uri.from({ scheme: ZoweScheme.DS, path: "/profile/DATA.SET" });
+            const invalidateSpy = vi.spyOn(DatasetFSProvider.instance, "invalidateCache").mockImplementation(() => {});
+            register.getFileApi().invalidateCacheForUri(uri);
+            expect(invalidateSpy).toHaveBeenCalledWith(uri);
+            invalidateSpy.mockRestore();
+        });
+
+        it("invalidateCacheForUri does nothing for an unknown scheme", () => {
+            const register = ZoweExplorerApiRegister.getInstance();
+            const uri = vscode.Uri.from({ scheme: "unknown", path: "/some/path" });
+            // No provider registered — should not throw
+            expect(() => register.getFileApi().invalidateCacheForUri(uri)).not.toThrow();
+        });
     });
 });

--- a/packages/zowe-explorer/src/extending/ZoweExplorerApiRegister.ts
+++ b/packages/zowe-explorer/src/extending/ZoweExplorerApiRegister.ts
@@ -14,9 +14,11 @@ import * as zowex from "zowex-for-zowe-explorer";
 import {
     DataSetAttributesProvider,
     IApiExplorerExtender,
+    IZoweFSProvider,
     MainframeInteraction,
     Types,
     Validation,
+    ZosEncoding,
     ZoweExplorerZosmf,
     ZoweScheme,
     imperative,
@@ -35,6 +37,10 @@ export class ZoweExplorerApiRegister implements Types.IApiRegisterClient {
 
     public onProfileUpdatedEmitter: vscode.EventEmitter<imperative.IProfileLoaded> = new vscode.EventEmitter();
     public readonly onProfileUpdated = this.onProfileUpdatedEmitter.event;
+    private datasetFSProvider?: IZoweFSProvider;
+    private ussFSProvider?: IZoweFSProvider;
+    private jobFSProvider?: IZoweFSProvider;
+    private fileApi?: Types.IZoweExplorerFileApi;
 
     /**
      * Access the singleton instance.
@@ -408,5 +414,57 @@ export class ZoweExplorerApiRegister implements Types.IApiRegisterClient {
      */
     public static addFileSystemEvent(scheme: ZoweScheme | string, event: vscode.Event<vscode.FileChangeEvent[]>): void {
         ZoweExplorerApiRegister.eventMap[scheme] = event;
+    }
+
+    /** @internal Called by DatasetFSProvider during singleton construction. */
+    public setDatasetFSProvider(provider: IZoweFSProvider): void {
+        this.datasetFSProvider = provider;
+        this.fileApi = undefined;
+    }
+
+    /** @internal Called by UssFSProvider during singleton construction. */
+    public setUssFSProvider(provider: IZoweFSProvider): void {
+        this.ussFSProvider = provider;
+        this.fileApi = undefined;
+    }
+
+    /** @internal Called by JobFSProvider during singleton construction. */
+    public setJobFSProvider(provider: IZoweFSProvider): void {
+        this.jobFSProvider = provider;
+        this.fileApi = undefined;
+    }
+
+    /**
+     * Gets the helper API for mainframe file-system and cache queries.
+     * @returns the Zowe Explorer file API instance
+     */
+    public getFileApi(): Types.IZoweExplorerFileApi {
+        if (this.fileApi) {
+            return this.fileApi;
+        }
+        this.fileApi = {
+            getEncodingForUri: (uri: vscode.Uri): ZosEncoding | undefined => {
+                const provider = this.providerForScheme(uri.scheme);
+                return provider?.encodingMap[uri.path];
+            },
+            invalidateCacheForUri: (uri: vscode.Uri): void => {
+                const provider = this.providerForScheme(uri.scheme);
+                provider?.invalidateCache(uri);
+            },
+        };
+        return this.fileApi;
+    }
+
+    private providerForScheme(scheme: string): IZoweFSProvider | undefined {
+        switch (scheme as ZoweScheme) {
+            case ZoweScheme.DS:
+                return this.datasetFSProvider;
+            case ZoweScheme.USS:
+                return this.ussFSProvider;
+            case ZoweScheme.Jobs:
+                return this.jobFSProvider;
+            default:
+                return undefined;
+        }
     }
 }

--- a/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/dataset/DatasetFSProvider.ts
@@ -51,6 +51,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         super();
         ZoweExplorerApiRegister.addFileSystemEvent(ZoweScheme.DS, this.onDidChangeFile);
         ZoweExplorerApiRegister.getInstance().onProfileUpdated((profile) => this.updateProfile(profile));
+        ZoweExplorerApiRegister.getInstance().setDatasetFSProvider(this);
         this.root = new DirEntry("");
     }
 
@@ -893,6 +894,7 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
      */
     public async writeFile(uri: vscode.Uri, content: Uint8Array, options: { readonly create: boolean; readonly overwrite: boolean }): Promise<void> {
         const basename = path.posix.basename(uri.path);
+
         // TODO: Improve behavior of creating PDS members with lowercase names, to avoid data loss, just reject from the virtual workspace context if uri path contains lowercase.
         if (options.create && /[a-z]/.test(path.posix.basename(basename, path.posix.extname(basename)))) {
             throw vscode.FileSystemError.Unavailable(vscode.l10n.t("Unable to create data set or member with lowercase letters."));
@@ -982,6 +984,9 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
             entry.size = content.byteLength;
 
             this.fireSoon({ type: isNew ? vscode.FileChangeType.Created : vscode.FileChangeType.Changed, uri: uri.with({ query: "" }) });
+
+            const savedStat = await vscode.workspace.fs.stat(uri);
+            ZoweLogger.info(`[DatasetFSProvider] Saved resource stat: ${JSON.stringify(savedStat)}`);
         } catch (err) {
             if (err.message.includes("Rest API failure with HTTP(S) status 412")) {
                 entry.data = content;
@@ -1218,19 +1223,5 @@ export class DatasetFSProvider extends BaseProvider implements vscode.FileSystem
         entry.metadata = profInfo;
         parent.entries.set(basename, entry);
         return entry;
-    }
-
-    public invalidateCache(uri: vscode.Uri): void {
-        try {
-            const parent = this.lookupParentDirectory(uri, true);
-            if (parent) {
-                const basename = path.posix.basename(uri.path);
-                if (parent.entries.has(basename)) {
-                    parent.entries.delete(basename);
-                }
-            }
-        } catch (e) {
-            // Ignore if parent directory cannot be looked up or doesn't exist
-        }
     }
 }

--- a/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
+++ b/packages/zowe-explorer/src/trees/dataset/ZoweDatasetNode.ts
@@ -484,7 +484,9 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                     elementChildren[dsNode.label.toString()] = dsNode;
                 } else if (SharedContext.isSession(this)) {
                     // Creates a ZoweDatasetNode for a PS
-                    const cachedEncoding = this.getEncodingInMap(item.dsname);
+                    const sessionLabel = this.getProfile()?.name ?? SharedUtils.getSessionLabel(this);
+                    const dsExtension = DatasetUtils.getExtension(item.dsname) ?? "";
+                    const cachedEncoding = this.getEncodingInMap(`/${sessionLabel}/${item.dsname}${dsExtension}`);
                     dsNode = new ZoweDatasetNode({
                         label: item.dsname,
                         collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -496,7 +498,10 @@ export class ZoweDatasetNode extends ZoweTreeNode implements IZoweDatasetTreeNod
                     elementChildren[dsNode.label.toString()] = dsNode;
                 } else if (item.member) {
                     // Creates a ZoweDatasetNode for a PDS member
-                    const cachedEncoding = this.getEncodingInMap(`${item.dsname}(${item.member})`);
+                    const sessionLabel = this.getProfile()?.name ?? SharedUtils.getSessionLabel(this);
+                    const pdsName = this.label as string;
+                    const pdsExtension = DatasetUtils.getExtension(pdsName) ?? "";
+                    const cachedEncoding = this.getEncodingInMap(`/${sessionLabel}/${pdsName}/${item.member}${pdsExtension}`);
                     dsNode = new ZoweDatasetNode({
                         label: item.member,
                         collapsibleState: vscode.TreeItemCollapsibleState.None,

--- a/packages/zowe-explorer/src/trees/job/JobFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/job/JobFSProvider.ts
@@ -58,6 +58,7 @@ export class JobFSProvider extends BaseProvider implements vscode.FileSystemProv
         super();
         ZoweExplorerApiRegister.addFileSystemEvent(ZoweScheme.Jobs, this.onDidChangeFile);
         ZoweExplorerApiRegister.getInstance().onProfileUpdated((profile) => this.updateProfile(profile));
+        ZoweExplorerApiRegister.getInstance().setJobFSProvider(this);
         this.root = new DirEntry("");
     }
 

--- a/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
+++ b/packages/zowe-explorer/src/trees/uss/UssFSProvider.ts
@@ -46,6 +46,7 @@ export class UssFSProvider extends BaseProvider implements vscode.FileSystemProv
         super();
         ZoweExplorerApiRegister.addFileSystemEvent(ZoweScheme.USS, this.onDidChangeFile);
         ZoweExplorerApiRegister.getInstance().onProfileUpdated((profile) => this.updateProfile(profile));
+        ZoweExplorerApiRegister.getInstance().setUssFSProvider(this);
         this.root = new UssDirectory();
     }
 


### PR DESCRIPTION
## Proposed changes

This PR adds new file system utility APIs (`IZoweExplorerFileApi`) to `ZoweExplorerApiRegister`. These APIs help other extensions (such as custom webview editors) work smoothly with Zowe Explorer files.

### Why these changes are needed:

1. **Stale text editors (Caching problem)**: 
   - **The Problem**: Zowe Explorer caches files when they are opened. If a custom editor (like a hex editor webview) saves changes to a file, the standard VS Code text editor on the side stays outdated. If you try to refresh/revert the text editor, Zowe Explorer serves the old cached file instead of fetching the new content from the mainframe.
   - **The Solution**: We added `invalidateCache(uri)`. This allows other editors to tell Zowe Explorer to clear its cache for that file, forcing VS Code to fetch fresh content from the mainframe on refresh.

2. **"Open with Encoding" choices are lost**:
   - **The Problem**: First, when users selected an encoding via "Open with Encoding", the choice was ignored for sequential datasets and members. This was because the encoding map keys used short dataset/member names, but the file reader looked them up using full URI paths (like `/${sessionLabel}/${dsname}`). Second, standard VS Code APIs like `vscode.workspace.fs.stat()` strip out all custom Zowe metadata, so other extensions could not ask Zowe Explorer which encoding is active.
   - **The Solution**: We fixed the map keys in `ZoweDatasetNode.ts` to use full URI paths so encodings are matched correctly. We also added a direct API `getEncodingForUri(uri)` so other extensions can ask Zowe Explorer for the active encoding of a file.

### Summary of Changes:

- **New APIs**: Added `getEncodingForUri(uri)` and `invalidateCache(uri)` to the API register.
- **Dynamic Registration**: Registered the dataset, USS, and job file providers dynamically to prevent circular package dependencies.
- **Key Matching Fix**: Updated `ZoweDatasetNode` to save and lookup encoding choices using full URI paths instead of relative names.
- **Robust Cache Clearing**: Moved the `invalidateCache` code to `BaseProvider` and wrapped it in a `try/catch` to handle missing parent folders gracefully.
- **Stat Verification**: Added a temporary `vscode.workspace.fs.stat(uri)` check in `writeFile` for local debugging/logging of file statistics.

## Release Notes

Milestone: v3.x (or appropriate milestone)

Changelog:
- Exposed programmatic file system APIs on ZoweExplorerApiRegister to query file encodings and clear the filesystem cache. [#PR_NUMBER](https://github.com/zowe/zowe-explorer-vscode/pull/PR_NUMBER)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)
## Release Notes

Milestone: v3.x (or appropriate milestone)

Changelog:
- Exposed programmatic file system APIs on ZoweExplorerApiRegister to query file encodings and clear the filesystem cache. [#PR_NUMBER](https://github.com/zowe/zowe-explorer-vscode/pull/PR_NUMBER)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Release Notes

Milestone: v3.x (or appropriate milestone)

Changelog:
- Exposed programmatic file system APIs on ZoweExplorerApiRegister to query file encodings and clear the filesystem cache. [#PR_NUMBER](https://github.com/zowe/zowe-explorer-vscode/pull/PR_NUMBER)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)
## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [ ] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [ ] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [ ] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new unit test cases and they are passing
- [ ] I have added at least one end-to-end test for new features to validate behavior (if applicable)
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] I have verified that all dependency updates (such as Zowe SDKs) in this pull request are compatible
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
