### PR TITLE
fix: improve error message when flat profile has no base profile for SSO login

### DIFF
--- a/packages/zowe-explorer-api/CHANGELOG.md
+++ b/packages/zowe-explorer-api/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the "zowe-explorer-api" extension will be documented in t
 
 ### Bug fixes
 
+- Improved the error message during SSO login/logout when no base profile is found for a flat profile. The message now explains how to resolve the issue by either converting to a nested profile or adding a default base profile. [#4428](https://github.com/zowe/zowe-explorer-vscode/issues/4428)
 - Fixed an issue where the `promptUserPass` function would incorrectly reject an empty username when its `rePrompt` parameter was false. [#4378](https://github.com/zowe/zowe-explorer-vscode/pull/4378)
 - Fixed an issue where the `ZoweVsCodeExtension.workspaceRoot` function getter could return a non-existent local directory. Now, invalid directory paths are ignored by Zowe Explorer and only valid paths are considered as the workspace root. [#4271](https://github.com/zowe/zowe-explorer-vscode/issues/4271)
 - Fixed an issue where executing Unix commands could fail if the current working directory path contained certain special characters. [#4330](https://github.com/zowe/zowe-explorer-vscode/pull/4330)

--- a/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
+++ b/packages/zowe-explorer-api/__tests__/__unit__/vscode/ZoweVsCodeExtension.unit.test.ts
@@ -194,7 +194,7 @@ describe("ZoweVsCodeExtension", () => {
             await ZoweVsCodeExtension.ssoLogin({ serviceProfile: "service" });
             expect(fetchBaseProfileSpy).toHaveBeenCalledTimes(1);
             expect(updateBaseProfileFileLoginSpy).not.toHaveBeenCalled();
-            expect(errorMessageSpy).toHaveBeenCalledWith(expect.stringContaining("Login failed: No base profile found"));
+            expect(errorMessageSpy).toHaveBeenCalledWith(expect.stringContaining("Login failed: No base or parent profile found"));
         });
         it("should not logout if the base profile cannot be fetched", async () => {
             const errorMessageSpy = vi.spyOn(Gui, "errorMessage");
@@ -203,7 +203,7 @@ describe("ZoweVsCodeExtension", () => {
             await ZoweVsCodeExtension.ssoLogout({ serviceProfile: "service" });
             expect(fetchBaseProfileSpy).toHaveBeenCalledTimes(1);
             expect(updateBaseProfileFileLoginSpy).not.toHaveBeenCalled();
-            expect(errorMessageSpy).toHaveBeenCalledWith(expect.stringContaining("Logout failed: No base profile found"));
+            expect(errorMessageSpy).toHaveBeenCalledWith(expect.stringContaining("Logout failed: No base or parent profile found"));
         });
 
         describe("user and password chosen", () => {
@@ -611,7 +611,7 @@ describe("ZoweVsCodeExtension", () => {
             });
 
             expect(testSpy).not.toHaveBeenCalled();
-            expect(errorMessageSpy).toHaveBeenCalledWith(expect.stringContaining("No base profile found"));
+            expect(errorMessageSpy).toHaveBeenCalledWith(expect.stringContaining("No base or parent profile found"));
             expect(didLogin).toBe(false);
             await expect(fetchBaseProfileSpy.mock.results[0].value).resolves.toBeUndefined();
         });

--- a/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
+++ b/packages/zowe-explorer-api/src/vscode/ZoweVsCodeExtension.ts
@@ -187,7 +187,11 @@ export class ZoweVsCodeExtension {
         const serviceProfile = await this.getServiceProfile(opts);
         const baseProfile = await cache.fetchBaseProfile(serviceProfile.name);
         if (baseProfile == null) {
-            Gui.errorMessage(`Login failed: No base profile found to store SSO token for profile "${serviceProfile.name}"`);
+            Gui.errorMessage(
+                `Login failed: No base or parent profile found to store SSO token for profile "${serviceProfile.name}". ` +
+                    "To fix this, either convert this profile to a nested profile under a parent profile, " +
+                    "or add a default base profile to your team configuration."
+            );
             return false;
         }
         const primaryProfile = opts.preferBaseToken ? baseProfile : serviceProfile;
@@ -349,7 +353,11 @@ export class ZoweVsCodeExtension {
         const serviceProfile = await this.getServiceProfile(opts);
         const baseProfile = await cache.fetchBaseProfile(serviceProfile.name);
         if (!baseProfile) {
-            Gui.errorMessage(`Logout failed: No base profile found to remove SSO token for profile "${serviceProfile.name}"`);
+            Gui.errorMessage(
+                `Logout failed: No base or parent profile found to remove SSO token for profile "${serviceProfile.name}". ` +
+                    "To fix this, either convert this profile to a nested profile under a parent profile, " +
+                    "or add a default base profile to your team configuration."
+            );
             return false;
         }
         const primaryProfile = opts.preferBaseToken ? baseProfile : serviceProfile;


### PR DESCRIPTION

<!-- 
**NOTE:** The team reserves the right to close pull requests that fail to meet quality standards or lack human contribution.
-->

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
When using a flat profile with no base profile, the login error message is misleading. It says a base profile is required but does not tell the user what actions they can take to fix it. This PR improves the error message to better describe the problem and the available options.

Fixes : #4428 

## Release Notes

<!-- Include the Milestone Number and a small description of your change that will be added to the changelog. -->
<!-- If there is a linked issue, it should have the same milestone as this PR. -->

Milestone:

Changelog:

## Types of changes

<!-- What types of changes does your code introduce to Zowe Explorer? Put an `x` in all boxes that apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (a change that would cause existing functionality to not work as expected)
- [ ] Documentation (Markdown, README updates)
- [ ] Other (please specify above in "Proposed changes" section)

## Checklist

<!-- Put an `x` in all boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This checklist will be used as reference for both the contributor and the reviewer. -->

**All checks must pass before this pull request is reviewed by the Zowe Explorer squad.**

**General**

- [x] I have read the [CONTRIBUTOR GUIDANCE](https://github.com/zowe/zowe-explorer-vscode/wiki/Best-Practices:-Contributor-Guidance) wiki
- [x] All PR dependencies have been merged and published (if applicable)
- [ ] A GIF or screenshot is included in the PR for visual changes
- [x] The pre-publish command has been executed:
  - **v2 and below:** `yarn workspace vscode-extension-for-zowe vscode:prepublish`
  - **v3:** `pnpm --filter vscode-extension-for-zowe vscode:prepublish`
- [ ] New ZE APIs are tested with extender types that haven't adopted yet to determine breaking changes. Can use Zowe zFTP marketplace extension.

**Code coverage**

- [ ] There is coverage for the code that I have added
- [ ] I have added new unit test cases and they are passing
- [ ] I have added at least one end-to-end test for new features to validate behavior (if applicable)
- [ ] I have manually tested the changes

**Deployment**

- [ ] I have tested new functionality with the FTP extension and profile verifying no extender profile type breakages introduced
- [ ] I have added developer documentation (if applicable)
- [ ] I have verified that all dependency updates (such as Zowe SDKs) in this pull request are compatible
- [ ] Documentation should be added to Zowe Docs
  - If you're an outside contributor, please post in the [#zowe-doc Slack channel](https://openmainframeproject.slack.com/archives/CC961JYMQ) to coordinate documentation.
  - Otherwise, please check with the rest of the squad about any needed documentation before merging.
- [ ] These changes may need ported to the appropriate branches (list here):

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did, what alternatives you considered, etc... -->
